### PR TITLE
feat(e2e): wire backend API + dashboard for end-to-end runner control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,76 @@
 # Prediction Market System (pms)
 
-Modular prediction market trading system with three phases:
+Modular prediction market trading system organised around a **cybernetic loop**:
 
-1. **Tool Evaluation Harness** — systematically evaluate open-source prediction market tools against benchmarks.
-2. **Trading Pipeline Skeleton** — sense → strategy → risk → execute → evaluate → feedback, with pluggable Protocol-based modules.
-3. **Correlation Engine** — embedding-based cross-market correlation and arbitrage detection.
+```
+Sensor → Controller → Actuator → Evaluator → Feedback → (Controller)
+```
 
-Target platforms: Polymarket and Kalshi.
+Target venues: Polymarket (primary) and Kalshi. Supports three run modes:
+`backtest`, `paper`, and `live` (gated by config).
 
 ## Layout
 
 ```
-python/pms/         # Single Python package
-  models/           # Frozen dataclasses (core domain types)
-  protocols/        # Protocol interfaces (structural typing)
-rust/               # Rust workspace stub (reserved for future perf paths)
-tests/              # Pytest test suite
+src/pms/               # Python package
+  actuator/            # risk + executor + feedback adapters
+  api/                 # FastAPI app + `pms-api` CLI entry
+  controller/          # decision pipeline
+  core/                # frozen dataclasses, enums, Protocol interfaces
+  evaluation/          # metrics collector + eval spool + feedback engine
+  sensor/              # HistoricalSensor + PolymarketRestSensor + stream
+  storage/             # EvalStore + FeedbackStore (JSONL persistence)
+  runner.py            # orchestrator wiring all four layers
+  config.py            # PMSSettings (pydantic-settings)
+dashboard/             # Next.js console (port 3100)
+rust/                  # PyO3 workspace stub (reserved for perf paths)
+tests/                 # pytest suite (unit + integration)
 ```
+
+## Quick start — backend + dashboard end-to-end
+
+```bash
+# 1. Install Python deps
+uv sync
+
+# 2. Start the FastAPI backend (port 8000 by default)
+uv run pms-api                       # → http://127.0.0.1:8000
+# Optional: auto-start the runner at boot
+PMS_AUTO_START=1 uv run pms-api
+
+# 3. In another shell, start the dashboard (port 3100)
+cd dashboard
+npm install
+PMS_API_BASE_URL=http://127.0.0.1:8000 npm run dev
+#   → http://127.0.0.1:3100
+```
+
+If `PMS_API_BASE_URL` is unset the dashboard silently falls back to the
+bundled mock store (`dashboard/lib/mock-store.ts`) — useful for pure frontend
+work, but every page will show fabricated data.
+
+## Runner lifecycle via the API
+
+```bash
+curl -X POST http://127.0.0.1:8000/run/start   # begin ingesting signals
+curl       http://127.0.0.1:8000/status        # {running: true, ...}
+curl -X POST http://127.0.0.1:8000/run/stop    # graceful shutdown
+```
+
+The `Overview` and `Backtest` dashboard pages include a **Runner Controls**
+panel that calls these endpoints directly.
 
 ## Development
 
 ```bash
 uv sync
-uv run pytest
-uv run mypy python/ --strict
+uv run pytest -q                              # full suite (66 pass, 2 skip)
+uv run mypy src/ tests/ --strict              # strict type check
+PMS_RUN_INTEGRATION=1 uv run pytest -m integration   # live network tests
 ```
+
+Baseline invariants enforced by CI:
+- pytest ≥ 66 passing, 2 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
+- mypy strict must be clean on every committed source file.
+
+See `CLAUDE.md` for the active engineering rules promoted from retros.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,46 +1,44 @@
-# config.yaml.example — sample pipeline configuration
+# config.yaml.example — PMSSettings override file
 #
-# Each section under the top-level keys specifies a `ModuleSpec`:
+# PMSSettings uses pydantic-settings with an env prefix of `PMS_` and a
+# nested delimiter of `__`. You can either export env vars
+# (e.g. PMS_MODE=paper, PMS_RISK__MAX_TOTAL_EXPOSURE=5000) or load a YAML
+# file via:
 #
-#     class:  fully-qualified dotted class path
-#     kwargs: dict of keyword arguments passed to the class constructor
+#     from pms.config import PMSSettings
+#     settings = PMSSettings.load("config.yaml")
 #
-# Load this file at runtime with:
-#
-#     from pathlib import Path
-#     from pms.orchestrator.config import load_config
-#     config = load_config(Path("config.yaml"))
-#
-# `ModuleRegistry.instantiate(spec)` then turns each ModuleSpec into a
-# fresh instance that you can hand to `TradingPipeline(...)`.
-#
-# NOTE: this file is illustrative. The tests in `tests/test_pipeline.py`
-# construct all of their mocks inline rather than loading this file.
+# Below are the supported top-level keys with their defaults.
 
-connectors:
-  - class: pms.connectors.polymarket.PolymarketConnector
-    kwargs: {}
-  - class: pms.connectors.kalshi.KalshiConnector
-    kwargs: {}
+mode: backtest                 # backtest | paper | live
+live_trading_enabled: false    # must be true to switch into live mode
 
-# Strategies are introduced in CP07. Until then this list stays empty.
-strategies: []
+risk:
+  max_position_usdc: 100.0
+  max_position_per_market: 100.0
+  max_total_exposure: 1000.0
+  max_brier_score: 0.30
+  slippage_threshold_bps: 50.0
+  min_win_rate: 0.50
+  min_order_usdc: 1.0
 
-# The executor, risk manager, metrics, and feedback engine are all
-# introduced in CP08/CP09. The entries below point at placeholder class
-# paths and will need to be updated when those checkpoints land.
-executor:
-  class: pms.execution.noop.NoopExecutor
-  kwargs: {}
+sensor:
+  poll_interval_s: 5.0
 
-risk_manager:
-  class: pms.execution.noop.NoopRiskManager
-  kwargs: {}
+controller:
+  min_volume: 0.0
+  max_slippage_bps: 100
+  time_in_force: GTC
 
-metrics:
-  class: pms.evaluation.noop.NoopMetricsCollector
-  kwargs: {}
+polymarket:
+  host: https://clob.polymarket.com
+  websocket_url: wss://ws-subscriptions-clob.polymarket.com/ws/
+  chain_id: 137
+  # private_key, api_key, api_secret, api_passphrase, funder_address,
+  # and signature_type are required for live trading; leave unset for
+  # paper/backtest modes.
 
-feedback_engine:
-  class: pms.evaluation.noop.NoopFeedbackEngine
-  kwargs: {}
+llm:
+  enabled: false
+  provider: null               # e.g. "anthropic" (requires `pms[llm]`)
+  model: claude-3-5-sonnet-latest

--- a/dashboard/app/api/pms/run/start/route.ts
+++ b/dashboard/app/api/pms/run/start/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { upstreamResponse } from '@/lib/upstream';
+
+export async function POST() {
+  const upstream = await upstreamResponse('/run/start', { method: 'POST' });
+  if (upstream) return upstream;
+  return NextResponse.json(
+    {
+      detail:
+        'PMS_API_BASE_URL is not configured — runner control requires a live backend.'
+    },
+    { status: 503 }
+  );
+}

--- a/dashboard/app/api/pms/run/stop/route.ts
+++ b/dashboard/app/api/pms/run/stop/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { upstreamResponse } from '@/lib/upstream';
+
+export async function POST() {
+  const upstream = await upstreamResponse('/run/stop', { method: 'POST' });
+  if (upstream) return upstream;
+  return NextResponse.json(
+    {
+      detail:
+        'PMS_API_BASE_URL is not configured — runner control requires a live backend.'
+    },
+    { status: 503 }
+  );
+}

--- a/dashboard/app/backtest/page.tsx
+++ b/dashboard/app/backtest/page.tsx
@@ -1,12 +1,20 @@
+'use client';
+
+import { RunControls } from '@/components/RunControls';
 import { Nav } from '@/components/Nav';
-import { mockDecisions, mockMetrics, mockSignals } from '@/lib/mock-store';
+import { useLiveData } from '@/lib/useLiveData';
+import type { MetricsResponse, Signal, StatusResponse } from '@/lib/types';
 
 export default function BacktestPage() {
-  const decisions = mockDecisions();
-  const metrics = mockMetrics();
-  const signals = mockSignals();
-  const first = signals[0]?.fetched_at ?? 'n/a';
-  const last = signals[signals.length - 1]?.fetched_at ?? 'n/a';
+  const status = useLiveData<StatusResponse>('/status');
+  const metrics = useLiveData<MetricsResponse>('/metrics');
+  const signals = useLiveData<Signal[]>('/signals?limit=200');
+
+  const first = signals.data?.[0]?.fetched_at ?? 'n/a';
+  const last = signals.data?.[signals.data.length - 1]?.fetched_at ?? 'n/a';
+  const running = status.data?.running ?? false;
+  const disconnected = status.disconnected || metrics.disconnected || signals.disconnected;
+
   return (
     <main className="shell">
       <Nav />
@@ -15,25 +23,45 @@ export default function BacktestPage() {
           <div>
             <p className="eyebrow">Replay</p>
             <h1>Backtest Run</h1>
-            <p className="lede">Synthetic seven-day replay summary for the current pipeline.</p>
+            <p className="lede">
+              Trigger a backtest replay and watch decisions, fills, and metrics populate.
+            </p>
           </div>
+          {disconnected ? <span className="badge disconnected">disconnected</span> : null}
         </div>
+        <RunControls
+          running={running}
+          mode={status.data?.mode ?? null}
+          onChange={() => {
+            // next poll tick refreshes status
+          }}
+        />
         <div className="summary-grid">
           <section className="card summary-card">
+            <span className="muted">Mode</span>
+            <div className="metric">{status.data?.mode ?? 'n/a'}</div>
+          </section>
+          <section className="card summary-card">
             <span className="muted">Total decisions</span>
-            <div className="metric">{decisions.length}</div>
+            <div className="metric">{status.data?.controller.decisions_total ?? 0}</div>
           </section>
           <section className="card summary-card">
-            <span className="muted">P&L</span>
-            <div className="metric">{metrics.pnl.toFixed(2)}</div>
+            <span className="muted">Fills</span>
+            <div className="metric">{status.data?.actuator.fills_total ?? 0}</div>
           </section>
           <section className="card summary-card">
-            <span className="muted">Brier by category</span>
-            <div className="metric">{Object.keys(metrics.brier_by_category).length}</div>
+            <span className="muted">P&amp;L</span>
+            <div className="metric">{metrics.data?.pnl.toFixed(2) ?? '0.00'}</div>
           </section>
           <section className="card summary-card">
-            <span className="muted">Date range covered</span>
-            <p>{first} to {last}</p>
+            <span className="muted">Brier overall</span>
+            <div className="metric">{metrics.data?.brier_overall?.toFixed(3) ?? 'n/a'}</div>
+          </section>
+          <section className="card summary-card">
+            <span className="muted">Signals window</span>
+            <p>{first}</p>
+            <p className="muted">to</p>
+            <p>{last}</p>
           </section>
         </div>
       </section>

--- a/dashboard/app/decisions/page.tsx
+++ b/dashboard/app/decisions/page.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import { Nav } from '@/components/Nav';
-import { mockDecisions } from '@/lib/mock-store';
+import { useLiveData } from '@/lib/useLiveData';
+import type { Decision } from '@/lib/types';
 
 export default function DecisionsPage() {
-  const decisions = mockDecisions();
+  const { data, loading, disconnected } = useLiveData<Decision[]>('/decisions?limit=100');
+  const decisions = data ?? [];
+
   return (
     <main className="shell">
       <Nav />
@@ -11,35 +16,46 @@ export default function DecisionsPage() {
           <div>
             <p className="eyebrow">Controller</p>
             <h1>Decision Ledger</h1>
-            <p className="lede">Recent trade decisions with forecaster attribution and Kelly sizing.</p>
+            <p className="lede">
+              Recent trade decisions with forecaster attribution and Kelly sizing.
+            </p>
           </div>
+          {disconnected ? <span className="badge disconnected">disconnected</span> : null}
         </div>
-        <div className="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>Market</th>
-                <th>Forecaster</th>
-                <th>Prob</th>
-                <th>Edge</th>
-                <th>Kelly size</th>
-                <th>Resolved</th>
-              </tr>
-            </thead>
-            <tbody>
-              {decisions.map((decision) => (
-                <tr key={decision.decision_id}>
-                  <td>{decision.market_id}</td>
-                  <td>{decision.forecaster}</td>
-                  <td>{decision.prob_estimate.toFixed(2)}</td>
-                  <td>{decision.expected_edge.toFixed(2)}</td>
-                  <td>{decision.kelly_size.toFixed(2)}</td>
-                  <td>{decision.resolved_outcome ?? 'pending'}</td>
+        {loading && decisions.length === 0 ? (
+          <p className="muted">Loading decisions…</p>
+        ) : decisions.length === 0 ? (
+          <p className="muted">
+            No decisions yet. Start the runner from the Overview page to populate this ledger.
+          </p>
+        ) : (
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Market</th>
+                  <th>Forecaster</th>
+                  <th>Side</th>
+                  <th>Prob</th>
+                  <th>Edge</th>
+                  <th>Kelly size</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {decisions.map((decision) => (
+                  <tr key={decision.decision_id}>
+                    <td>{decision.market_id}</td>
+                    <td>{decision.forecaster}</td>
+                    <td>{decision.side ?? '—'}</td>
+                    <td>{decision.prob_estimate.toFixed(3)}</td>
+                    <td>{decision.expected_edge.toFixed(3)}</td>
+                    <td>{decision.kelly_size.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </section>
     </main>
   );

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -315,6 +315,43 @@ th {
   padding: 18px;
 }
 
+.run-controls {
+  align-items: center;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  margin: 18px 0;
+  padding: 18px;
+}
+
+.button-row {
+  display: flex;
+  gap: 10px;
+}
+
+.button-row button {
+  background: var(--ink);
+  color: #fff;
+  font-weight: 700;
+  padding: 9px 16px;
+}
+
+.button-row button:hover:not(:disabled) {
+  background: var(--green);
+}
+
+.button-row button:disabled {
+  background: var(--line);
+  color: var(--muted);
+  cursor: not-allowed;
+}
+
+.error {
+  color: var(--coral);
+  font-weight: 700;
+  margin: 0;
+}
+
 @media (max-width: 900px) {
   .shell {
     padding: 18px;

--- a/dashboard/app/metrics/page.tsx
+++ b/dashboard/app/metrics/page.tsx
@@ -1,9 +1,27 @@
+'use client';
+
 import { MetricChartsNoSsr } from '@/components/MetricChartsNoSsr';
 import { Nav } from '@/components/Nav';
-import { mockMetrics } from '@/lib/mock-store';
+import { useLiveData } from '@/lib/useLiveData';
+import type { MetricsResponse } from '@/lib/types';
+
+const EMPTY_METRICS: MetricsResponse = {
+  brier_overall: null,
+  brier_by_category: {},
+  pnl: 0,
+  slippage_bps: 0,
+  fill_rate: 0,
+  win_rate: 0,
+  brier_series: [],
+  calibration_curve: [],
+  pnl_series: []
+};
 
 export default function MetricsPage() {
-  const metrics = mockMetrics();
+  const { data, loading, disconnected } = useLiveData<MetricsResponse>('/metrics');
+  const metrics = data ?? EMPTY_METRICS;
+  const hasData = (metrics.brier_series?.length ?? 0) > 0;
+
   return (
     <main className="shell">
       <Nav />
@@ -12,10 +30,37 @@ export default function MetricsPage() {
           <div>
             <p className="eyebrow">Evaluator</p>
             <h1>Metric Review</h1>
-            <p className="lede">Brier, calibration, and P&L traces for the current backtest run.</p>
+            <p className="lede">Brier, calibration, and P&amp;L traces for the current run.</p>
           </div>
+          {disconnected ? <span className="badge disconnected">disconnected</span> : null}
         </div>
-        <MetricChartsNoSsr metrics={metrics} />
+        <div className="summary-grid">
+          <section className="card summary-card">
+            <span className="muted">Brier overall</span>
+            <div className="metric">{metrics.brier_overall?.toFixed(3) ?? 'n/a'}</div>
+          </section>
+          <section className="card summary-card">
+            <span className="muted">Fill rate</span>
+            <div className="metric">{(metrics.fill_rate * 100).toFixed(1)}%</div>
+          </section>
+          <section className="card summary-card">
+            <span className="muted">Win rate</span>
+            <div className="metric">{(metrics.win_rate * 100).toFixed(1)}%</div>
+          </section>
+          <section className="card summary-card">
+            <span className="muted">P&amp;L</span>
+            <div className="metric">{metrics.pnl.toFixed(2)}</div>
+          </section>
+        </div>
+        {loading && !hasData ? (
+          <p className="muted">Loading metrics…</p>
+        ) : hasData ? (
+          <MetricChartsNoSsr metrics={metrics} />
+        ) : (
+          <p className="muted">
+            No eval records yet. Run a backtest or start the paper runner to populate charts.
+          </p>
+        )}
       </section>
     </main>
   );

--- a/dashboard/app/signals/page.tsx
+++ b/dashboard/app/signals/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Nav } from '@/components/Nav';
+import { useLiveData } from '@/lib/useLiveData';
+import type { Signal } from '@/lib/types';
+
+export default function SignalsPage() {
+  const { data, loading, disconnected } = useLiveData<Signal[]>('/signals?limit=100');
+  const signals = data ?? [];
+  const reversed = [...signals].reverse();
+
+  return (
+    <main className="shell">
+      <Nav />
+      <section className="page">
+        <div className="hero">
+          <div>
+            <p className="eyebrow">Sensor</p>
+            <h1>Signal Stream</h1>
+            <p className="lede">
+              Most recent market signals delivered to the controller, newest first.
+            </p>
+          </div>
+          {disconnected ? <span className="badge disconnected">disconnected</span> : null}
+        </div>
+        {loading && signals.length === 0 ? (
+          <p className="muted">Loading signals…</p>
+        ) : signals.length === 0 ? (
+          <p className="muted">
+            No signals yet. Start the runner to begin ingesting Polymarket / historical data.
+          </p>
+        ) : (
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Fetched at</th>
+                  <th>Market</th>
+                  <th>Title</th>
+                  <th>Yes price</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reversed.map((signal) => (
+                  <tr key={`${signal.market_id}-${signal.fetched_at}`}>
+                    <td>{signal.fetched_at}</td>
+                    <td>{signal.market_id}</td>
+                    <td>{signal.title}</td>
+                    <td>{signal.yes_price.toFixed(3)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/dashboard/components/DashboardClient.tsx
+++ b/dashboard/components/DashboardClient.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FeedbackPanel } from './FeedbackPanel';
 import { LayerCard } from './LayerCard';
+import { RunControls } from './RunControls';
 import { apiGet } from '@/lib/api';
 import type { Feedback, MetricsResponse, StatusResponse } from '@/lib/types';
 
@@ -22,30 +23,32 @@ const initialData: DashboardData = {
 
 export function DashboardClient() {
   const [data, setData] = useState<DashboardData>(initialData);
+  const cancelledRef = useRef(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      try {
-        const [status, metrics, feedback] = await Promise.all([
-          apiGet<StatusResponse>('/status'),
-          apiGet<MetricsResponse>('/metrics'),
-          apiGet<Feedback[]>('/feedback?resolved=false')
-        ]);
-        if (!cancelled) setData({ status, metrics, feedback, disconnected: false });
-      } catch {
-        if (!cancelled) {
-          setData((current) => ({ ...current, disconnected: true }));
-        }
+  const load = useCallback(async () => {
+    try {
+      const [status, metrics, feedback] = await Promise.all([
+        apiGet<StatusResponse>('/status'),
+        apiGet<MetricsResponse>('/metrics'),
+        apiGet<Feedback[]>('/feedback?resolved=false')
+      ]);
+      if (!cancelledRef.current) setData({ status, metrics, feedback, disconnected: false });
+    } catch {
+      if (!cancelledRef.current) {
+        setData((current) => ({ ...current, disconnected: true }));
       }
     }
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
     void load();
-    const timer = window.setInterval(load, 5000);
+    const timer = window.setInterval(() => void load(), 5000);
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
       window.clearInterval(timer);
     };
-  }, []);
+  }, [load]);
 
   const status = data.status;
   const metrics = data.metrics;
@@ -76,6 +79,12 @@ export function DashboardClient() {
           </div>
         </div>
       </section>
+
+      <RunControls
+        running={status?.running ?? false}
+        mode={status?.mode ?? null}
+        onChange={() => void load()}
+      />
 
       <section className="grid-four" aria-label="layer status">
         <LayerCard

--- a/dashboard/components/Nav.tsx
+++ b/dashboard/components/Nav.tsx
@@ -9,8 +9,9 @@ export function Nav() {
       </Link>
       <div className="nav-links">
         <Link href="/">Overview</Link>
-        <Link href="/metrics">Metrics</Link>
+        <Link href="/signals">Signals</Link>
         <Link href="/decisions">Decisions</Link>
+        <Link href="/metrics">Metrics</Link>
         <Link href="/backtest">Backtest</Link>
       </div>
     </nav>

--- a/dashboard/components/RunControls.tsx
+++ b/dashboard/components/RunControls.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { apiPost } from '@/lib/api';
+
+type RunControlsProps = {
+  running: boolean;
+  mode: string | null;
+  onChange: () => void;
+};
+
+export function RunControls({ running, mode, onChange }: RunControlsProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function trigger(action: 'start' | 'stop') {
+    setBusy(true);
+    setError(null);
+    try {
+      await apiPost(`/run/${action}`);
+      onChange();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'request failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="card run-controls" aria-label="runner controls">
+      <div>
+        <h2>Runner Controls</h2>
+        <p className="muted">
+          Mode: <strong>{mode ?? 'unknown'}</strong>
+          {' — '}
+          {running ? 'running' : 'idle'}
+        </p>
+      </div>
+      <div className="button-row">
+        <button
+          type="button"
+          onClick={() => void trigger('start')}
+          disabled={busy || running}
+        >
+          Start
+        </button>
+        <button
+          type="button"
+          onClick={() => void trigger('stop')}
+          disabled={busy || !running}
+        >
+          Stop
+        </button>
+      </div>
+      {error ? <p className="error">{error}</p> : null}
+    </section>
+  );
+}

--- a/dashboard/lib/mock-store.ts
+++ b/dashboard/lib/mock-store.ts
@@ -10,6 +10,7 @@ export function mockStatus(): StatusResponse {
   return {
     mode: 'backtest',
     runner_started_at: '2026-04-14T00:00:00+00:00',
+    running: false,
     sensors: [{ name: 'HistoricalSensor', status: 'idle', last_signal_at: '2026-04-07T22:39:00+00:00' }],
     controller: { decisions_total: mockDecisions().length },
     actuator: { fills_total: 18, mode: 'backtest' },
@@ -49,7 +50,7 @@ export function mockMetrics(): MetricsResponse {
     slippage_bps: 18.4,
     fill_rate: 0.92,
     win_rate: 0.61,
-    brier_series: decisions.map((decision, index) => ({
+    brier_series: decisions.map((_decision, index) => ({
       recorded_at: `2026-04-${String(1 + index).padStart(2, '0')}T00:00:00+00:00`,
       brier_score: 0.08 + (index % 6) / 100
     })),
@@ -57,7 +58,7 @@ export function mockMetrics(): MetricsResponse {
       prob_estimate: decision.prob_estimate,
       resolved_outcome: decision.resolved_outcome ?? 0
     })),
-    pnl_series: decisions.map((decision, index) => ({
+    pnl_series: decisions.map((_decision, index) => ({
       recorded_at: `2026-04-${String(1 + index).padStart(2, '0')}T00:00:00+00:00`,
       pnl: -8 + index * 3.1
     }))

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -1,6 +1,7 @@
 export type StatusResponse = {
   mode: string;
   runner_started_at: string | null;
+  running?: boolean;
   sensors: Array<{ name: string; status: string; last_signal_at: string | null }>;
   controller: { decisions_total: number };
   actuator: { fills_total: number; mode: string };

--- a/dashboard/lib/useLiveData.ts
+++ b/dashboard/lib/useLiveData.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiGet } from './api';
+
+export type LiveData<T> = {
+  data: T | null;
+  loading: boolean;
+  disconnected: boolean;
+  error: string | null;
+};
+
+export function useLiveData<T>(path: string, intervalMs = 5000): LiveData<T> {
+  const [state, setState] = useState<LiveData<T>>({
+    data: null,
+    loading: true,
+    disconnected: false,
+    error: null
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const result = await apiGet<T>(path);
+        if (!cancelled) {
+          setState({ data: result, loading: false, disconnected: false, error: null });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            loading: false,
+            disconnected: true,
+            error: err instanceof Error ? err.message : 'Unknown error'
+          }));
+        }
+      }
+    }
+    void load();
+    const timer = window.setInterval(load, intervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [path, intervalMs]);
+
+  return state;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,12 @@ dependencies = [
     "pydantic>=2.12.0",
     "pydantic-settings>=2.11.0",
     "pyyaml>=6.0.3",
+    "uvicorn>=0.30",
     "websockets>=16.0",
 ]
+
+[project.scripts]
+pms-api = "pms.api.__main__:main"
 
 [project.optional-dependencies]
 # CP05: Anthropic SDK powers the optional LLM forecaster. Install with

--- a/src/pms/api/__main__.py
+++ b/src/pms/api/__main__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="pms-api", description="Run the PMS FastAPI server.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--log-level", default="info")
+    parser.add_argument("--reload", action="store_true", help="Enable hot-reload for development.")
+    args = parser.parse_args()
+
+    uvicorn.run(
+        "pms.api.app:create_app",
+        factory=True,
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level,
+        reload=args.reload,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+import logging
+import os
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from enum import Enum
@@ -19,23 +22,46 @@ T = TypeVar("T")
 LIVE_DISABLED_DETAIL = (
     "Live trading is disabled. Set live_trading_enabled=true in config."
 )
+RUNNER_ALREADY_RUNNING_DETAIL = "Runner is already running."
+logger = logging.getLogger(__name__)
 
 
 class ConfigUpdate(BaseModel):
     mode: RunMode
 
 
-def create_app(runner: Runner | None = None) -> FastAPI:
+def create_app(
+    runner: Runner | None = None,
+    *,
+    auto_start: bool | None = None,
+) -> FastAPI:
     active_runner = runner or Runner()
-    app = FastAPI(title="PMS API")
+    if auto_start is None:
+        auto_start = os.environ.get("PMS_AUTO_START", "").lower() in {"1", "true", "yes"}
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        started_here = False
+        if auto_start and not _is_runner_running(active_runner):
+            logger.info("PMS_AUTO_START enabled — starting runner in %s mode", active_runner.state.mode.value)
+            await active_runner.start()
+            started_here = True
+        try:
+            yield
+        finally:
+            if started_here:
+                await active_runner.stop()
+
+    app = FastAPI(title="PMS API", lifespan=lifespan)
     app.state.runner = active_runner
 
     @app.get("/status")
     async def status() -> dict[str, Any]:
-        metrics = _metrics(active_runner)
+        metrics_snapshot = _metrics(active_runner)
         return {
             "mode": active_runner.state.mode.value,
             "runner_started_at": _jsonable(active_runner.state.runner_started_at),
+            "running": _is_runner_running(active_runner),
             "sensors": _sensor_statuses(active_runner),
             "controller": {"decisions_total": len(active_runner.state.decisions)},
             "actuator": {
@@ -44,7 +70,7 @@ def create_app(runner: Runner | None = None) -> FastAPI:
             },
             "evaluator": {
                 "eval_records_total": len(active_runner.eval_store.all()),
-                "brier_overall": metrics.brier_overall,
+                "brier_overall": metrics_snapshot.brier_overall,
             },
         }
 
@@ -67,7 +93,38 @@ def create_app(runner: Runner | None = None) -> FastAPI:
 
     @app.get("/metrics")
     async def metrics() -> dict[str, Any]:
-        return cast(dict[str, Any], _jsonable(_metrics(active_runner)))
+        snapshot = _metrics(active_runner)
+        records = sorted(
+            active_runner.eval_store.all(),
+            key=lambda record: record.recorded_at,
+        )
+        payload = cast(dict[str, Any], _jsonable(snapshot))
+        payload["brier_series"] = [
+            {
+                "recorded_at": record.recorded_at.isoformat(),
+                "brier_score": record.brier_score,
+            }
+            for record in records
+        ]
+        payload["calibration_curve"] = [
+            {
+                "prob_estimate": record.prob_estimate,
+                "resolved_outcome": record.resolved_outcome,
+            }
+            for record in records
+        ]
+        cumulative_pnl = 0.0
+        pnl_series: list[dict[str, Any]] = []
+        for record in records:
+            cumulative_pnl += record.pnl
+            pnl_series.append(
+                {
+                    "recorded_at": record.recorded_at.isoformat(),
+                    "pnl": cumulative_pnl,
+                }
+            )
+        payload["pnl_series"] = pnl_series
+        return payload
 
     @app.get("/feedback")
     async def feedback(resolved: bool | None = None) -> list[dict[str, Any]]:
@@ -90,6 +147,22 @@ def create_app(runner: Runner | None = None) -> FastAPI:
         active_runner.switch_mode(update.mode)
         return {"mode": active_runner.state.mode.value}
 
+    @app.post("/run/start")
+    async def run_start() -> dict[str, Any]:
+        if _is_runner_running(active_runner):
+            raise HTTPException(status_code=409, detail=RUNNER_ALREADY_RUNNING_DETAIL)
+        await active_runner.start()
+        return {
+            "status": "started",
+            "mode": active_runner.state.mode.value,
+            "runner_started_at": _jsonable(active_runner.state.runner_started_at),
+        }
+
+    @app.post("/run/stop")
+    async def run_stop() -> dict[str, Any]:
+        await active_runner.stop()
+        return {"status": "stopped"}
+
     return app
 
 
@@ -102,6 +175,10 @@ def _latest(items: Sequence[T], limit: int) -> list[T]:
 
 def _metrics(runner: Runner) -> MetricsSnapshot:
     return MetricsCollector(runner.eval_store.all()).snapshot()
+
+
+def _is_runner_running(runner: Runner) -> bool:
+    return any(not task.done() for task in runner.tasks)
 
 
 def _sensor_statuses(runner: Runner) -> list[dict[str, Any]]:

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -41,15 +41,16 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-        started_here = False
         if auto_start and not _is_runner_running(active_runner):
             logger.info("PMS_AUTO_START enabled — starting runner in %s mode", active_runner.state.mode.value)
             await active_runner.start()
-            started_here = True
         try:
             yield
         finally:
-            if started_here:
+            # Always stop a running runner on shutdown — covers both auto_start
+            # and runners launched by callers via POST /run/start, so sensor
+            # resources (e.g. PolymarketRestSensor's httpx client) close cleanly.
+            if _is_runner_running(active_runner):
                 await active_runner.stop()
 
     app = FastAPI(title="PMS API", lifespan=lifespan)

--- a/src/pms/storage/feedback_store.py
+++ b/src/pms/storage/feedback_store.py
@@ -14,6 +14,19 @@ class FeedbackStore:
     path: Path | None = field(default_factory=lambda: Path(".data/feedback.jsonl"))
     _items: list[Feedback] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        if self.path is None or not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8") as stream:
+            for line in stream:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    self._items.append(_feedback_from_json(json.loads(line)))
+                except (ValueError, KeyError):
+                    continue
+
     def append(self, feedback: Feedback) -> None:
         self._items.append(feedback)
         self._append_to_disk(feedback)
@@ -63,3 +76,32 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, list):
         return [_jsonable(item) for item in value]
     return value
+
+
+def _feedback_from_json(payload: dict[str, Any]) -> Feedback:
+    created_at = _parse_datetime(payload["created_at"])
+    resolved_at_raw = payload.get("resolved_at")
+    resolved_at = _parse_datetime(resolved_at_raw) if resolved_at_raw else None
+    metadata_raw = payload.get("metadata")
+    metadata: dict[str, Any] = metadata_raw if isinstance(metadata_raw, dict) else {}
+    return Feedback(
+        feedback_id=str(payload["feedback_id"]),
+        target=str(payload["target"]),
+        source=str(payload["source"]),
+        message=str(payload["message"]),
+        severity=str(payload["severity"]),
+        created_at=created_at,
+        resolved=bool(payload.get("resolved", False)),
+        resolved_at=resolved_at,
+        category=payload.get("category"),
+        metadata=metadata,
+    )
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value)
+    msg = f"Unable to parse datetime from {value!r}"
+    raise ValueError(msg)

--- a/src/pms/storage/feedback_store.py
+++ b/src/pms/storage/feedback_store.py
@@ -23,8 +23,17 @@ class FeedbackStore:
                 if not line:
                     continue
                 try:
-                    self._items.append(_feedback_from_json(json.loads(line)))
-                except (ValueError, KeyError):
+                    payload = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(payload, dict):
+                    # Non-object row (array / string / number) — skip instead
+                    # of letting _feedback_from_json raise TypeError and abort
+                    # the reload of every subsequent row.
+                    continue
+                try:
+                    self._items.append(_feedback_from_json(payload))
+                except (KeyError, TypeError, ValueError):
                     continue
 
     def append(self, feedback: Feedback) -> None:

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -163,7 +163,7 @@ async def test_polymarket_actuator_raises_when_live_trading_disabled() -> None:
 
 
 def test_actuator_feedback_appends_controller_feedback() -> None:
-    store = FeedbackStore()
+    store = FeedbackStore(path=None)
     generator = ActuatorFeedback(store)
 
     feedback = generator.generate(_order_state(), reason="insufficient_liquidity")
@@ -176,7 +176,7 @@ def test_actuator_feedback_appends_controller_feedback() -> None:
 
 @pytest.mark.asyncio
 async def test_executor_releases_dedup_token_on_success_and_liquidity_rejection() -> None:
-    store = FeedbackStore()
+    store = FeedbackStore(path=None)
     tokens = executor.DedupTokenStore()
     ok_executor = executor.ActuatorExecutor(
         adapter=PaperActuator(

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import UTC, datetime
+from pathlib import Path
 
 import httpx
 import pytest
@@ -19,6 +20,9 @@ from pms.core.models import (
 from pms.runner import Runner
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
+
+
+FIXTURE_PATH = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
 
 
 def _settings() -> PMSSettings:
@@ -177,3 +181,83 @@ async def test_api_feedback_resolve_and_config_errors() -> None:
     assert blocked_live.json() == {
         "detail": "Live trading is disabled. Set live_trading_enabled=true in config."
     }
+
+
+@pytest.mark.asyncio
+async def test_api_run_start_stop_cycle(tmp_path: Path) -> None:
+    runner = Runner(
+        config=PMSSettings(
+            mode=RunMode.BACKTEST,
+            risk=RiskSettings(
+                max_position_per_market=1000.0,
+                max_total_exposure=10_000.0,
+            ),
+        ),
+        historical_data_path=FIXTURE_PATH,
+        eval_store=EvalStore(path=tmp_path / "eval.jsonl"),
+        feedback_store=FeedbackStore(path=tmp_path / "feedback.jsonl"),
+    )
+    app = create_app(runner)
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            initial_status = (await client.get("/status")).json()
+            start_resp = await client.post("/run/start")
+            conflict_resp = await client.post("/run/start")
+            await runner.wait_until_idle()
+            running_status = (await client.get("/status")).json()
+            stop_resp = await client.post("/run/stop")
+            stopped_status = (await client.get("/status")).json()
+    finally:
+        await runner.stop()
+
+    assert initial_status["running"] is False
+    assert start_resp.status_code == 200
+    assert start_resp.json()["status"] == "started"
+    assert start_resp.json()["mode"] == "backtest"
+    assert conflict_resp.status_code == 409
+    assert running_status["controller"]["decisions_total"] > 0
+    assert stop_resp.status_code == 200
+    assert stop_resp.json() == {"status": "stopped"}
+    assert stopped_status["running"] is False
+
+
+@pytest.mark.asyncio
+async def test_api_auto_start_lifespan(tmp_path: Path) -> None:
+    runner = Runner(
+        config=PMSSettings(
+            mode=RunMode.BACKTEST,
+            risk=RiskSettings(
+                max_position_per_market=1000.0,
+                max_total_exposure=10_000.0,
+            ),
+        ),
+        historical_data_path=FIXTURE_PATH,
+        eval_store=EvalStore(path=tmp_path / "eval.jsonl"),
+        feedback_store=FeedbackStore(path=tmp_path / "feedback.jsonl"),
+    )
+    app = create_app(runner, auto_start=True)
+
+    async with app.router.lifespan_context(app):
+        assert any(not task.done() for task in runner.tasks)
+        await runner.wait_until_idle()
+
+    assert all(task.done() for task in runner.tasks)
+
+
+@pytest.mark.asyncio
+async def test_api_auto_start_disabled_keeps_runner_idle(tmp_path: Path) -> None:
+    runner = Runner(
+        config=PMSSettings(mode=RunMode.BACKTEST),
+        historical_data_path=FIXTURE_PATH,
+        eval_store=EvalStore(path=tmp_path / "eval.jsonl"),
+        feedback_store=FeedbackStore(path=tmp_path / "feedback.jsonl"),
+    )
+    app = create_app(runner, auto_start=False)
+
+    async with app.router.lifespan_context(app):
+        assert runner.tasks == ()

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -261,3 +261,30 @@ async def test_api_auto_start_disabled_keeps_runner_idle(tmp_path: Path) -> None
 
     async with app.router.lifespan_context(app):
         assert runner.tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_api_lifespan_stops_runner_started_via_api(tmp_path: Path) -> None:
+    """Regression for codex-bot C1: /run/start-triggered runner must also be stopped on shutdown."""
+    runner = Runner(
+        config=PMSSettings(
+            mode=RunMode.BACKTEST,
+            risk=RiskSettings(
+                max_position_per_market=1000.0,
+                max_total_exposure=10_000.0,
+            ),
+        ),
+        historical_data_path=FIXTURE_PATH,
+        eval_store=EvalStore(path=tmp_path / "eval.jsonl"),
+        feedback_store=FeedbackStore(path=tmp_path / "feedback.jsonl"),
+    )
+    app = create_app(runner, auto_start=False)
+    transport = httpx.ASGITransport(app=app)
+
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            started = await client.post("/run/start")
+        assert started.status_code == 200
+        assert any(not task.done() for task in runner.tasks)
+
+    assert all(task.done() for task in runner.tasks)

--- a/tests/unit/test_evaluation_cp07.py
+++ b/tests/unit/test_evaluation_cp07.py
@@ -264,3 +264,21 @@ def test_feedback_store_reloads_from_disk(tmp_path: Path) -> None:
 
     assert [item.feedback_id for item in reloaded.all()] == ["fb-reload"]
     assert reloaded.all()[0].resolved is True
+
+
+def test_feedback_store_skips_malformed_reload_rows(tmp_path: Path) -> None:
+    """Regression for codex-bot C2: non-dict / partial JSONL rows must not abort init."""
+    path = tmp_path / "feedback.jsonl"
+    store = FeedbackStore(path=path)
+    store.append(_feedback("fb-good"))
+    # Append poisonous rows: array, string, number, missing-field dict, invalid JSON.
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write("[1, 2, 3]\n")
+        stream.write("\"scalar\"\n")
+        stream.write("42\n")
+        stream.write("{\"partial\": true}\n")
+        stream.write("not json at all\n")
+
+    reloaded = FeedbackStore(path=path)
+
+    assert [item.feedback_id for item in reloaded.all()] == ["fb-good"]

--- a/tests/unit/test_evaluation_cp07.py
+++ b/tests/unit/test_evaluation_cp07.py
@@ -252,3 +252,15 @@ def test_eval_store_append_writes_jsonl(tmp_path: Path) -> None:
 
     assert len(store.all()) == 1
     assert "d-cp07" in (tmp_path / "eval_records.jsonl").read_text(encoding="utf-8")
+
+
+def test_feedback_store_reloads_from_disk(tmp_path: Path) -> None:
+    path = tmp_path / "feedback.jsonl"
+    first = FeedbackStore(path=path)
+    first.append(_feedback("fb-reload"))
+    first.resolve("fb-reload")
+
+    reloaded = FeedbackStore(path=path)
+
+    assert [item.feedback_id for item in reloaded.all()] == ["fb-reload"]
+    assert reloaded.all()[0].resolved is True

--- a/uv.lock
+++ b/uv.lock
@@ -62,6 +62,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -597,6 +609,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "uvicorn" },
     { name = "websockets" },
 ]
 
@@ -623,6 +636,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "uvicorn", specifier = ">=0.30" },
     { name = "websockets", specifier = ">=16.0" },
 ]
 provides-extras = ["llm"]
@@ -982,6 +996,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Unblocks the eight gaps surfaced during the E2E audit so that a single command boots the backend, a second boots the dashboard, and Start/Stop round-trips through the UI populate real pipeline state.

- **Backend**: `uvicorn` dep + `pms-api` CLI, FastAPI `lifespan` with `PMS_AUTO_START`, `POST /run/start`, `POST /run/stop`, `status.running`, `/metrics` enriched with brier / calibration / pnl series, `FeedbackStore` reloads JSONL on init.
- **Dashboard**: `/backtest` `/decisions` `/metrics` now fetch live API via a new `useLiveData` hook, new `/signals` page, `RunControls` Start/Stop component on Overview + Backtest, dashboard proxy routes for `/api/pms/run/{start,stop}`.
- **Docs**: README and `config.yaml.example` rewritten for pms-v2 layout.

## Test plan

- [x] \`uv run pytest -q\` — **66 passed, 2 skipped** (was 62/2; +4 new: run/start cycle, auto_start on, auto_start off, feedback reload)
- [x] \`uv run mypy src/ tests/ --strict\` — **55 source files, no issues**
- [x] \`npx tsc --noEmit\` in dashboard — clean
- [x] Manual E2E: \`uv run pms-api --port 8765\` + \`PMS_API_BASE_URL=http://127.0.0.1:8765 npm run dev\`, then \`POST /api/pms/run/start\` via the dashboard proxy produced \`decisions_total=100 / fills_total=60 / eval_records=60 / brier=0.25 / pnl=69.39\` within ~2s; double-start returns 409; \`/run/stop\` + restart cycle works.
- [ ] Visual QA of all four subpages in a browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and quick-start for API and dashboard; clarified modes (backtest, paper, live) and config examples.

* **New Features**
  * Runner control panel with Start/Stop and lifecycle controls; dashboard uses a mock store when backend is not configured.
  * New Signals page and live-data updates for Backtest, Metrics, Decisions, and Signals pages with connection status badges.
  * New CLI command to launch the API server and API runner control endpoints (start/stop/status).

* **Tests**
  * Added unit/integration tests covering runner lifecycle and feedback persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->