### PR TITLE
feat: add strategy aggregate registry and dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,7 @@ jobs:
         env:
           PMS_RUN_INTEGRATION: "1"
           PMS_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/pms_test
-        run: >
-          uv run pytest -q
-          tests/integration/test_schema_apply_outer.py
-          tests/integration/test_schema_apply_inner.py
-          tests/integration/test_db_conn_rollback.py
-          tests/integration/test_runner_pool_integration.py
+        run: uv run pytest -q -m integration
 
       - name: Run mypy
         run: uv run mypy src/ tests/ --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,6 @@ jobs:
 
       - name: Run mypy
         run: uv run mypy src/ tests/ --strict
+
+      - name: Run import-linter
+        run: uv run lint-imports

--- a/.harness/retro/2026-04-17-pms-strategy-aggregate-v1.md
+++ b/.harness/retro/2026-04-17-pms-strategy-aggregate-v1.md
@@ -1,0 +1,92 @@
+---
+task_id: pms-strategy-aggregate-v1
+task_title: "S2 — Strategy aggregate + registry + import-linter + default seed"
+date: 2026-04-17
+checkpoints_total: 7
+checkpoints_passed_first_try: 7
+total_eval_iterations: 7
+total_commits: 17
+reverts: 0
+avg_iterations_per_checkpoint: 1.0
+---
+
+# Retro — pms-strategy-aggregate-v1
+
+## Observations
+
+### What Worked Well
+
+1. **Checkpoint execution stayed clean.** All 7 checkpoints passed on the
+   first evaluator pass, with zero reverts across 17 commits. The branch
+   moved linearly from red/green checkpoint work through E2E without any
+   checkpoint-local rewrites.
+
+2. **Review-loop found the right class of defects.** Claude surfaced 10
+   findings in 2 rounds. Eight were accepted and fixed, one suggestion
+   (`f6`) was rejected with a concrete runtime trace, and one finding
+   (`f10`) was deferred because the user explicitly marked those files as
+   out of scope. The peer accepted the `f6` rejection once the Pydantic
+   `Z` vs `+00:00` mismatch was demonstrated.
+
+3. **Full-verify failed for one narrow reason and recovered in one
+   commit.** The initial full-verify run had no command failures; the
+   only hard failure was repo-wide coverage at `81%` versus the harness
+   floor of `85%`. A single targeted test commit
+   (`7e08d27 test(full-verify): raise strategy aggregate coverage`) took
+   `src/pms/storage/strategy_registry.py` to `100%`, covered the
+   `pms-api` entrypoint, and moved total coverage to `85%` without
+   touching production code.
+
+### Error Patterns
+
+1. **[category: cross-checkpoint-integration]** The review loop found two
+   real contract seams after all checkpoints had already passed:
+   `schema.sql` seeded a default strategy payload that the registry could
+   not decode, and CI still ran a stale hand-curated subset of
+   integration files instead of the full `-m integration` suite. The
+   code inside each checkpoint was locally coherent, but the producer /
+   consumer contract across schema, registry, and CI verification only
+   became visible once the branch was reviewed as a whole. This is a
+   recurrence of the existing harness-side pattern, not a new
+   project-level rule.
+
+2. **[category: review-rejection-hygiene]** `f6` recommended removing
+   the `/strategies` `created_at` serializer as redundant. The rejection
+   only held because it was backed by a direct runtime reproduction
+   showing Pydantic JSON mode emits `Z` while the CP07 route contract and
+   tests require `datetime.isoformat()` with `+00:00`. This is the active
+   rule working as intended: rejection by witness, not by preference.
+
+3. **[category: project-ide-tooling-drift]** `dashboard/next-env.d.ts`
+   drifted to `.next/dev/types/routes.d.ts` during local frontend tool
+   runs and had to be restored twice, once during review-loop fixes and
+   again after full-verify. The file is Next-managed and not a product
+   change; the pattern remains generated-file churn rather than a
+   correctness issue.
+
+### Rule Conflict Observations
+
+None.
+
+## Recommendations
+
+### No new proposals this task
+
+No new pattern crossed the promotion threshold. The recurring issues on
+this branch were already covered by existing harness learnings.
+
+### Active / existing patterns confirmed
+
+- **`cross-checkpoint-integration`** recurred. Keep it as a harness-side
+  proposed improvement: end-of-branch review still catches producer /
+  consumer seams that checkpoint-local evaluation cannot see.
+- **`review-rejection-hygiene`** recurred and validated the active rule.
+  The `f6` rejection succeeded because it included a named runtime trace
+  and a concrete contract contradiction.
+- **`project-ide-tooling-drift`** recurred. Keep it in monitoring; the
+  fix remains to restore generated files before commit rather than to add
+  project CLAUDE rules.
+
+### Skill Defect Flags
+
+None from this task.

--- a/.harness/retro/index.md
+++ b/.harness/retro/index.md
@@ -24,15 +24,15 @@ CLAUDE.md, contributors expected to follow) → `retired` (resolved).
 
 | Pattern                              | Occurrences | Severity | Status     | First Task | Last Task   | Proposal |
 |--------------------------------------|-------------|----------|------------|------------|-------------|----------|
-| review-rejection-hygiene             | 1           | high     | active     | pms-v1     | pms-v1      | Proposal 1 |
+| review-rejection-hygiene             | 2           | high     | active     | pms-v1     | pms-strategy-aggregate-v1 | Proposal 1 |
 | domain-math-piecewise                | 1           | high     | active     | pms-v1     | pms-v1      | Proposal 2 |
 | lifecycle-cleanup-exit-paths         | 1           | high     | active     | pms-v1     | pms-v1      | Proposal 3 |
 | document-instead-of-fix              | 1           | medium   | active     | pms-v1     | pms-v1      | Proposal 4 |
-| cross-checkpoint-integration         | 2           | medium   | proposed   | pms-v1     | pms-market-data-v1 | Proposal 5 |
+| cross-checkpoint-integration         | 3           | medium   | proposed   | pms-v1     | pms-strategy-aggregate-v1 | Proposal 5 |
 | magnitude-overrun-tests              | 1           | low      | monitoring | pms-v1     | pms-v1      | Proposal 6 |
 | rule-conflict-precedence             | 1           | low      | active     | pms-v1     | pms-v1      | Proposal 7 |
 | runtime-behaviour-vs-design-intent   | 1           | high     | active     | pms-v1     | pms-v1      | Principle |
-| project-ide-tooling-drift            | 1           | low      | monitoring | pms-v1     | pms-v1      | Skill defect |
+| project-ide-tooling-drift            | 2           | low      | monitoring | pms-v1     | pms-strategy-aggregate-v1 | Skill defect |
 | tool-env-assumption                  | 1           | medium   | active     | pms-phase2 | pms-phase2  | phase2-P1 |
 | stale-baseline                       | 2           | medium   | active     | pms-phase2 | pms-market-data-v1 | phase2-P2 |
 | pytest-marker-no-auto-deselect       | 1           | low      | active     | pms-phase2 | pms-phase2  | phase2-P3 |
@@ -94,3 +94,4 @@ These are ready for the Orchestrator to auto-create GitHub issues.
 | pms-phase2  | 2026-04-08 | 7   | 6          | 9     | 0       | [2026-04-08-pms-phase2.md](./2026-04-08-pms-phase2.md) |
 | pms-phase3  | 2026-04-09 | 4   | 4          | 4     | 0       | [2026-04-09-pms-phase3.md](./2026-04-09-pms-phase3.md) |
 | pms-market-data-v1 | 2026-04-17 | 12  | 11         | 14    | 0       | [2026-04-17-pms-market-data-v1.md](./2026-04-17-pms-market-data-v1.md) |
+| pms-strategy-aggregate-v1 | 2026-04-17 | 7   | 7          | 7     | 0       | [2026-04-17-pms-strategy-aggregate-v1.md](./2026-04-17-pms-strategy-aggregate-v1.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,12 +31,8 @@ uv run pytest -q                         # full suite — see baseline below
 uv run mypy src/ tests/ --strict         # strict on every committed module
 ```
 
-**Baseline (as of 2026-04-17, feat/pms-market-data-v1):** `pytest`
-<<<<<<< Updated upstream
-93 passing, 32 skipped. The 32 skips are PostgreSQL-backed integration
-=======
-87 passing, 30 skipped. The 30 skips are PostgreSQL-backed integration
->>>>>>> Stashed changes
+**Baseline (as of 2026-04-17, feat/pms-strategy-aggregate-v1):** `pytest`
+145 passing, 42 skipped. The 42 skips are PostgreSQL-backed integration
 checks gated on `PMS_RUN_INTEGRATION=1` and, where needed,
 `PMS_TEST_DATABASE_URL`. mypy strict must be clean. If the baseline
 fails on a fresh clone, fix the config — not the test — and commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,14 @@ Run from a clean shell at the repo root. Both gates are load-bearing.
 uv sync                                  # install deps from uv.lock
 uv run pytest -q                         # full suite — see baseline below
 uv run mypy src/ tests/ --strict         # strict on every committed module
-uv run lint-imports                      # import boundary contracts
 ```
 
 **Baseline (as of 2026-04-17, feat/pms-market-data-v1):** `pytest`
+<<<<<<< Updated upstream
 93 passing, 32 skipped. The 32 skips are PostgreSQL-backed integration
+=======
+87 passing, 30 skipped. The 30 skips are PostgreSQL-backed integration
+>>>>>>> Stashed changes
 checks gated on `PMS_RUN_INTEGRATION=1` and, where needed,
 `PMS_TEST_DATABASE_URL`. mypy strict must be clean. If the baseline
 fails on a fresh clone, fix the config — not the test — and commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Run from a clean shell at the repo root. Both gates are load-bearing.
 uv sync                                  # install deps from uv.lock
 uv run pytest -q                         # full suite — see baseline below
 uv run mypy src/ tests/ --strict         # strict on every committed module
+uv run lint-imports                      # import boundary contracts
 ```
 
 **Baseline (as of 2026-04-17, feat/pms-market-data-v1):** `pytest`

--- a/README.md
+++ b/README.md
@@ -70,11 +70,7 @@ PMS_RUN_INTEGRATION=1 uv run pytest -m integration   # PostgreSQL + live-network
 ```
 
 Baseline invariants enforced by CI:
-<<<<<<< Updated upstream
-- pytest 93 passing, 32 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
-=======
-- pytest 87 passing, 30 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
->>>>>>> Stashed changes
+- pytest 145 passing, 42 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
 - mypy strict must be clean on every committed source file.
 
 ### Isolating dev state

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ PMS_RUN_INTEGRATION=1 uv run pytest -m integration   # PostgreSQL + live-network
 ```
 
 Baseline invariants enforced by CI:
+<<<<<<< Updated upstream
 - pytest 93 passing, 32 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
+=======
+- pytest 87 passing, 30 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
+>>>>>>> Stashed changes
 - mypy strict must be clean on every committed source file.
 
 ### Isolating dev state

--- a/dashboard/app/api/pms/strategies/route.ts
+++ b/dashboard/app/api/pms/strategies/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { upstreamResponse } from '@/lib/upstream';
+
+export async function GET() {
+  const upstream = await upstreamResponse('/strategies');
+  if (upstream) return upstream;
+  return NextResponse.json(
+    { detail: 'PMS upstream unavailable for /strategies' },
+    { status: 503 }
+  );
+}

--- a/dashboard/app/api/pms/strategies/route.ts
+++ b/dashboard/app/api/pms/strategies/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from 'next/server';
+import { mockStrategies } from '@/lib/mock-store';
 import { upstreamResponse } from '@/lib/upstream';
 
 export async function GET() {
   const upstream = await upstreamResponse('/strategies');
   if (upstream) return upstream;
-  return NextResponse.json(
-    { detail: 'PMS upstream unavailable for /strategies' },
-    { status: 503 }
-  );
+  return NextResponse.json(mockStrategies());
 }

--- a/dashboard/app/strategies/page.tsx
+++ b/dashboard/app/strategies/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Nav } from '@/components/Nav';
+import { useLiveData } from '@/lib/useLiveData';
+import type { StrategiesResponse } from '@/lib/types';
+
+const createdAtFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short'
+});
+
+function formatCreatedAt(createdAt: string): string {
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return createdAt;
+  }
+  return createdAtFormatter.format(parsed);
+}
+
+export default function StrategiesPage() {
+  const { data, loading, disconnected } = useLiveData<StrategiesResponse>('/strategies', 15_000);
+  const strategies = data?.strategies ?? [];
+
+  return (
+    <main className="shell">
+      <Nav />
+      <section className="page">
+        <div className="hero">
+          <div>
+            <p className="eyebrow">Controller</p>
+            <h1>Strategies</h1>
+            <p className="lede">
+              Active strategy versions registered in PostgreSQL and available to the runner.
+            </p>
+          </div>
+          {disconnected ? <span className="badge disconnected">disconnected</span> : null}
+        </div>
+
+        {loading && strategies.length === 0 ? (
+          <p className="muted">Loading strategies…</p>
+        ) : disconnected && strategies.length === 0 ? (
+          <p className="muted">Strategy registry unavailable.</p>
+        ) : strategies.length === 0 ? (
+          <p className="muted">No strategies registered.</p>
+        ) : (
+          <div className="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Strategy</th>
+                  <th>Active version</th>
+                  <th>Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {strategies.map((strategy) => (
+                  <tr key={strategy.strategy_id}>
+                    <td>{strategy.strategy_id}</td>
+                    <td>{strategy.active_version_id ?? '—'}</td>
+                    <td>{formatCreatedAt(strategy.created_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/dashboard/components/Nav.tsx
+++ b/dashboard/components/Nav.tsx
@@ -10,6 +10,7 @@ export function Nav() {
       <div className="nav-links">
         <Link href="/">Overview</Link>
         <Link href="/signals">Signals</Link>
+        <Link href="/strategies">Strategies</Link>
         <Link href="/decisions">Decisions</Link>
         <Link href="/metrics">Metrics</Link>
         <Link href="/backtest">Backtest</Link>

--- a/dashboard/e2e/strategies.spec.ts
+++ b/dashboard/e2e/strategies.spec.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+
+const evidenceDir = path.resolve(
+  process.cwd(),
+  '..',
+  '.harness',
+  'pms-strategy-aggregate-v1',
+  'checkpoints',
+  '07',
+  'iter-1',
+  'evidence'
+);
+
+test.beforeAll(() => {
+  fs.mkdirSync(evidenceDir, { recursive: true });
+});
+
+test('strategies page renders seeded registry row without console errors', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(message.text());
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  await page.goto('/strategies');
+
+  await expect(page.getByRole('columnheader', { name: 'Strategy' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Active version' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'Created' })).toBeVisible();
+  await expect(page.locator('tbody tr')).toHaveCount(1);
+  await expect(page.locator('tbody tr').first().locator('td').first()).toHaveText('default');
+
+  await page.screenshot({
+    path: path.join(evidenceDir, 'strategies-page.png'),
+    fullPage: true
+  });
+
+  expect(errors).toEqual([]);
+});

--- a/dashboard/lib/mock-store.ts
+++ b/dashboard/lib/mock-store.ts
@@ -6,7 +6,8 @@ import type {
   MetricsResponse,
   Signal,
   SignalDepth,
-  StatusResponse
+  StatusResponse,
+  StrategiesResponse
 } from './types';
 
 const rootDir = path.resolve(process.cwd(), '..');
@@ -69,6 +70,18 @@ export function mockMetrics(): MetricsResponse {
       recorded_at: `2026-04-${String(1 + index).padStart(2, '0')}T00:00:00+00:00`,
       pnl: -8 + index * 3.1
     }))
+  };
+}
+
+export function mockStrategies(): StrategiesResponse {
+  return {
+    strategies: [
+      {
+        strategy_id: 'default',
+        active_version_id: 'd50c4db65699c222620c85f0cf84c0324c148a34b212c5f69903dbf4b950757c',
+        created_at: '2026-04-14T00:00:00+00:00'
+      }
+    ]
   };
 }
 

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -65,3 +65,13 @@ export type SignalDepth = {
   last_update_ts: string | null;
   stale: boolean;
 };
+
+export type StrategyRow = {
+  strategy_id: string;
+  active_version_id: string | null;
+  created_at: string;
+};
+
+export type StrategiesResponse = {
+  strategies: StrategyRow[];
+};

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ llm = ["anthropic>=0.40.0"]
 
 [dependency-groups]
 dev = [
+    "import-linter>=2.0",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=6.0",
@@ -72,3 +73,30 @@ explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = ["asyncpg"]
 ignore_missing_imports = true
+
+[tool.importlinter]
+root_packages = ["pms"]
+
+[[tool.importlinter.contracts]]
+name = "Sensor strategy-agnostic: no aggregate import"
+type = "forbidden"
+source_modules = ["pms.sensor"]
+forbidden_modules = ["pms.strategies.aggregate"]
+
+[[tool.importlinter.contracts]]
+name = "Actuator strategy-agnostic: no aggregate import"
+type = "forbidden"
+source_modules = ["pms.actuator"]
+forbidden_modules = ["pms.strategies.aggregate"]
+
+[[tool.importlinter.contracts]]
+name = "Sensor + Actuator: no controller import"
+type = "forbidden"
+source_modules = ["pms.sensor", "pms.actuator"]
+forbidden_modules = ["pms.controller"]
+
+[[tool.importlinter.contracts]]
+name = "Sensor: no market_selection import"
+type = "forbidden"
+source_modules = ["pms.sensor"]
+forbidden_modules = ["pms.market_selection"]

--- a/schema.sql
+++ b/schema.sql
@@ -182,4 +182,22 @@ CREATE TABLE IF NOT EXISTS fills (
 
 -- END INNER-RING PRODUCT SHELLS
 
+-- default strategy seed (Invariant 3 NULLABLE→seed pattern).
+-- load-bearing legacy bootstrap row: changing `default-v1` requires a coordinated
+-- migration of every existing inner-ring product row tagged by the pre-S5 runtime.
+INSERT INTO strategies (strategy_id, active_version_id)
+    VALUES ('default', 'default-v1')
+    ON CONFLICT (strategy_id) DO NOTHING;
+
+INSERT INTO strategy_versions (
+    strategy_version_id,
+    strategy_id,
+    config_json
+) VALUES (
+    'default-v1',
+    'default',
+    '{"config":{},"risk":{},"eval":{},"forecaster":{},"market_selection":{}}'::jsonb
+)
+ON CONFLICT (strategy_version_id) DO NOTHING;
+
 COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -112,6 +112,22 @@ BEGIN
 END
 $$;
 
+-- strategy_factors: link table (empty in S2; populated by S3). Columns declared so S3 inserts do not require a schema change (Invariants 2, 4, 8)
+-- Invariant 4: raw factor rows are stored in factor_values (S3); composite factors belong in StrategyConfig.factor_composition, not as first-class rows here.
+-- S3 will add: FOREIGN KEY (factor_id) REFERENCES factors(factor_id)
+CREATE TABLE IF NOT EXISTS strategy_factors (
+    strategy_id TEXT NOT NULL,
+    strategy_version_id TEXT NOT NULL,
+    factor_id TEXT NOT NULL,
+    param JSONB NOT NULL DEFAULT '{}'::jsonb,
+    weight DOUBLE PRECISION NOT NULL,
+    direction TEXT NOT NULL CHECK (direction IN ('long', 'short')),
+    PRIMARY KEY (strategy_id, strategy_version_id, factor_id),
+    FOREIGN KEY (strategy_id, strategy_version_id)
+        REFERENCES strategy_versions(strategy_id, strategy_version_id)
+        ON DELETE CASCADE
+);
+
 -- BEGIN INNER-RING PRODUCT SHELLS
 
 CREATE TABLE IF NOT EXISTS feedback (

--- a/schema.sql
+++ b/schema.sql
@@ -196,7 +196,7 @@ INSERT INTO strategy_versions (
 ) VALUES (
     'default-v1',
     'default',
-    '{"config":{},"risk":{},"eval":{},"forecaster":{},"market_selection":{}}'::jsonb
+    '{"config":{"factor_composition":[["factor-a",0.6],["factor-b",0.4]],"metadata":[["owner","system"],["tier","default"]],"strategy_id":"default"},"eval_spec":{"metrics":["brier","pnl","fill_rate"]},"forecaster":{"forecasters":[["rules",[["threshold","0.55"]]],["stats",[["window","15m"]]]]},"market_selection":{"resolution_time_max_horizon_days":7,"venue":"polymarket","volume_min_usdc":500.0},"risk":{"max_daily_drawdown_pct":2.5,"max_position_notional_usdc":100.0,"min_order_size_usdc":1.0}}'::jsonb
 )
 ON CONFLICT (strategy_version_id) DO NOTHING;
 

--- a/schema.sql
+++ b/schema.sql
@@ -77,6 +77,41 @@ CREATE INDEX IF NOT EXISTS idx_trades_market_token_ts
 
 -- END OUTER RING
 
+-- strategies: inner-ring identity table (Invariants 3, 8)
+
+CREATE TABLE IF NOT EXISTS strategies (
+    strategy_id TEXT PRIMARY KEY,
+    active_version_id TEXT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- strategy_versions: immutable hash-keyed version rows (Invariant 3)
+
+CREATE TABLE IF NOT EXISTS strategy_versions (
+    strategy_version_id TEXT PRIMARY KEY,
+    strategy_id TEXT NOT NULL REFERENCES strategies(strategy_id) ON DELETE CASCADE,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (strategy_id, strategy_version_id)
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'strategies_active_version_id_fkey'
+    ) THEN
+        ALTER TABLE strategies
+            ADD CONSTRAINT strategies_active_version_id_fkey
+            FOREIGN KEY (active_version_id)
+            REFERENCES strategy_versions(strategy_version_id)
+            DEFERRABLE INITIALLY DEFERRED;
+    END IF;
+END
+$$;
+
 -- BEGIN INNER-RING PRODUCT SHELLS
 
 CREATE TABLE IF NOT EXISTS feedback (

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from pms.api.routes.feedback import list_feedback as list_feedback_items
 from pms.api.routes.feedback import resolve_feedback as resolve_feedback_item
 from pms.api.routes.signals import SignalDepthNotFoundError, get_signal_depth
+from pms.api.routes.strategies import list_strategies as list_strategies_items
 from pms.core.enums import RunMode
 from pms.core.models import MarketSignal, TradeDecision
 from pms.evaluation.metrics import MetricsCollector, MetricsSnapshot
@@ -161,6 +162,12 @@ def create_app(
             cast(dict[str, Any], _jsonable(item))
             for item in await list_feedback_items(active_runner.feedback_store, resolved=resolved)
         ]
+
+    @app.get("/strategies")
+    async def strategies() -> dict[str, Any]:
+        if active_runner.pg_pool is None:
+            raise HTTPException(status_code=503, detail="Runner PostgreSQL pool is not initialized")
+        return await list_strategies_items(active_runner.pg_pool)
 
     @app.post("/feedback/{feedback_id}/resolve")
     async def resolve_feedback(feedback_id: str) -> dict[str, Any]:

--- a/src/pms/api/routes/strategies.py
+++ b/src/pms/api/routes/strategies.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import asyncpg
+from pydantic import BaseModel, field_serializer
+
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+
+
+class StrategyRowResponse(BaseModel):
+    strategy_id: str
+    active_version_id: str | None
+    created_at: datetime
+
+    @field_serializer("created_at")
+    def _serialize_created_at(self, created_at: datetime) -> str:
+        return created_at.isoformat()
+
+
+class StrategiesResponse(BaseModel):
+    strategies: list[StrategyRowResponse]
+
+
+async def list_strategies(pg_pool: asyncpg.Pool) -> dict[str, Any]:
+    registry = PostgresStrategyRegistry(pg_pool)
+    payload = StrategiesResponse(
+        strategies=[
+            StrategyRowResponse(
+                strategy_id=row.strategy_id,
+                active_version_id=row.active_version_id,
+                created_at=row.created_at,
+            )
+            for row in await registry.list_strategies()
+        ]
+    )
+    return payload.model_dump(mode="json")

--- a/src/pms/storage/eval_store.py
+++ b/src/pms/storage/eval_store.py
@@ -8,6 +8,7 @@ from typing import cast
 import asyncpg
 
 from pms.core.models import EvalRecord
+from pms.storage.strategy_tags import resolve_strategy_tags
 
 
 @dataclass
@@ -22,7 +23,7 @@ class EvalStore:
         record: EvalRecord,
         *,
         strategy_id: str = "default",
-        strategy_version_id: str = "default-v1",
+        strategy_version_id: str | None = None,
     ) -> None:
         async with self._pool().acquire() as connection:
             await insert_eval_record_row(
@@ -71,8 +72,13 @@ async def insert_eval_record_row(
     record: EvalRecord,
     *,
     strategy_id: str = "default",
-    strategy_version_id: str = "default-v1",
+    strategy_version_id: str | None = None,
 ) -> None:
+    resolved_strategy_id, resolved_strategy_version_id = await resolve_strategy_tags(
+        connection,
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+    )
     await connection.execute(
         """
         INSERT INTO eval_records (
@@ -108,8 +114,8 @@ async def insert_eval_record_row(
         record.pnl,
         record.slippage_bps,
         record.filled,
-        strategy_id,
-        strategy_version_id,
+        resolved_strategy_id,
+        resolved_strategy_version_id,
     )
 
 

--- a/src/pms/storage/eval_store.py
+++ b/src/pms/storage/eval_store.py
@@ -17,9 +17,20 @@ class EvalStore:
     def bind_pool(self, pool: asyncpg.Pool) -> None:
         self.pool = pool
 
-    async def append(self, record: EvalRecord) -> None:
+    async def append(
+        self,
+        record: EvalRecord,
+        *,
+        strategy_id: str = "default",
+        strategy_version_id: str = "default-v1",
+    ) -> None:
         async with self._pool().acquire() as connection:
-            await insert_eval_record_row(connection, record)
+            await insert_eval_record_row(
+                connection,
+                record,
+                strategy_id=strategy_id,
+                strategy_version_id=strategy_version_id,
+            )
 
     async def all(self) -> list[EvalRecord]:
         if self.pool is None:
@@ -58,6 +69,9 @@ class EvalStore:
 async def insert_eval_record_row(
     connection: asyncpg.Connection,
     record: EvalRecord,
+    *,
+    strategy_id: str = "default",
+    strategy_version_id: str = "default-v1",
 ) -> None:
     await connection.execute(
         """
@@ -78,7 +92,7 @@ async def insert_eval_record_row(
             strategy_id,
             strategy_version_id
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, NULL, NULL
+            $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14, $15
         )
         """,
         record.decision_id,
@@ -94,6 +108,8 @@ async def insert_eval_record_row(
         record.pnl,
         record.slippage_bps,
         record.filled,
+        strategy_id,
+        strategy_version_id,
     )
 
 

--- a/src/pms/storage/feedback_store.py
+++ b/src/pms/storage/feedback_store.py
@@ -33,9 +33,20 @@ class FeedbackStore:
     def bind_pool(self, pool: asyncpg.Pool) -> None:
         self.pool = pool
 
-    async def append(self, feedback: Feedback) -> None:
+    async def append(
+        self,
+        feedback: Feedback,
+        *,
+        strategy_id: str = "default",
+        strategy_version_id: str = "default-v1",
+    ) -> None:
         async with self._pool().acquire() as connection:
-            await insert_feedback_row(connection, feedback)
+            await insert_feedback_row(
+                connection,
+                feedback,
+                strategy_id=strategy_id,
+                strategy_version_id=strategy_version_id,
+            )
 
     async def all(self) -> list[Feedback]:
         return await self.list()
@@ -87,7 +98,13 @@ class FeedbackStore:
         return self.pool
 
 
-async def insert_feedback_row(connection: asyncpg.Connection, feedback: Feedback) -> None:
+async def insert_feedback_row(
+    connection: asyncpg.Connection,
+    feedback: Feedback,
+    *,
+    strategy_id: str = "default",
+    strategy_version_id: str = "default-v1",
+) -> None:
     await connection.execute(
         """
         INSERT INTO feedback (
@@ -104,7 +121,7 @@ async def insert_feedback_row(connection: asyncpg.Connection, feedback: Feedback
             strategy_id,
             strategy_version_id
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, NULL, NULL
+            $1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12
         )
         """,
         feedback.feedback_id,
@@ -117,6 +134,8 @@ async def insert_feedback_row(connection: asyncpg.Connection, feedback: Feedback
         feedback.resolved_at,
         feedback.category,
         json.dumps(feedback.metadata),
+        strategy_id,
+        strategy_version_id,
     )
 
 

--- a/src/pms/storage/feedback_store.py
+++ b/src/pms/storage/feedback_store.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import asyncpg
 
 from pms.core.models import Feedback
+from pms.storage.strategy_tags import resolve_strategy_tags
 
 
 _SELECT_FEEDBACK_COLUMNS = """
@@ -38,7 +39,7 @@ class FeedbackStore:
         feedback: Feedback,
         *,
         strategy_id: str = "default",
-        strategy_version_id: str = "default-v1",
+        strategy_version_id: str | None = None,
     ) -> None:
         async with self._pool().acquire() as connection:
             await insert_feedback_row(
@@ -103,8 +104,13 @@ async def insert_feedback_row(
     feedback: Feedback,
     *,
     strategy_id: str = "default",
-    strategy_version_id: str = "default-v1",
+    strategy_version_id: str | None = None,
 ) -> None:
+    resolved_strategy_id, resolved_strategy_version_id = await resolve_strategy_tags(
+        connection,
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+    )
     await connection.execute(
         """
         INSERT INTO feedback (
@@ -134,8 +140,8 @@ async def insert_feedback_row(
         feedback.resolved_at,
         feedback.category,
         json.dumps(feedback.metadata),
-        strategy_id,
-        strategy_version_id,
+        resolved_strategy_id,
+        resolved_strategy_version_id,
     )
 
 

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -46,6 +46,14 @@ class PostgresStrategyRegistry:
             await connection.execute(query, strategy_id, metadata_json)
 
     async def create_version(self, strategy: Strategy) -> StrategyVersion:
+        """Register a strategy snapshot and make that version active.
+
+        Re-registering an existing version is idempotent for the
+        `strategy_versions` row but still re-points
+        `strategies.active_version_id` to the requested version. S2
+        treats `create_version(...)` as the explicit register-and-activate
+        entrypoint until a separate activation API exists.
+        """
         strategy_id = strategy.config.strategy_id
         strategy_version_id = compute_strategy_version_id(*strategy.snapshot())
         config_json = serialize_strategy_config_json(*strategy.snapshot())
@@ -182,13 +190,19 @@ def _strategy_from_config_json(raw_value: object) -> Strategy:
     )
     return Strategy(
         config=StrategyConfig(
-            strategy_id=cast(str, config_payload["strategy_id"]),
+            strategy_id=_json_string(config_payload["strategy_id"], "config.strategy_id"),
             factor_composition=tuple(
-                (cast(str, item[0]), _json_float(item[1], "config.factor_composition"))
+                (
+                    _json_string(item[0], "config.factor_composition.key"),
+                    _json_float(item[1], "config.factor_composition"),
+                )
                 for item in _json_pairs(config_payload["factor_composition"])
             ),
             metadata=tuple(
-                (cast(str, item[0]), cast(str, item[1]))
+                (
+                    _json_string(item[0], "config.metadata.key"),
+                    _json_string(item[1], "config.metadata.value"),
+                )
                 for item in _json_pairs(config_payload["metadata"])
             ),
         ),
@@ -207,14 +221,17 @@ def _strategy_from_config_json(raw_value: object) -> Strategy:
             ),
         ),
         eval_spec=EvalSpec(
-            metrics=tuple(cast(list[str], eval_spec_payload["metrics"]))
+            metrics=tuple(_json_string_list(eval_spec_payload["metrics"], "eval_spec.metrics"))
         ),
         forecaster=ForecasterSpec(
             forecasters=tuple(
                 (
-                    cast(str, item[0]),
+                    _json_string(item[0], "forecaster.forecasters.name"),
                     tuple(
-                        (cast(str, param[0]), cast(str, param[1]))
+                        (
+                            _json_string(param[0], "forecaster.forecasters.param.key"),
+                            _json_string(param[1], "forecaster.forecasters.param.value"),
+                        )
                         for param in _json_pairs(item[1])
                     ),
                 )
@@ -222,10 +239,10 @@ def _strategy_from_config_json(raw_value: object) -> Strategy:
             )
         ),
         market_selection=MarketSelectionSpec(
-            venue=cast(str, market_selection_payload["venue"]),
-            resolution_time_max_horizon_days=cast(
-                int | None,
+            venue=_json_string(market_selection_payload["venue"], "market_selection.venue"),
+            resolution_time_max_horizon_days=_json_optional_int(
                 market_selection_payload["resolution_time_max_horizon_days"],
+                "market_selection.resolution_time_max_horizon_days",
             ),
             volume_min_usdc=_json_float(
                 market_selection_payload["volume_min_usdc"],
@@ -265,6 +282,32 @@ def _json_pairs(value: object) -> list[list[object]]:
             raise TypeError(msg)
         decoded_pairs.append(cast(list[object], pair))
     return decoded_pairs
+
+
+def _json_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        msg = f"{field_name} must decode to a string"
+        raise TypeError(msg)
+    return value
+
+
+def _json_string_list(value: object, field_name: str) -> list[str]:
+    if not isinstance(value, list):
+        msg = f"{field_name} must decode to a JSON array"
+        raise TypeError(msg)
+    decoded: list[str] = []
+    for item in value:
+        decoded.append(_json_string(item, field_name))
+    return decoded
+
+
+def _json_optional_int(value: object, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        msg = f"{field_name} must decode to an int or null"
+        raise TypeError(msg)
+    return value
 
 
 def _json_float(value: object, field_name: str) -> float:

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -311,7 +311,7 @@ def _json_optional_int(value: object, field_name: str) -> int | None:
 
 
 def _json_float(value: object, field_name: str) -> float:
-    if not isinstance(value, (int, float, str)):
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
         msg = f"{field_name} must decode to a float-compatible value"
         raise TypeError(msg)
     return float(value)

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+from typing import Any, cast
+
+import asyncpg
+
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+    StrategyRow,
+    StrategyVersion,
+)
+from pms.strategies.versioning import (
+    compute_strategy_version_id,
+    serialize_strategy_config_json,
+)
+
+
+class PostgresStrategyRegistry:
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def create_strategy(
+        self,
+        strategy_id: str,
+        metadata: dict[str, str] | None = None,
+    ) -> None:
+        query = """
+        INSERT INTO strategies (strategy_id, metadata_json)
+        VALUES ($1, $2::jsonb)
+        ON CONFLICT (strategy_id) DO NOTHING
+        """
+        metadata_json = json.dumps(
+            metadata or {},
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        async with self._pool.acquire() as connection:
+            await connection.execute(query, strategy_id, metadata_json)
+
+    async def create_version(self, strategy: Strategy) -> StrategyVersion:
+        strategy_id = strategy.config.strategy_id
+        strategy_version_id = compute_strategy_version_id(*strategy.snapshot())
+        config_json = serialize_strategy_config_json(*strategy.snapshot())
+        metadata_json = json.dumps(
+            dict(strategy.config.metadata),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        insert_strategy_query = """
+        INSERT INTO strategies (strategy_id, metadata_json)
+        VALUES ($1, $2::jsonb)
+        ON CONFLICT (strategy_id) DO NOTHING
+        """
+        insert_version_query = """
+        INSERT INTO strategy_versions (
+            strategy_version_id,
+            strategy_id,
+            config_json,
+            created_at
+        ) VALUES ($1, $2, $3::jsonb, clock_timestamp())
+        ON CONFLICT (strategy_version_id) DO NOTHING
+        RETURNING created_at
+        """
+        select_version_query = """
+        SELECT created_at
+        FROM strategy_versions
+        WHERE strategy_id = $1 AND strategy_version_id = $2
+        """
+        update_strategy_query = """
+        UPDATE strategies
+        SET active_version_id = $2
+        WHERE strategy_id = $1
+        """
+        async with self._pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute(
+                    insert_strategy_query,
+                    strategy_id,
+                    metadata_json,
+                )
+                created_at = await connection.fetchval(
+                    insert_version_query,
+                    strategy_version_id,
+                    strategy_id,
+                    config_json,
+                )
+                if created_at is None:
+                    created_at = await connection.fetchval(
+                        select_version_query,
+                        strategy_id,
+                        strategy_version_id,
+                    )
+                if not isinstance(created_at, datetime):
+                    msg = "strategy_versions.created_at did not return a timestamp"
+                    raise TypeError(msg)
+                await connection.execute(
+                    update_strategy_query,
+                    strategy_id,
+                    strategy_version_id,
+                )
+        return StrategyVersion(
+            strategy_id=strategy_id,
+            strategy_version_id=strategy_version_id,
+            created_at=_ensure_utc(created_at),
+        )
+
+    async def get_by_id(self, strategy_id: str) -> Strategy | None:
+        query = """
+        SELECT versions.config_json
+        FROM strategies
+        LEFT JOIN strategy_versions AS versions
+            ON versions.strategy_version_id = strategies.active_version_id
+        WHERE strategies.strategy_id = $1
+        """
+        async with self._pool.acquire() as connection:
+            row = await connection.fetchrow(query, strategy_id)
+        if row is None or row["config_json"] is None:
+            return None
+        return _strategy_from_config_json(row["config_json"])
+
+    async def list_strategies(self) -> list[StrategyRow]:
+        query = """
+        SELECT strategy_id, active_version_id, created_at
+        FROM strategies
+        ORDER BY strategy_id ASC
+        """
+        async with self._pool.acquire() as connection:
+            rows = await connection.fetch(query)
+        return [
+            StrategyRow(
+                strategy_id=row["strategy_id"],
+                active_version_id=row["active_version_id"],
+                created_at=_ensure_utc(row["created_at"]),
+            )
+            for row in rows
+        ]
+
+    async def list_versions(self, strategy_id: str) -> list[StrategyVersion]:
+        query = """
+        SELECT strategy_id, strategy_version_id, created_at
+        FROM strategy_versions
+        WHERE strategy_id = $1
+        ORDER BY created_at ASC, strategy_version_id ASC
+        """
+        async with self._pool.acquire() as connection:
+            rows = await connection.fetch(query, strategy_id)
+        return [
+            StrategyVersion(
+                strategy_id=row["strategy_id"],
+                strategy_version_id=row["strategy_version_id"],
+                created_at=_ensure_utc(row["created_at"]),
+            )
+            for row in rows
+        ]
+
+
+def _ensure_utc(value: object) -> datetime:
+    if not isinstance(value, datetime):
+        msg = f"expected datetime, got {type(value).__name__}"
+        raise TypeError(msg)
+    return value.astimezone(UTC)
+
+
+def _strategy_from_config_json(raw_value: object) -> Strategy:
+    payload = _load_json_object(raw_value)
+    config_payload = _json_object(payload["config"], "config")
+    risk_payload = _json_object(payload["risk"], "risk")
+    eval_spec_payload = _json_object(payload["eval_spec"], "eval_spec")
+    forecaster_payload = _json_object(payload["forecaster"], "forecaster")
+    market_selection_payload = _json_object(
+        payload["market_selection"],
+        "market_selection",
+    )
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=cast(str, config_payload["strategy_id"]),
+            factor_composition=tuple(
+                (cast(str, item[0]), _json_float(item[1], "config.factor_composition"))
+                for item in _json_pairs(config_payload["factor_composition"])
+            ),
+            metadata=tuple(
+                (cast(str, item[0]), cast(str, item[1]))
+                for item in _json_pairs(config_payload["metadata"])
+            ),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=_json_float(
+                risk_payload["max_position_notional_usdc"],
+                "risk.max_position_notional_usdc",
+            ),
+            max_daily_drawdown_pct=_json_float(
+                risk_payload["max_daily_drawdown_pct"],
+                "risk.max_daily_drawdown_pct",
+            ),
+            min_order_size_usdc=_json_float(
+                risk_payload["min_order_size_usdc"],
+                "risk.min_order_size_usdc",
+            ),
+        ),
+        eval_spec=EvalSpec(
+            metrics=tuple(cast(list[str], eval_spec_payload["metrics"]))
+        ),
+        forecaster=ForecasterSpec(
+            forecasters=tuple(
+                (
+                    cast(str, item[0]),
+                    tuple(
+                        (cast(str, param[0]), cast(str, param[1]))
+                        for param in _json_pairs(item[1])
+                    ),
+                )
+                for item in _json_pairs(forecaster_payload["forecasters"])
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue=cast(str, market_selection_payload["venue"]),
+            resolution_time_max_horizon_days=cast(
+                int | None,
+                market_selection_payload["resolution_time_max_horizon_days"],
+            ),
+            volume_min_usdc=_json_float(
+                market_selection_payload["volume_min_usdc"],
+                "market_selection.volume_min_usdc",
+            ),
+        ),
+    )
+
+
+def _load_json_object(raw_value: object) -> dict[str, object]:
+    if isinstance(raw_value, str):
+        loaded = json.loads(raw_value)
+    else:
+        loaded = raw_value
+    if not isinstance(loaded, dict):
+        msg = "strategy config payload must be a JSON object"
+        raise TypeError(msg)
+    return cast(dict[str, object], loaded)
+
+
+def _json_object(value: object, field_name: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        msg = f"{field_name} must decode to a JSON object"
+        raise TypeError(msg)
+    return cast(dict[str, object], value)
+
+
+def _json_pairs(value: object) -> list[list[object]]:
+    if not isinstance(value, list):
+        msg = "expected JSON array of pairs"
+        raise TypeError(msg)
+    pairs = cast(list[object], value)
+    decoded_pairs: list[list[object]] = []
+    for pair in pairs:
+        if not isinstance(pair, list) or len(pair) != 2:
+            msg = "expected JSON array pair"
+            raise TypeError(msg)
+        decoded_pairs.append(cast(list[object], pair))
+    return decoded_pairs
+
+
+def _json_float(value: object, field_name: str) -> float:
+    if not isinstance(value, (int, float, str)):
+        msg = f"{field_name} must decode to a float-compatible value"
+        raise TypeError(msg)
+    return float(value)

--- a/src/pms/storage/strategy_tags.py
+++ b/src/pms/storage/strategy_tags.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import asyncpg
+
+
+async def resolve_strategy_tags(
+    connection: asyncpg.Connection,
+    *,
+    strategy_id: str,
+    strategy_version_id: str | None,
+) -> tuple[str, str]:
+    if strategy_version_id is not None:
+        return strategy_id, strategy_version_id
+
+    active_version_id = await connection.fetchval(
+        """
+        SELECT active_version_id
+        FROM strategies
+        WHERE strategy_id = $1
+        """,
+        strategy_id,
+    )
+    if not isinstance(active_version_id, str):
+        msg = f"strategy {strategy_id!r} has no active version"
+        raise RuntimeError(msg)
+    return strategy_id, active_version_id

--- a/src/pms/strategies/__init__.py
+++ b/src/pms/strategies/__init__.py
@@ -1,0 +1,19 @@
+"""Strategy aggregate and immutable projection value objects."""
+
+from .aggregate import Strategy
+from .projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+__all__ = [
+    "EvalSpec",
+    "ForecasterSpec",
+    "MarketSelectionSpec",
+    "RiskParams",
+    "Strategy",
+    "StrategyConfig",
+]

--- a/src/pms/strategies/aggregate.py
+++ b/src/pms/strategies/aggregate.py
@@ -1,0 +1,90 @@
+"""Strategy aggregate that owns immutable projection state."""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from .projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+
+ProjectionT = TypeVar("ProjectionT")
+
+
+class Strategy:
+    __slots__ = (
+        "_config",
+        "_risk",
+        "_eval_spec",
+        "_forecaster",
+        "_market_selection",
+    )
+
+    def __init__(
+        self,
+        *,
+        config: StrategyConfig,
+        risk: RiskParams,
+        eval_spec: EvalSpec,
+        forecaster: ForecasterSpec,
+        market_selection: MarketSelectionSpec,
+    ) -> None:
+        self._config = self._require_projection("config", config)
+        self._risk = self._require_projection("risk", risk)
+        self._eval_spec = self._require_projection("eval_spec", eval_spec)
+        self._forecaster = self._require_projection("forecaster", forecaster)
+        self._market_selection = self._require_projection(
+            "market_selection",
+            market_selection,
+        )
+
+    @staticmethod
+    def _require_projection(
+        field_name: str,
+        value: ProjectionT | None,
+    ) -> ProjectionT:
+        if value is None:
+            raise TypeError(f"{field_name} must not be None")
+        return value
+
+    @property
+    def config(self) -> StrategyConfig:
+        return self._config
+
+    @property
+    def risk(self) -> RiskParams:
+        return self._risk
+
+    @property
+    def eval_spec(self) -> EvalSpec:
+        return self._eval_spec
+
+    @property
+    def forecaster(self) -> ForecasterSpec:
+        return self._forecaster
+
+    @property
+    def market_selection(self) -> MarketSelectionSpec:
+        return self._market_selection
+
+    def snapshot(
+        self,
+    ) -> tuple[
+        StrategyConfig,
+        RiskParams,
+        EvalSpec,
+        ForecasterSpec,
+        MarketSelectionSpec,
+    ]:
+        return (
+            self._config,
+            self._risk,
+            self._eval_spec,
+            self._forecaster,
+            self._market_selection,
+        )

--- a/src/pms/strategies/aggregate.py
+++ b/src/pms/strategies/aggregate.py
@@ -88,3 +88,11 @@ class Strategy:
             self._forecaster,
             self._market_selection,
         )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Strategy):
+            return NotImplemented
+        return self.snapshot() == other.snapshot()
+
+    def __hash__(self) -> int:
+        return hash(self.snapshot())

--- a/src/pms/strategies/projections.py
+++ b/src/pms/strategies/projections.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,3 +35,17 @@ class MarketSelectionSpec:
     venue: str
     resolution_time_max_horizon_days: int | None
     volume_min_usdc: float
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyRow:
+    strategy_id: str
+    active_version_id: str | None
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyVersion:
+    strategy_id: str
+    strategy_version_id: str
+    created_at: datetime

--- a/src/pms/strategies/projections.py
+++ b/src/pms/strategies/projections.py
@@ -1,0 +1,36 @@
+"""Immutable strategy projection value objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyConfig:
+    strategy_id: str
+    factor_composition: tuple[tuple[str, float], ...]
+    metadata: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RiskParams:
+    max_position_notional_usdc: float
+    max_daily_drawdown_pct: float
+    min_order_size_usdc: float
+
+
+@dataclass(frozen=True, slots=True)
+class EvalSpec:
+    metrics: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ForecasterSpec:
+    forecasters: tuple[tuple[str, tuple[tuple[str, str], ...]], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MarketSelectionSpec:
+    venue: str
+    resolution_time_max_horizon_days: int | None
+    volume_min_usdc: float

--- a/src/pms/strategies/versioning.py
+++ b/src/pms/strategies/versioning.py
@@ -32,6 +32,26 @@ def _json_sort_key(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
+def _payload_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        return _payload_value(asdict(value, dict_factory=_sorted_dict_factory))
+    if isinstance(value, dict):
+        return {
+            key: _payload_value(value[key])
+            for key in sorted(value)
+        }
+    if isinstance(value, tuple):
+        return [_payload_value(item) for item in value]
+    if isinstance(value, list):
+        return [_payload_value(item) for item in value]
+    if isinstance(value, frozenset):
+        normalized_items = [_payload_value(item) for item in value]
+        return sorted(normalized_items, key=_json_sort_key)
+    return value
+
+
 def _normalize_value(value: Any) -> Any:
     if isinstance(value, dict):
         return {
@@ -55,6 +75,43 @@ def _json_default(value: Any) -> Any:
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
+def _strategy_payload(
+    config: StrategyConfig,
+    risk: RiskParams,
+    eval_spec: EvalSpec,
+    forecaster: ForecasterSpec,
+    market_selection: MarketSelectionSpec,
+) -> dict[str, Any]:
+    return {
+        "config": _payload_value(config),
+        "risk": _payload_value(risk),
+        "eval_spec": _payload_value(eval_spec),
+        "forecaster": _payload_value(forecaster),
+        "market_selection": _payload_value(market_selection),
+    }
+
+
+def serialize_strategy_config_json(
+    config: StrategyConfig,
+    risk: RiskParams,
+    eval_spec: EvalSpec,
+    forecaster: ForecasterSpec,
+    market_selection: MarketSelectionSpec,
+) -> str:
+    return json.dumps(
+        _strategy_payload(
+            config=config,
+            risk=risk,
+            eval_spec=eval_spec,
+            forecaster=forecaster,
+            market_selection=market_selection,
+        ),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
 def compute_strategy_version_id(
     config: StrategyConfig,
     risk: RiskParams,
@@ -62,18 +119,19 @@ def compute_strategy_version_id(
     forecaster: ForecasterSpec,
     market_selection: MarketSelectionSpec,
 ) -> str:
-    canonical_payload = {
-        "config": config,
-        "risk": risk,
-        "eval_spec": eval_spec,
-        "forecaster": forecaster,
-        "market_selection": market_selection,
-    }
+    canonical_payload = _normalize_value(
+        _strategy_payload(
+            config=config,
+            risk=risk,
+            eval_spec=eval_spec,
+            forecaster=forecaster,
+            market_selection=market_selection,
+        )
+    )
     canonical_json = json.dumps(
         canonical_payload,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=True,
-        default=_json_default,
     )
     return sha256(canonical_json.encode("utf-8")).hexdigest()

--- a/src/pms/strategies/versioning.py
+++ b/src/pms/strategies/versioning.py
@@ -55,6 +55,15 @@ def _payload_value(value: Any) -> Any:
     return value
 
 
+def _is_pair_record(item: Any) -> bool:
+    # Pair records — 2-element (tuple|list) — model ordered (key, value)
+    # structure throughout the projection layer (metadata entries,
+    # factor composition weights, forecaster specs). Their element order
+    # carries meaning and must not be sorted, or swapping key/value
+    # produces a hash collision (Invariant 3 violation).
+    return isinstance(item, (tuple, list)) and len(item) == 2
+
+
 def _normalize_value(value: Any) -> Any:
     # Version ids intentionally normalize sequence ordering so semantically
     # equivalent projection payloads hash identically across processes.
@@ -64,6 +73,12 @@ def _normalize_value(value: Any) -> Any:
             for key in sorted(value)
         }
     if isinstance(value, (tuple, list)):
+        if value and all(_is_pair_record(item) for item in value):
+            normalized_pairs = [
+                [_normalize_value(item[0]), _normalize_value(item[1])]
+                for item in value
+            ]
+            return sorted(normalized_pairs, key=_json_sort_key)
         normalized_items = [_normalize_value(item) for item in value]
         return sorted(normalized_items, key=_json_sort_key)
     if isinstance(value, frozenset):

--- a/src/pms/strategies/versioning.py
+++ b/src/pms/strategies/versioning.py
@@ -1,8 +1,9 @@
 """Deterministic strategy-version hashing.
 
-Canonicalization uses ``json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=True)`` before hashing. The ``default=`` hook handles ``Enum``
-values via ``.value`` and nested frozen dataclasses via recursive
-``dataclasses.asdict(..., dict_factory=<sorted-dict>)`` normalization.
+Canonicalization first normalizes frozen projection dataclasses,
+``Enum`` values, and nested containers into plain builtins. The
+normalized payload is then serialized with
+``json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=True)``.
 
 The resulting SHA-256 hex digest must remain byte-identical across Python minor-version bumps and process restarts. Any accidental drift is an Invariant 3 violation.
 """
@@ -33,6 +34,8 @@ def _json_sort_key(value: Any) -> str:
 
 
 def _payload_value(value: Any) -> Any:
+    # Stored config_json must preserve sequence order so the row can round-trip
+    # back into the original projection tuple.
     if isinstance(value, Enum):
         return value.value
     if is_dataclass(value) and not isinstance(value, type):
@@ -53,6 +56,8 @@ def _payload_value(value: Any) -> Any:
 
 
 def _normalize_value(value: Any) -> Any:
+    # Version ids intentionally normalize sequence ordering so semantically
+    # equivalent projection payloads hash identically across processes.
     if isinstance(value, dict):
         return {
             key: _normalize_value(value[key])
@@ -65,14 +70,6 @@ def _normalize_value(value: Any) -> Any:
         normalized_items = [_normalize_value(item) for item in value]
         return sorted(normalized_items, key=_json_sort_key)
     return value
-
-
-def _json_default(value: Any) -> Any:
-    if isinstance(value, Enum):
-        return value.value
-    if is_dataclass(value) and not isinstance(value, type):
-        return _normalize_value(asdict(value, dict_factory=_sorted_dict_factory))
-    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
 
 
 def _strategy_payload(

--- a/src/pms/strategies/versioning.py
+++ b/src/pms/strategies/versioning.py
@@ -1,0 +1,79 @@
+"""Deterministic strategy-version hashing.
+
+Canonicalization uses ``json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=True)`` before hashing. The ``default=`` hook handles ``Enum``
+values via ``.value`` and nested frozen dataclasses via recursive
+``dataclasses.asdict(..., dict_factory=<sorted-dict>)`` normalization.
+
+The resulting SHA-256 hex digest must remain byte-identical across Python minor-version bumps and process restarts. Any accidental drift is an Invariant 3 violation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from hashlib import sha256
+import json
+from typing import Any
+
+from .projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+
+def _sorted_dict_factory(items: list[tuple[str, Any]]) -> dict[str, Any]:
+    return {key: value for key, value in sorted(items)}
+
+
+def _json_sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _normalize_value(value[key])
+            for key in sorted(value)
+        }
+    if isinstance(value, (tuple, list)):
+        normalized_items = [_normalize_value(item) for item in value]
+        return sorted(normalized_items, key=_json_sort_key)
+    if isinstance(value, frozenset):
+        normalized_items = [_normalize_value(item) for item in value]
+        return sorted(normalized_items, key=_json_sort_key)
+    return value
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        return _normalize_value(asdict(value, dict_factory=_sorted_dict_factory))
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def compute_strategy_version_id(
+    config: StrategyConfig,
+    risk: RiskParams,
+    eval_spec: EvalSpec,
+    forecaster: ForecasterSpec,
+    market_selection: MarketSelectionSpec,
+) -> str:
+    canonical_payload = {
+        "config": config,
+        "risk": risk,
+        "eval_spec": eval_spec,
+        "forecaster": forecaster,
+        "market_selection": market_selection,
+    }
+    canonical_json = json.dumps(
+        canonical_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=_json_default,
+    )
+    return sha256(canonical_json.encode("utf-8")).hexdigest()

--- a/tests/integration/test_default_strategy_tagging.py
+++ b/tests/integration/test_default_strategy_tagging.py
@@ -11,6 +11,7 @@ from pms.config import DatabaseSettings, PMSSettings, RiskSettings
 from pms.core.enums import MarketStatus, RunMode
 from pms.core.models import MarketSignal
 from pms.runner import Runner
+from pms.strategies.aggregate import Strategy
 from pms.strategies.projections import (
     EvalSpec,
     ForecasterSpec,
@@ -21,6 +22,7 @@ from pms.strategies.projections import (
 from pms.strategies.versioning import serialize_strategy_config_json
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
+from pms.storage.strategy_registry import PostgresStrategyRegistry
 
 
 PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
@@ -114,6 +116,33 @@ def _default_strategy_config_json() -> str:
     )
 
 
+def _strategy(*, drawdown_pct: float) -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=drawdown_pct,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
 async def _count_null_strategy_tags(connection: asyncpg.Connection, table: str) -> int:
     query = f"""
     SELECT COUNT(*)
@@ -145,31 +174,9 @@ async def _strategy_pairs(
 async def test_runner_tags_inner_ring_rows_with_default_strategy(
     pg_pool: asyncpg.Pool,
 ) -> None:
-    async with pg_pool.acquire() as connection:
-        async with connection.transaction():
-            await connection.execute("SET CONSTRAINTS ALL DEFERRED")
-            await connection.execute(
-                """
-                INSERT INTO strategies (strategy_id, active_version_id)
-                VALUES ('default', 'default-v1')
-                ON CONFLICT (strategy_id) DO NOTHING
-                """
-            )
-            await connection.execute(
-                """
-                INSERT INTO strategy_versions (
-                    strategy_version_id,
-                    strategy_id,
-                    config_json
-                ) VALUES (
-                    'default-v1',
-                    'default',
-                    $1::jsonb
-                )
-                ON CONFLICT (strategy_version_id) DO NOTHING
-                """,
-                _default_strategy_config_json(),
-            )
+    active_version = await PostgresStrategyRegistry(pg_pool).create_version(
+        _strategy(drawdown_pct=3.5)
+    )
 
     runner = Runner(
         config=_settings(),
@@ -210,8 +217,10 @@ async def test_runner_tags_inner_ring_rows_with_default_strategy(
             """
             SELECT COUNT(*)
             FROM strategy_versions
-            WHERE strategy_id = 'default' AND strategy_version_id = 'default-v1'
+            WHERE strategy_id = 'default' AND strategy_version_id = $1
             """
+            ,
+            active_version.strategy_version_id,
         )
         feedback_count = await connection.fetchval("SELECT COUNT(*) FROM feedback")
         eval_count = await connection.fetchval("SELECT COUNT(*) FROM eval_records")
@@ -233,8 +242,10 @@ async def test_runner_tags_inner_ring_rows_with_default_strategy(
                 f"""
                 SELECT COUNT(*)
                 FROM {table}
-                WHERE strategy_id = 'default' AND strategy_version_id = 'default-v1'
+                WHERE strategy_id = 'default' AND strategy_version_id = $1
                 """
+                ,
+                active_version.strategy_version_id,
             )
             for table in counts
         }
@@ -255,7 +266,7 @@ async def test_runner_tags_inner_ring_rows_with_default_strategy(
     }
     assert tagged_counts["feedback"] > 0
     assert tagged_counts["eval_records"] > 0
-    assert strategy_pairs["feedback"] == {("default", "default-v1")}
-    assert strategy_pairs["eval_records"] == {("default", "default-v1")}
+    assert strategy_pairs["feedback"] == {("default", active_version.strategy_version_id)}
+    assert strategy_pairs["eval_records"] == {("default", active_version.strategy_version_id)}
     assert strategy_pairs["orders"] == set()
     assert strategy_pairs["fills"] == set()

--- a/tests/integration/test_default_strategy_tagging.py
+++ b/tests/integration/test_default_strategy_tagging.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import asyncpg
+import pytest
+
+from pms.config import DatabaseSettings, PMSSettings, RiskSettings
+from pms.core.enums import MarketStatus, RunMode
+from pms.core.models import MarketSignal
+from pms.runner import Runner
+from pms.storage.eval_store import EvalStore
+from pms.storage.feedback_store import FeedbackStore
+
+
+PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run PostgreSQL integration tests",
+    ),
+    pytest.mark.skipif(
+        PMS_TEST_DATABASE_URL is None,
+        reason="set PMS_TEST_DATABASE_URL to the compose-backed PostgreSQL URI",
+    ),
+]
+
+
+class SequenceSensor:
+    def __init__(self, signals: list[MarketSignal]) -> None:
+        self._signals = list(signals)
+
+    def __aiter__(self) -> AsyncIterator[MarketSignal]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[MarketSignal]:
+        for signal in self._signals:
+            yield signal
+
+
+def _settings() -> PMSSettings:
+    assert PMS_TEST_DATABASE_URL is not None
+    return PMSSettings(
+        mode=RunMode.PAPER,
+        database=DatabaseSettings(
+            dsn=PMS_TEST_DATABASE_URL,
+            pool_min_size=1,
+            pool_max_size=2,
+        ),
+        risk=RiskSettings(
+            max_position_per_market=1000.0,
+            max_total_exposure=10_000.0,
+        ),
+    )
+
+
+def _signal(
+    *,
+    market_id: str,
+    orderbook: dict[str, object],
+    external_signal: dict[str, object],
+) -> MarketSignal:
+    return MarketSignal(
+        market_id=market_id,
+        token_id="yes-token",
+        venue="polymarket",
+        title="Will CP06 default-tag runtime writes?",
+        yes_price=0.4,
+        volume_24h=1000.0,
+        resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
+        orderbook=orderbook,
+        external_signal=external_signal,
+        fetched_at=datetime(2026, 4, 17, tzinfo=UTC),
+        market_status=MarketStatus.OPEN.value,
+    )
+
+
+async def _count_null_strategy_tags(connection: asyncpg.Connection, table: str) -> int:
+    query = f"""
+    SELECT COUNT(*)
+    FROM {table}
+    WHERE strategy_id IS NULL OR strategy_version_id IS NULL
+    """
+    count = await connection.fetchval(query)
+    assert isinstance(count, int)
+    return count
+
+
+async def _strategy_pairs(
+    connection: asyncpg.Connection,
+    table: str,
+) -> set[tuple[str, str]]:
+    query = f"""
+    SELECT DISTINCT strategy_id, strategy_version_id
+    FROM {table}
+    WHERE strategy_id IS NOT NULL AND strategy_version_id IS NOT NULL
+    """
+    rows = await connection.fetch(query)
+    return {
+        (row["strategy_id"], row["strategy_version_id"])
+        for row in rows
+    }
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_runner_tags_inner_ring_rows_with_default_strategy(
+    pg_pool: asyncpg.Pool,
+) -> None:
+    runner = Runner(
+        config=_settings(),
+        sensors=[
+            SequenceSensor(
+                [
+                    _signal(
+                        market_id="paper-empty-book",
+                        orderbook={"bids": [], "asks": []},
+                        external_signal={"fair_value": 0.7, "resolved_outcome": 1.0},
+                    ),
+                    _signal(
+                        market_id="paper-with-depth",
+                        orderbook={
+                            "bids": [{"price": 0.39, "size": 250.0}],
+                            "asks": [{"price": 0.41, "size": 250.0}],
+                        },
+                        external_signal={"metaculus_prob": 0.9, "resolved_outcome": 1.0},
+                    ),
+                ]
+            )
+        ],
+        eval_store=EvalStore(),
+        feedback_store=FeedbackStore(),
+    )
+
+    try:
+        await runner.start()
+        await runner.wait_until_idle()
+    finally:
+        await runner.stop()
+
+    async with pg_pool.acquire() as connection:
+        strategies_count = await connection.fetchval(
+            "SELECT COUNT(*) FROM strategies WHERE strategy_id = 'default'"
+        )
+        versions_count = await connection.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM strategy_versions
+            WHERE strategy_id = 'default' AND strategy_version_id = 'default-v1'
+            """
+        )
+        feedback_count = await connection.fetchval("SELECT COUNT(*) FROM feedback")
+        eval_count = await connection.fetchval("SELECT COUNT(*) FROM eval_records")
+        orders_count = await connection.fetchval("SELECT COUNT(*) FROM orders")
+        fills_count = await connection.fetchval("SELECT COUNT(*) FROM fills")
+
+        counts = {
+            "feedback": feedback_count,
+            "eval_records": eval_count,
+            "orders": orders_count,
+            "fills": fills_count,
+        }
+        null_counts = {
+            table: await _count_null_strategy_tags(connection, table)
+            for table in counts
+        }
+        tagged_counts = {
+            table: await connection.fetchval(
+                f"""
+                SELECT COUNT(*)
+                FROM {table}
+                WHERE strategy_id = 'default' AND strategy_version_id = 'default-v1'
+                """
+            )
+            for table in counts
+        }
+        strategy_pairs = {
+            table: await _strategy_pairs(connection, table)
+            for table in counts
+        }
+
+    assert strategies_count == 1
+    assert versions_count == 1
+    assert counts["feedback"] > 0
+    assert counts["eval_records"] > 0
+    assert null_counts == {
+        "feedback": 0,
+        "eval_records": 0,
+        "orders": 0,
+        "fills": 0,
+    }
+    assert tagged_counts["feedback"] > 0
+    assert tagged_counts["eval_records"] > 0
+    assert strategy_pairs["feedback"] == {("default", "default-v1")}
+    assert strategy_pairs["eval_records"] == {("default", "default-v1")}
+    assert strategy_pairs["orders"] == set()
+    assert strategy_pairs["fills"] == set()

--- a/tests/integration/test_default_strategy_tagging.py
+++ b/tests/integration/test_default_strategy_tagging.py
@@ -110,6 +110,28 @@ async def _strategy_pairs(
 async def test_runner_tags_inner_ring_rows_with_default_strategy(
     pg_pool: asyncpg.Pool,
 ) -> None:
+    async with pg_pool.acquire() as connection:
+        await connection.execute(
+            """
+            BEGIN;
+            SET CONSTRAINTS ALL DEFERRED;
+            INSERT INTO strategies (strategy_id, active_version_id)
+            VALUES ('default', 'default-v1')
+            ON CONFLICT (strategy_id) DO NOTHING;
+            INSERT INTO strategy_versions (
+                strategy_version_id,
+                strategy_id,
+                config_json
+            ) VALUES (
+                'default-v1',
+                'default',
+                '{"config":{},"risk":{},"eval":{},"forecaster":{},"market_selection":{}}'::jsonb
+            )
+            ON CONFLICT (strategy_version_id) DO NOTHING;
+            COMMIT;
+            """
+        )
+
     runner = Runner(
         config=_settings(),
         sensors=[

--- a/tests/integration/test_default_strategy_tagging.py
+++ b/tests/integration/test_default_strategy_tagging.py
@@ -11,6 +11,14 @@ from pms.config import DatabaseSettings, PMSSettings, RiskSettings
 from pms.core.enums import MarketStatus, RunMode
 from pms.core.models import MarketSignal
 from pms.runner import Runner
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from pms.strategies.versioning import serialize_strategy_config_json
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
 
@@ -79,6 +87,33 @@ def _signal(
     )
 
 
+def _default_strategy_config_json() -> str:
+    return serialize_strategy_config_json(
+        StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
 async def _count_null_strategy_tags(connection: asyncpg.Connection, table: str) -> int:
     query = f"""
     SELECT COUNT(*)
@@ -111,26 +146,30 @@ async def test_runner_tags_inner_ring_rows_with_default_strategy(
     pg_pool: asyncpg.Pool,
 ) -> None:
     async with pg_pool.acquire() as connection:
-        await connection.execute(
-            """
-            BEGIN;
-            SET CONSTRAINTS ALL DEFERRED;
-            INSERT INTO strategies (strategy_id, active_version_id)
-            VALUES ('default', 'default-v1')
-            ON CONFLICT (strategy_id) DO NOTHING;
-            INSERT INTO strategy_versions (
-                strategy_version_id,
-                strategy_id,
-                config_json
-            ) VALUES (
-                'default-v1',
-                'default',
-                '{"config":{},"risk":{},"eval":{},"forecaster":{},"market_selection":{}}'::jsonb
+        async with connection.transaction():
+            await connection.execute("SET CONSTRAINTS ALL DEFERRED")
+            await connection.execute(
+                """
+                INSERT INTO strategies (strategy_id, active_version_id)
+                VALUES ('default', 'default-v1')
+                ON CONFLICT (strategy_id) DO NOTHING
+                """
             )
-            ON CONFLICT (strategy_version_id) DO NOTHING;
-            COMMIT;
-            """
-        )
+            await connection.execute(
+                """
+                INSERT INTO strategy_versions (
+                    strategy_version_id,
+                    strategy_id,
+                    config_json
+                ) VALUES (
+                    'default-v1',
+                    'default',
+                    $1::jsonb
+                )
+                ON CONFLICT (strategy_version_id) DO NOTHING
+                """,
+                _default_strategy_config_json(),
+            )
 
     runner = Runner(
         config=_settings(),

--- a/tests/integration/test_schema_apply_aggregate.py
+++ b/tests/integration/test_schema_apply_aggregate.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+
+
+SCHEMA_PATH = Path("schema.sql")
+PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
+
+EXPECTED_COLUMNS: dict[str, list[tuple[str, str]]] = {
+    "strategies": [
+        ("strategy_id", "text"),
+        ("active_version_id", "text"),
+        ("created_at", "timestamp with time zone"),
+        ("metadata_json", "jsonb"),
+    ],
+    "strategy_versions": [
+        ("strategy_version_id", "text"),
+        ("strategy_id", "text"),
+        ("config_json", "jsonb"),
+        ("created_at", "timestamp with time zone"),
+    ],
+}
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run PostgreSQL schema integration tests",
+    ),
+    pytest.mark.skipif(
+        PMS_TEST_DATABASE_URL is None,
+        reason="set PMS_TEST_DATABASE_URL to a PostgreSQL URI with CREATE DATABASE privileges",
+    ),
+]
+
+
+def _replace_database(database_url: str, database_name: str) -> str:
+    parts = urlsplit(database_url)
+    return urlunsplit(
+        (
+            parts.scheme,
+            parts.netloc,
+            f"/{database_name}",
+            parts.query,
+            parts.fragment,
+        )
+    )
+
+
+def _run_psql(
+    database_url: str,
+    *args: str,
+    input_sql: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["psql", database_url, "--set", "ON_ERROR_STOP=1", *args],
+        input=input_sql,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def test_schema_sql_applies_strategy_identity_tables() -> None:
+    assert PMS_TEST_DATABASE_URL is not None
+
+    schema_text = SCHEMA_PATH.read_text()
+    assert "-- strategies: inner-ring identity table (Invariants 3, 8)" in schema_text
+    assert "-- strategy_versions: immutable hash-keyed version rows (Invariant 3)" in schema_text
+
+    admin_database_url = _replace_database(PMS_TEST_DATABASE_URL, "postgres")
+    temp_database = f"pms_cp02_{uuid.uuid4().hex[:12]}"
+    temp_database_url = _replace_database(PMS_TEST_DATABASE_URL, temp_database)
+
+    try:
+        _run_psql(admin_database_url, "-c", f"CREATE DATABASE {temp_database}")
+        _run_psql(temp_database_url, "-f", str(SCHEMA_PATH))
+
+        columns_result = _run_psql(
+            temp_database_url,
+            "-At",
+            "-F",
+            "|",
+            "-c",
+            """
+            SELECT table_name, column_name, data_type
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name IN ('strategies', 'strategy_versions')
+            ORDER BY table_name, ordinal_position
+            """,
+        )
+
+        actual_columns: dict[str, list[tuple[str, str]]] = {}
+        for line in columns_result.stdout.splitlines():
+            table_name, column_name, data_type = line.split("|")
+            actual_columns.setdefault(table_name, []).append((column_name, data_type))
+
+        assert actual_columns == EXPECTED_COLUMNS
+
+        _run_psql(
+            temp_database_url,
+            "-c",
+            """
+            BEGIN;
+            SET CONSTRAINTS ALL DEFERRED;
+            INSERT INTO strategies (
+                strategy_id,
+                active_version_id,
+                metadata_json
+            ) VALUES (
+                'default',
+                'default-v1',
+                '{}'::jsonb
+            );
+            INSERT INTO strategy_versions (
+                strategy_version_id,
+                strategy_id,
+                config_json
+            ) VALUES (
+                'default-v1',
+                'default',
+                '{}'::jsonb
+            );
+            COMMIT;
+            """,
+        )
+
+        counts_result = _run_psql(
+            temp_database_url,
+            "-At",
+            "-F",
+            "|",
+            "-c",
+            """
+            SELECT 'strategies', COUNT(*) FROM strategies
+            UNION ALL
+            SELECT 'strategy_versions', COUNT(*) FROM strategy_versions
+            ORDER BY 1
+            """,
+        )
+
+        actual_counts = dict(
+            (table_name, int(count))
+            for table_name, count in (
+                line.split("|") for line in counts_result.stdout.splitlines()
+            )
+        )
+
+        assert actual_counts == {
+            "strategies": 1,
+            "strategy_versions": 1,
+        }
+    finally:
+        _run_psql(
+            admin_database_url,
+            "-c",
+            f"DROP DATABASE IF EXISTS {temp_database} WITH (FORCE)",
+        )

--- a/tests/integration/test_schema_apply_aggregate.py
+++ b/tests/integration/test_schema_apply_aggregate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import uuid
@@ -7,6 +8,15 @@ from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 import pytest
+
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from pms.strategies.versioning import serialize_strategy_config_json
 
 
 SCHEMA_PATH = Path("schema.sql")
@@ -72,6 +82,33 @@ def _run_psql(
         text=True,
         capture_output=True,
         check=True,
+    )
+
+
+def _default_strategy_config_json() -> str:
+    return serialize_strategy_config_json(
+        StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
     )
 
 
@@ -166,10 +203,10 @@ def test_schema_sql_applies_strategy_identity_tables() -> None:
             """,
         )
 
-        assert seed_result.stdout.strip() == (
-            'default|default-v1|{"eval": {}, "risk": {}, "config": {}, '
-            '"forecaster": {}, "market_selection": {}}'
-        )
+        strategy_id, active_version_id, config_json = seed_result.stdout.strip().split("|", 2)
+        assert strategy_id == "default"
+        assert active_version_id == "default-v1"
+        assert json.loads(config_json) == json.loads(_default_strategy_config_json())
     finally:
         _run_psql(
             admin_database_url,

--- a/tests/integration/test_schema_apply_aggregate.py
+++ b/tests/integration/test_schema_apply_aggregate.py
@@ -25,6 +25,14 @@ EXPECTED_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("config_json", "jsonb"),
         ("created_at", "timestamp with time zone"),
     ],
+    "strategy_factors": [
+        ("strategy_id", "text"),
+        ("strategy_version_id", "text"),
+        ("factor_id", "text"),
+        ("param", "jsonb"),
+        ("weight", "double precision"),
+        ("direction", "text"),
+    ],
 }
 
 pytestmark = [
@@ -73,6 +81,11 @@ def test_schema_sql_applies_strategy_identity_tables() -> None:
     schema_text = SCHEMA_PATH.read_text()
     assert "-- strategies: inner-ring identity table (Invariants 3, 8)" in schema_text
     assert "-- strategy_versions: immutable hash-keyed version rows (Invariant 3)" in schema_text
+    assert (
+        "-- strategy_factors: link table (empty in S2; populated by S3). Columns "
+        "declared so S3 inserts do not require a schema change (Invariants 2, 4, 8)"
+        in schema_text
+    )
 
     admin_database_url = _replace_database(PMS_TEST_DATABASE_URL, "postgres")
     temp_database = f"pms_cp02_{uuid.uuid4().hex[:12]}"
@@ -92,7 +105,7 @@ def test_schema_sql_applies_strategy_identity_tables() -> None:
             SELECT table_name, column_name, data_type
             FROM information_schema.columns
             WHERE table_schema = 'public'
-              AND table_name IN ('strategies', 'strategy_versions')
+              AND table_name IN ('strategies', 'strategy_versions', 'strategy_factors')
             ORDER BY table_name, ordinal_position
             """,
         )
@@ -142,6 +155,8 @@ def test_schema_sql_applies_strategy_identity_tables() -> None:
             SELECT 'strategies', COUNT(*) FROM strategies
             UNION ALL
             SELECT 'strategy_versions', COUNT(*) FROM strategy_versions
+            UNION ALL
+            SELECT 'strategy_factors', COUNT(*) FROM strategy_factors
             ORDER BY 1
             """,
         )
@@ -154,6 +169,7 @@ def test_schema_sql_applies_strategy_identity_tables() -> None:
         )
 
         assert actual_counts == {
+            "strategy_factors": 0,
             "strategies": 1,
             "strategy_versions": 1,
         }

--- a/tests/integration/test_schema_apply_aggregate.py
+++ b/tests/integration/test_schema_apply_aggregate.py
@@ -117,34 +117,6 @@ def test_schema_sql_applies_strategy_identity_tables() -> None:
 
         assert actual_columns == EXPECTED_COLUMNS
 
-        _run_psql(
-            temp_database_url,
-            "-c",
-            """
-            BEGIN;
-            SET CONSTRAINTS ALL DEFERRED;
-            INSERT INTO strategies (
-                strategy_id,
-                active_version_id,
-                metadata_json
-            ) VALUES (
-                'default',
-                'default-v1',
-                '{}'::jsonb
-            );
-            INSERT INTO strategy_versions (
-                strategy_version_id,
-                strategy_id,
-                config_json
-            ) VALUES (
-                'default-v1',
-                'default',
-                '{}'::jsonb
-            );
-            COMMIT;
-            """,
-        )
-
         counts_result = _run_psql(
             temp_database_url,
             "-At",
@@ -173,6 +145,31 @@ def test_schema_sql_applies_strategy_identity_tables() -> None:
             "strategies": 1,
             "strategy_versions": 1,
         }
+
+        seed_result = _run_psql(
+            temp_database_url,
+            "-At",
+            "-F",
+            "|",
+            "-c",
+            """
+            SELECT
+                strategy_id,
+                active_version_id,
+                (
+                    SELECT config_json::text
+                    FROM strategy_versions
+                    WHERE strategy_version_id = 'default-v1'
+                )
+            FROM strategies
+            WHERE strategy_id = 'default'
+            """,
+        )
+
+        assert seed_result.stdout.strip() == (
+            'default|default-v1|{"eval": {}, "risk": {}, "config": {}, '
+            '"forecaster": {}, "market_selection": {}}'
+        )
     finally:
         _run_psql(
             admin_database_url,

--- a/tests/integration/test_store_migration.py
+++ b/tests/integration/test_store_migration.py
@@ -145,8 +145,8 @@ async def test_feedback_store_persists_and_filters_rows_in_postgres(
     assert [item.feedback_id for item in resolved] == ["fb-1"]
     assert resolved[0].resolved is True
     assert stored_row is not None
-    assert stored_row["strategy_id"] is None
-    assert stored_row["strategy_version_id"] is None
+    assert stored_row["strategy_id"] == "default"
+    assert stored_row["strategy_version_id"] == "default-v1"
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -169,8 +169,8 @@ async def test_eval_store_persists_rows_in_postgres(
 
     assert [record.decision_id for record in records] == ["decision-cp09"]
     assert stored_row is not None
-    assert stored_row["strategy_id"] is None
-    assert stored_row["strategy_version_id"] is None
+    assert stored_row["strategy_id"] == "default"
+    assert stored_row["strategy_version_id"] == "default-v1"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/integration/test_store_migration.py
+++ b/tests/integration/test_store_migration.py
@@ -14,8 +14,17 @@ import pytest
 
 from pms.core.enums import FeedbackSource, FeedbackTarget, OrderStatus
 from pms.core.models import EvalRecord, Feedback
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
+from pms.storage.strategy_registry import PostgresStrategyRegistry
 
 
 PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
@@ -83,6 +92,37 @@ def _eval_record(decision_id: str) -> EvalRecord:
     )
 
 
+def _strategy(*, drawdown_pct: float = 2.5) -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=drawdown_pct,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
+async def _seed_active_default_strategy(pool: asyncpg.Pool) -> None:
+    await PostgresStrategyRegistry(pool).create_version(_strategy())
+
+
 def _jsonable(value: Any) -> Any:
     if isinstance(value, datetime):
         return value.isoformat()
@@ -124,6 +164,9 @@ def _run_migration(data_dir: Path) -> subprocess.CompletedProcess[str]:
 async def test_feedback_store_persists_and_filters_rows_in_postgres(
     db_conn: asyncpg.Connection,
 ) -> None:
+    active_version = await PostgresStrategyRegistry(cast(Any, _SingleConnectionPool(db_conn))).create_version(
+        _strategy()
+    )
     store = FeedbackStore(pool=cast(Any, _SingleConnectionPool(db_conn)))
 
     await store.append(_feedback("fb-1"))
@@ -146,13 +189,16 @@ async def test_feedback_store_persists_and_filters_rows_in_postgres(
     assert resolved[0].resolved is True
     assert stored_row is not None
     assert stored_row["strategy_id"] == "default"
-    assert stored_row["strategy_version_id"] == "default-v1"
+    assert stored_row["strategy_version_id"] == active_version.strategy_version_id
 
 
 @pytest.mark.asyncio(loop_scope="session")
 async def test_eval_store_persists_rows_in_postgres(
     db_conn: asyncpg.Connection,
 ) -> None:
+    active_version = await PostgresStrategyRegistry(cast(Any, _SingleConnectionPool(db_conn))).create_version(
+        _strategy()
+    )
     store = EvalStore(pool=cast(Any, _SingleConnectionPool(db_conn)))
 
     await store.append(_eval_record("decision-cp09"))
@@ -170,7 +216,7 @@ async def test_eval_store_persists_rows_in_postgres(
     assert [record.decision_id for record in records] == ["decision-cp09"]
     assert stored_row is not None
     assert stored_row["strategy_id"] == "default"
-    assert stored_row["strategy_version_id"] == "default-v1"
+    assert stored_row["strategy_version_id"] == active_version.strategy_version_id
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -178,6 +224,7 @@ async def test_jsonl_migration_script_copies_feedback_and_eval_rows(
     pg_pool: asyncpg.Pool,
     tmp_path: Path,
 ) -> None:
+    await _seed_active_default_strategy(pg_pool)
     data_dir = tmp_path / ".data"
     _write_jsonl(
         data_dir / "feedback.jsonl",
@@ -203,6 +250,7 @@ async def test_jsonl_migration_script_aborts_on_invalid_json_line(
     pg_pool: asyncpg.Pool,
     tmp_path: Path,
 ) -> None:
+    await _seed_active_default_strategy(pg_pool)
     data_dir = tmp_path / ".data"
     _write_jsonl(
         data_dir / "feedback.jsonl",

--- a/tests/integration/test_strategies_route.py
+++ b/tests/integration/test_strategies_route.py
@@ -11,6 +11,14 @@ import pytest
 from pms.api.app import create_app
 from pms.config import DatabaseSettings, PMSSettings
 from pms.runner import Runner
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from pms.strategies.versioning import serialize_strategy_config_json
 
 
 PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
@@ -34,6 +42,33 @@ def _settings() -> PMSSettings:
     )
 
 
+def _default_strategy_config_json() -> str:
+    return serialize_strategy_config_json(
+        StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
 async def _seed_default_strategy(connection: asyncpg.Connection) -> datetime:
     async with connection.transaction():
         await connection.execute("SET CONSTRAINTS ALL DEFERRED")
@@ -53,10 +88,11 @@ async def _seed_default_strategy(connection: asyncpg.Connection) -> datetime:
             ) VALUES (
                 'default-v1',
                 'default',
-                '{"config":{},"risk":{},"eval":{},"forecaster":{},"market_selection":{}}'::jsonb
+                $1::jsonb
             )
             ON CONFLICT (strategy_version_id) DO NOTHING
-            """
+            """,
+            _default_strategy_config_json(),
         )
     created_at = await connection.fetchval(
         "SELECT created_at FROM strategies WHERE strategy_id = 'default'"

--- a/tests/integration/test_strategies_route.py
+++ b/tests/integration/test_strategies_route.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from typing import cast
+
+import asyncpg
+import httpx
+import pytest
+
+from pms.api.app import create_app
+from pms.config import DatabaseSettings, PMSSettings
+from pms.runner import Runner
+
+
+PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run PostgreSQL integration tests",
+    ),
+    pytest.mark.skipif(
+        PMS_TEST_DATABASE_URL is None,
+        reason="set PMS_TEST_DATABASE_URL to the compose-backed PostgreSQL URI",
+    ),
+]
+
+
+def _settings() -> PMSSettings:
+    return PMSSettings(
+        database=DatabaseSettings(dsn=cast(str, PMS_TEST_DATABASE_URL)),
+    )
+
+
+async def _seed_default_strategy(connection: asyncpg.Connection) -> datetime:
+    async with connection.transaction():
+        await connection.execute("SET CONSTRAINTS ALL DEFERRED")
+        await connection.execute(
+            """
+            INSERT INTO strategies (strategy_id, active_version_id)
+            VALUES ('default', 'default-v1')
+            ON CONFLICT (strategy_id) DO NOTHING
+            """
+        )
+        await connection.execute(
+            """
+            INSERT INTO strategy_versions (
+                strategy_version_id,
+                strategy_id,
+                config_json
+            ) VALUES (
+                'default-v1',
+                'default',
+                '{"config":{},"risk":{},"eval":{},"forecaster":{},"market_selection":{}}'::jsonb
+            )
+            ON CONFLICT (strategy_version_id) DO NOTHING
+            """
+        )
+    created_at = await connection.fetchval(
+        "SELECT created_at FROM strategies WHERE strategy_id = 'default'"
+    )
+    assert isinstance(created_at, datetime)
+    return created_at.astimezone(UTC)
+
+
+def _app_client(pg_pool: asyncpg.Pool) -> httpx.AsyncClient:
+    runner = Runner(config=_settings())
+    runner.bind_pg_pool(pg_pool)
+    app = create_app(runner)
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_strategies_route_returns_seeded_registry_rows(
+    pg_pool: asyncpg.Pool,
+) -> None:
+    async with pg_pool.acquire() as connection:
+        expected_created_at = await _seed_default_strategy(connection)
+
+    async with _app_client(pg_pool) as client:
+        response = await client.get("/strategies")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "strategies": [
+            {
+                "strategy_id": "default",
+                "active_version_id": "default-v1",
+                "created_at": expected_created_at.isoformat(),
+            }
+        ]
+    }

--- a/tests/integration/test_strategy_column_reservation.py
+++ b/tests/integration/test_strategy_column_reservation.py
@@ -27,10 +27,9 @@ pytestmark = [
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_feedback_and_eval_stores_accept_null_strategy_columns(
+async def test_feedback_and_eval_stores_default_strategy_columns(
     pg_pool: asyncpg.Pool,
 ) -> None:
-    # S5-MIGRATION-MARKER: flip NULL asserts after NOT NULL upgrade lands
     feedback_store = FeedbackStore(pg_pool)
     eval_store = EvalStore(pg_pool)
     created_at = datetime(2026, 4, 17, tzinfo=UTC)
@@ -80,14 +79,14 @@ async def test_feedback_and_eval_stores_accept_null_strategy_columns(
             WHERE decision_id = $1
             """,
             "reservation-decision",
-        )
+    )
 
     assert feedback_row is not None
-    assert feedback_row["strategy_id"] is None
-    assert feedback_row["strategy_version_id"] is None
+    assert feedback_row["strategy_id"] == "default"
+    assert feedback_row["strategy_version_id"] == "default-v1"
     assert eval_row is not None
-    assert eval_row["strategy_id"] is None
-    assert eval_row["strategy_version_id"] is None
+    assert eval_row["strategy_id"] == "default"
+    assert eval_row["strategy_version_id"] == "default-v1"
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/integration/test_strategy_column_reservation.py
+++ b/tests/integration/test_strategy_column_reservation.py
@@ -6,9 +6,18 @@ from datetime import UTC, datetime
 import asyncpg
 import pytest
 
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
 from pms.core.models import EvalRecord, Feedback
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
+from pms.storage.strategy_registry import PostgresStrategyRegistry
 
 
 PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
@@ -26,10 +35,40 @@ pytestmark = [
 ]
 
 
+def _strategy(*, drawdown_pct: float) -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=drawdown_pct,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
 @pytest.mark.asyncio(loop_scope="session")
-async def test_feedback_and_eval_stores_default_strategy_columns(
+async def test_feedback_and_eval_stores_use_active_strategy_version_by_default(
     pg_pool: asyncpg.Pool,
 ) -> None:
+    active_version = await PostgresStrategyRegistry(pg_pool).create_version(
+        _strategy(drawdown_pct=3.5)
+    )
     feedback_store = FeedbackStore(pg_pool)
     eval_store = EvalStore(pg_pool)
     created_at = datetime(2026, 4, 17, tzinfo=UTC)
@@ -83,10 +122,10 @@ async def test_feedback_and_eval_stores_default_strategy_columns(
 
     assert feedback_row is not None
     assert feedback_row["strategy_id"] == "default"
-    assert feedback_row["strategy_version_id"] == "default-v1"
+    assert feedback_row["strategy_version_id"] == active_version.strategy_version_id
     assert eval_row is not None
     assert eval_row["strategy_id"] == "default"
-    assert eval_row["strategy_version_id"] == "default-v1"
+    assert eval_row["strategy_version_id"] == active_version.strategy_version_id
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/integration/test_strategy_factors_empty.py
+++ b/tests/integration/test_strategy_factors_empty.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run PostgreSQL integration tests",
+    ),
+    pytest.mark.skipif(
+        os.environ.get("PMS_TEST_DATABASE_URL") is None,
+        reason="set PMS_TEST_DATABASE_URL to the compose-backed PostgreSQL URI",
+    ),
+]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_strategy_factors_starts_empty(pg_pool: asyncpg.Pool) -> None:
+    async with pg_pool.acquire() as connection:
+        count = await connection.fetchval("SELECT COUNT(*) FROM strategy_factors")
+
+    assert count == 0

--- a/tests/integration/test_strategy_registry.py
+++ b/tests/integration/test_strategy_registry.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import importlib
+import os
+from typing import Any, cast
+
+import asyncpg
+import pytest
+
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from pms.strategies.versioning import compute_strategy_version_id
+
+
+PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run PostgreSQL integration tests",
+    ),
+    pytest.mark.skipif(
+        PMS_TEST_DATABASE_URL is None,
+        reason="set PMS_TEST_DATABASE_URL to the compose-backed PostgreSQL URI",
+    ),
+]
+
+
+class _AcquireConnection:
+    def __init__(self, connection: asyncpg.Connection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> asyncpg.Connection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class _SingleConnectionPool:
+    def __init__(self, connection: asyncpg.Connection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> _AcquireConnection:
+        return _AcquireConnection(self._connection)
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in red phase
+        pytest.fail(f"{module_name} is missing: {exc}")
+    return getattr(module, symbol_name)
+
+
+def _strategy(
+    strategy_id: str,
+    *,
+    owner: str,
+    drawdown_pct: float,
+) -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=strategy_id,
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", owner), ("tier", "default")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=drawdown_pct,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_strategy_and_list_strategies(
+    db_conn: asyncpg.Connection,
+) -> None:
+    registry_cls = _load_symbol("pms.storage.strategy_registry", "PostgresStrategyRegistry")
+    strategy_row_cls = _load_symbol("pms.strategies.projections", "StrategyRow")
+    registry = registry_cls(pool=cast(Any, _SingleConnectionPool(db_conn)))
+
+    await registry.create_strategy("default", metadata={"owner": "system"})
+
+    rows = await registry.list_strategies()
+
+    assert len(rows) == 1
+    assert isinstance(rows[0], strategy_row_cls)
+    assert rows[0].strategy_id == "default"
+    assert rows[0].active_version_id is None
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_version_and_get_by_id_round_trip_strategy(
+    db_conn: asyncpg.Connection,
+) -> None:
+    registry_cls = _load_symbol("pms.storage.strategy_registry", "PostgresStrategyRegistry")
+    strategy_version_cls = _load_symbol("pms.strategies.projections", "StrategyVersion")
+    registry = registry_cls(pool=cast(Any, _SingleConnectionPool(db_conn)))
+    strategy = _strategy("default", owner="system", drawdown_pct=2.5)
+
+    await registry.create_strategy("default", metadata={"owner": "system"})
+    created_version = await registry.create_version(strategy)
+    fetched_strategy = await registry.get_by_id("default")
+
+    assert isinstance(created_version, strategy_version_cls)
+    assert created_version.strategy_version_id == compute_strategy_version_id(*strategy.snapshot())
+    assert fetched_strategy == strategy
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_by_id_returns_none_for_unknown_strategy(
+    db_conn: asyncpg.Connection,
+) -> None:
+    registry_cls = _load_symbol("pms.storage.strategy_registry", "PostgresStrategyRegistry")
+    registry = registry_cls(pool=cast(Any, _SingleConnectionPool(db_conn)))
+
+    assert await registry.get_by_id("missing-strategy") is None
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_versions_returns_rows_in_created_at_order(
+    db_conn: asyncpg.Connection,
+) -> None:
+    registry_cls = _load_symbol("pms.storage.strategy_registry", "PostgresStrategyRegistry")
+    strategy_version_cls = _load_symbol("pms.strategies.projections", "StrategyVersion")
+    registry = registry_cls(pool=cast(Any, _SingleConnectionPool(db_conn)))
+
+    first_strategy = _strategy("default", owner="system", drawdown_pct=2.5)
+    second_strategy = _strategy("default", owner="system", drawdown_pct=3.5)
+    expected_ids = [
+        compute_strategy_version_id(*first_strategy.snapshot()),
+        compute_strategy_version_id(*second_strategy.snapshot()),
+    ]
+
+    await registry.create_strategy("default", metadata={"owner": "system"})
+    first_version = await registry.create_version(first_strategy)
+    await db_conn.execute("SELECT pg_sleep(0.01)")
+    second_version = await registry.create_version(second_strategy)
+
+    versions = await registry.list_versions("default")
+
+    assert isinstance(first_version, strategy_version_cls)
+    assert isinstance(second_version, strategy_version_cls)
+    assert [version.strategy_version_id for version in versions] == expected_ids
+    assert all(
+        isinstance(version.created_at, datetime) and version.created_at.tzinfo is UTC
+        for version in versions
+    )

--- a/tests/integration/test_strategy_registry.py
+++ b/tests/integration/test_strategy_registry.py
@@ -16,7 +16,7 @@ from pms.strategies.projections import (
     RiskParams,
     StrategyConfig,
 )
-from pms.strategies.versioning import compute_strategy_version_id
+from pms.strategies.versioning import compute_strategy_version_id, serialize_strategy_config_json
 
 
 PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
@@ -112,6 +112,39 @@ async def test_create_strategy_and_list_strategies(
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_get_by_id_round_trips_seeded_default_strategy(
+    db_conn: asyncpg.Connection,
+) -> None:
+    registry_cls = _load_symbol("pms.storage.strategy_registry", "PostgresStrategyRegistry")
+    registry = registry_cls(pool=cast(Any, _SingleConnectionPool(db_conn)))
+    strategy = _strategy("default", owner="system", drawdown_pct=2.5)
+
+    await db_conn.execute("SET CONSTRAINTS ALL DEFERRED")
+    await db_conn.execute(
+        """
+        INSERT INTO strategies (strategy_id, active_version_id)
+        VALUES ('default', 'default-v1')
+        ON CONFLICT (strategy_id) DO NOTHING
+        """
+    )
+    await db_conn.execute(
+        """
+        INSERT INTO strategy_versions (
+            strategy_version_id,
+            strategy_id,
+            config_json
+        ) VALUES ($1, $2, $3::jsonb)
+        ON CONFLICT (strategy_version_id) DO NOTHING
+        """,
+        "default-v1",
+        "default",
+        serialize_strategy_config_json(*strategy.snapshot()),
+    )
+
+    assert await registry.get_by_id("default") == strategy
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_create_version_and_get_by_id_round_trip_strategy(
     db_conn: asyncpg.Connection,
 ) -> None:
@@ -127,6 +160,38 @@ async def test_create_version_and_get_by_id_round_trip_strategy(
     assert isinstance(created_version, strategy_version_cls)
     assert created_version.strategy_version_id == compute_strategy_version_id(*strategy.snapshot())
     assert fetched_strategy == strategy
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_by_id_raises_type_error_for_invalid_config_json(
+    db_conn: asyncpg.Connection,
+) -> None:
+    registry_cls = _load_symbol("pms.storage.strategy_registry", "PostgresStrategyRegistry")
+    registry = registry_cls(pool=cast(Any, _SingleConnectionPool(db_conn)))
+
+    await db_conn.execute("SET CONSTRAINTS ALL DEFERRED")
+    await db_conn.execute(
+        """
+        INSERT INTO strategies (strategy_id, active_version_id)
+        VALUES ('broken', 'broken-v1')
+        """
+    )
+    await db_conn.execute(
+        """
+        INSERT INTO strategy_versions (
+            strategy_version_id,
+            strategy_id,
+            config_json
+        ) VALUES (
+            'broken-v1',
+            'broken',
+            '{"config":{"strategy_id":7,"factor_composition":[],"metadata":[]},"risk":{"max_position_notional_usdc":100.0,"max_daily_drawdown_pct":2.5,"min_order_size_usdc":1.0},"eval_spec":{"metrics":["brier"]},"forecaster":{"forecasters":[]},"market_selection":{"venue":"polymarket","resolution_time_max_horizon_days":7,"volume_min_usdc":500.0}}'::jsonb
+        )
+        """
+    )
+
+    with pytest.raises(TypeError, match="config.strategy_id"):
+        await registry.get_by_id("broken")
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import runpy
+import sys
+from typing import Any
+
+
+def test_module_entrypoint_invokes_uvicorn_with_cli_defaults(
+    monkeypatch: Any,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_run(app: str, **kwargs: Any) -> None:
+        calls["app"] = app
+        calls.update(kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["pms-api"])
+
+    runpy.run_module("pms.api.__main__", run_name="__main__")
+
+    assert calls == {
+        "app": "pms.api.app:create_app",
+        "factory": True,
+        "host": "127.0.0.1",
+        "port": 8000,
+        "log_level": "info",
+        "reload": False,
+    }

--- a/tests/unit/test_import_linter_contracts.py
+++ b/tests/unit/test_import_linter_contracts.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SENSOR_AGGREGATE_CONTRACT = "Sensor strategy-agnostic: no aggregate import"
+
+IMPORT_LINTER_CONFIG = """
+[project]
+name = "scratch-import-linter"
+version = "0.0.1"
+requires-python = ">=3.11"
+
+[tool.importlinter]
+root_packages = ["pms"]
+
+[[tool.importlinter.contracts]]
+name = "Sensor strategy-agnostic: no aggregate import"
+type = "forbidden"
+source_modules = ["pms.sensor"]
+forbidden_modules = ["pms.strategies.aggregate"]
+
+[[tool.importlinter.contracts]]
+name = "Actuator strategy-agnostic: no aggregate import"
+type = "forbidden"
+source_modules = ["pms.actuator"]
+forbidden_modules = ["pms.strategies.aggregate"]
+
+[[tool.importlinter.contracts]]
+name = "Sensor + Actuator: no controller import"
+type = "forbidden"
+source_modules = ["pms.sensor", "pms.actuator"]
+forbidden_modules = ["pms.controller"]
+
+[[tool.importlinter.contracts]]
+name = "Sensor: no market_selection import"
+type = "forbidden"
+source_modules = ["pms.sensor"]
+forbidden_modules = ["pms.market_selection"]
+""".strip()
+
+
+def test_import_linter_rejects_sensor_aggregate_violation(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(f"{IMPORT_LINTER_CONFIG}\n")
+    for package in [
+        "pms",
+        "pms/sensor",
+        "pms/actuator",
+        "pms/controller",
+        "pms/strategies",
+    ]:
+        package_dir = tmp_path / package
+        package_dir.mkdir(parents=True, exist_ok=True)
+        (package_dir / "__init__.py").write_text("")
+    (tmp_path / "pms/strategies/aggregate.py").write_text("class Strategy: ...\n")
+    (tmp_path / "pms/sensor/bad.py").write_text(
+        "from pms.strategies.aggregate import Strategy\n"
+    )
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "lint-imports",
+            "--config",
+            str(tmp_path / "pyproject.toml"),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert SENSOR_AGGREGATE_CONTRACT in result.stdout
+
+
+def test_current_tree_lints_clean() -> None:
+    result = subprocess.run(
+        ["uv", "run", "lint-imports"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/test_import_linter_contracts.py
+++ b/tests/unit/test_import_linter_contracts.py
@@ -63,6 +63,8 @@ def test_import_linter_rejects_sensor_aggregate_violation(tmp_path: Path) -> Non
         [
             "uv",
             "run",
+            "--project",
+            str(REPO_ROOT),
             "lint-imports",
             "--config",
             str(tmp_path / "pyproject.toml"),

--- a/tests/unit/test_schema_invariant_8.py
+++ b/tests/unit/test_schema_invariant_8.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+SCHEMA_PATH = Path("schema.sql")
+
+
+def _extract_outer_ring_block(schema_text: str) -> str:
+    match = re.search(
+        r"(?s)-- BEGIN OUTER RING\s*(.*?)\s*-- END OUTER RING",
+        schema_text,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_schema_declares_strategy_identity_and_version_blocks() -> None:
+    schema_text = SCHEMA_PATH.read_text()
+
+    assert "-- strategies: inner-ring identity table (Invariants 3, 8)" in schema_text
+    assert "CREATE TABLE IF NOT EXISTS strategies" in schema_text
+    assert "-- strategy_versions: immutable hash-keyed version rows (Invariant 3)" in schema_text
+    assert "CREATE TABLE IF NOT EXISTS strategy_versions" in schema_text
+
+
+def test_outer_ring_tables_remain_strategy_agnostic() -> None:
+    outer_ring = _extract_outer_ring_block(SCHEMA_PATH.read_text())
+
+    assert "strategy_id" not in outer_ring
+    assert "strategy_version_id" not in outer_ring

--- a/tests/unit/test_strategy_aggregate.py
+++ b/tests/unit/test_strategy_aggregate.py
@@ -16,7 +16,7 @@ def _load_symbol(module_name: str, symbol_name: str) -> Any:
     return getattr(module, symbol_name)
 
 
-def _build_projections() -> dict[str, object]:
+def _build_projections() -> dict[str, Any]:
     strategy_config = _load_symbol("pms.strategies.projections", "StrategyConfig")
     risk_params = _load_symbol("pms.strategies.projections", "RiskParams")
     eval_spec = _load_symbol("pms.strategies.projections", "EvalSpec")

--- a/tests/unit/test_strategy_aggregate.py
+++ b/tests/unit/test_strategy_aggregate.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import Any
+
+import pytest
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in red phase
+        pytest.fail(f"{module_name} is missing: {exc}")
+
+    return getattr(module, symbol_name)
+
+
+def _build_projections() -> dict[str, object]:
+    strategy_config = _load_symbol("pms.strategies.projections", "StrategyConfig")
+    risk_params = _load_symbol("pms.strategies.projections", "RiskParams")
+    eval_spec = _load_symbol("pms.strategies.projections", "EvalSpec")
+    forecaster_spec = _load_symbol("pms.strategies.projections", "ForecasterSpec")
+    market_selection_spec = _load_symbol(
+        "pms.strategies.projections",
+        "MarketSelectionSpec",
+    )
+
+    return {
+        "config": strategy_config(
+            strategy_id="default",
+            factor_composition=(("factor-a", 1.0),),
+            metadata=(("owner", "system"),),
+        ),
+        "risk": risk_params(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        "eval_spec": eval_spec(metrics=("brier", "pnl")),
+        "forecaster": forecaster_spec(
+            forecasters=(("rules", (("threshold", "0.55"),)),),
+        ),
+        "market_selection": market_selection_spec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=14,
+            volume_min_usdc=250.0,
+        ),
+    }
+
+
+def test_strategy_init_requires_keyword_only_projection_args() -> None:
+    strategy = _load_symbol("pms.strategies.aggregate", "Strategy")
+    signature = inspect.signature(strategy)
+
+    assert list(signature.parameters) == [
+        "config",
+        "risk",
+        "eval_spec",
+        "forecaster",
+        "market_selection",
+    ]
+    for parameter in signature.parameters.values():
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameter.default is inspect.Parameter.empty
+
+
+def test_strategy_returns_cached_projection_references_and_fixed_snapshot_order() -> None:
+    strategy = _load_symbol("pms.strategies.aggregate", "Strategy")
+    projections = _build_projections()
+
+    aggregate = strategy(**projections)
+
+    assert aggregate.config is projections["config"]
+    assert aggregate.risk is projections["risk"]
+    assert aggregate.eval_spec is projections["eval_spec"]
+    assert aggregate.forecaster is projections["forecaster"]
+    assert aggregate.market_selection is projections["market_selection"]
+    assert aggregate.snapshot() == (
+        projections["config"],
+        projections["risk"],
+        projections["eval_spec"],
+        projections["forecaster"],
+        projections["market_selection"],
+    )
+
+
+@pytest.mark.parametrize(
+    "missing_kwarg",
+    ["config", "risk", "eval_spec", "forecaster", "market_selection"],
+)
+def test_strategy_missing_projection_kwarg_raises_type_error(
+    missing_kwarg: str,
+) -> None:
+    strategy = _load_symbol("pms.strategies.aggregate", "Strategy")
+    projections = _build_projections()
+    projections.pop(missing_kwarg)
+
+    with pytest.raises(TypeError, match=missing_kwarg):
+        strategy(**projections)
+
+
+@pytest.mark.parametrize(
+    "none_kwarg",
+    ["config", "risk", "eval_spec", "forecaster", "market_selection"],
+)
+def test_strategy_none_projection_kwarg_raises_type_error(none_kwarg: str) -> None:
+    strategy = _load_symbol("pms.strategies.aggregate", "Strategy")
+    projections = _build_projections()
+    projections[none_kwarg] = None
+
+    with pytest.raises(TypeError, match=none_kwarg):
+        strategy(**projections)
+
+
+def test_strategy_surface_excludes_select_markets() -> None:
+    aggregate_module = importlib.import_module("pms.strategies.aggregate")
+    strategy = getattr(aggregate_module, "Strategy")
+
+    assert not hasattr(strategy, "select_markets")
+    assert "select_markets" not in (inspect.getdoc(aggregate_module) or "")
+    assert "select_markets" not in (inspect.getdoc(strategy) or "")

--- a/tests/unit/test_strategy_projections.py
+++ b/tests/unit/test_strategy_projections.py
@@ -47,7 +47,7 @@ def _load_projections_module() -> Any:
         pytest.fail(f"pms.strategies.projections is missing: {exc}")
 
 
-def _sample_projection_values() -> dict[str, object]:
+def _sample_projection_values() -> dict[str, Any]:
     module = _load_projections_module()
     return {
         "StrategyConfig": module.StrategyConfig(

--- a/tests/unit/test_strategy_projections.py
+++ b/tests/unit/test_strategy_projections.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import FrozenInstanceError, fields, is_dataclass
+from typing import Any, get_args, get_origin, get_type_hints
+
+import pytest
+
+
+PROJECTION_NAMES = [
+    "StrategyConfig",
+    "RiskParams",
+    "EvalSpec",
+    "ForecasterSpec",
+    "MarketSelectionSpec",
+]
+
+EXPECTED_FIELD_TYPES: dict[str, dict[str, object]] = {
+    "StrategyConfig": {
+        "strategy_id": str,
+        "factor_composition": tuple[tuple[str, float], ...],
+        "metadata": tuple[tuple[str, str], ...],
+    },
+    "RiskParams": {
+        "max_position_notional_usdc": float,
+        "max_daily_drawdown_pct": float,
+        "min_order_size_usdc": float,
+    },
+    "EvalSpec": {
+        "metrics": tuple[str, ...],
+    },
+    "ForecasterSpec": {
+        "forecasters": tuple[tuple[str, tuple[tuple[str, str], ...]], ...],
+    },
+    "MarketSelectionSpec": {
+        "venue": str,
+        "resolution_time_max_horizon_days": int | None,
+        "volume_min_usdc": float,
+    },
+}
+
+
+def _load_projections_module() -> Any:
+    try:
+        return importlib.import_module("pms.strategies.projections")
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in red phase
+        pytest.fail(f"pms.strategies.projections is missing: {exc}")
+
+
+def _sample_projection_values() -> dict[str, object]:
+    module = _load_projections_module()
+    return {
+        "StrategyConfig": module.StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        "RiskParams": module.RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=5.0,
+            min_order_size_usdc=1.0,
+        ),
+        "EvalSpec": module.EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        "ForecasterSpec": module.ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        "MarketSelectionSpec": module.MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    }
+
+
+def _assert_no_mutable_containers(type_hint: object) -> None:
+    origin = get_origin(type_hint)
+    if type_hint in {list, dict, set} or origin in {list, dict, set}:
+        pytest.fail(f"mutable container type is not allowed: {type_hint!r}")
+
+    if origin is None:
+        return
+
+    for nested in get_args(type_hint):
+        if nested is type(None):
+            continue
+        _assert_no_mutable_containers(nested)
+
+
+def test_strategy_projection_dataclasses_are_frozen_slotted_and_ordered() -> None:
+    module = _load_projections_module()
+
+    projection_names = [
+        name for name in module.__dict__ if name in PROJECTION_NAMES and is_dataclass(module.__dict__[name])
+    ]
+
+    assert projection_names == PROJECTION_NAMES
+
+    for projection_name in projection_names:
+        projection = getattr(module, projection_name)
+        params = projection.__dataclass_params__
+
+        assert params.frozen
+        assert hasattr(projection, "__slots__")
+
+
+def test_strategy_projection_field_types_match_checkpoint_spec() -> None:
+    module = _load_projections_module()
+
+    for projection_name, expected_fields in EXPECTED_FIELD_TYPES.items():
+        projection = getattr(module, projection_name)
+        hints = get_type_hints(projection)
+
+        assert [field.name for field in fields(projection)] == list(expected_fields)
+        for field_name, expected_type in expected_fields.items():
+            assert hints[field_name] == expected_type
+
+
+def test_strategy_projection_field_types_exclude_mutable_collections() -> None:
+    module = _load_projections_module()
+
+    for projection_name in PROJECTION_NAMES:
+        projection = getattr(module, projection_name)
+        hints = get_type_hints(projection)
+
+        for field_name in [field.name for field in fields(projection)]:
+            _assert_no_mutable_containers(hints[field_name])
+
+
+def test_strategy_projections_are_immutable_instances() -> None:
+    projection_instances = _sample_projection_values()
+
+    for projection_name, projection in projection_instances.items():
+        first_field = fields(type(projection))[0].name
+        replacement_value = "mutated" if projection_name != "RiskParams" else 999.0
+
+        with pytest.raises(FrozenInstanceError):
+            setattr(projection, first_field, replacement_value)

--- a/tests/unit/test_strategy_registry.py
+++ b/tests/unit/test_strategy_registry.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta, timezone
+import json
+from typing import Any
+
+import pytest
+
+from pms.storage.strategy_registry import (
+    PostgresStrategyRegistry,
+    _ensure_utc,
+    _json_float,
+    _json_object,
+    _json_optional_int,
+    _json_pairs,
+    _json_string,
+    _json_string_list,
+    _load_json_object,
+    _strategy_from_config_json,
+)
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from pms.strategies.versioning import (
+    compute_strategy_version_id,
+    serialize_strategy_config_json,
+)
+
+
+@dataclass
+class FakeTransaction:
+    entered: int = 0
+    exited: int = 0
+
+    async def __aenter__(self) -> None:
+        self.entered += 1
+        return None
+
+    async def __aexit__(self, *_: object) -> None:
+        self.exited += 1
+        return None
+
+
+@dataclass
+class FakeConnection:
+    fetchval_results: list[object] = field(default_factory=list)
+    fetchrow_results: list[dict[str, object] | None] = field(default_factory=list)
+    fetch_results: list[list[dict[str, object]]] = field(default_factory=list)
+    execute_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    fetchval_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    fetchrow_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    fetch_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    transaction_manager: FakeTransaction = field(default_factory=FakeTransaction)
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.execute_calls.append((query, args))
+        return "EXECUTE"
+
+    async def fetchval(self, query: str, *args: object) -> object:
+        self.fetchval_calls.append((query, args))
+        if not self.fetchval_results:
+            msg = "fetchval called without a configured result"
+            raise AssertionError(msg)
+        return self.fetchval_results.pop(0)
+
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
+        self.fetchrow_calls.append((query, args))
+        if not self.fetchrow_results:
+            return None
+        return self.fetchrow_results.pop(0)
+
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+        self.fetch_calls.append((query, args))
+        if not self.fetch_results:
+            return []
+        return self.fetch_results.pop(0)
+
+    def transaction(self) -> FakeTransaction:
+        return self.transaction_manager
+
+
+class FakeAcquire:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class FakePool:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self._connection)
+
+
+def _strategy(
+    strategy_id: str = "default",
+    *,
+    owner: str = "system",
+    drawdown_pct: float = 2.5,
+) -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=strategy_id,
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", owner), ("tier", "default")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=drawdown_pct,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_strategy_serializes_metadata_json() -> None:
+    connection = FakeConnection()
+    registry = PostgresStrategyRegistry(FakePool(connection))
+
+    await registry.create_strategy("default", metadata={"tier": "default", "owner": "system"})
+
+    assert connection.execute_calls == [
+        (
+            """
+        INSERT INTO strategies (strategy_id, metadata_json)
+        VALUES ($1, $2::jsonb)
+        ON CONFLICT (strategy_id) DO NOTHING
+        """,
+            ("default", '{"owner":"system","tier":"default"}'),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_version_inserts_and_activates_strategy() -> None:
+    strategy = _strategy()
+    created_at = datetime(2026, 4, 17, 12, 30, tzinfo=timezone(timedelta(hours=-5)))
+    connection = FakeConnection(fetchval_results=[created_at])
+    registry = PostgresStrategyRegistry(FakePool(connection))
+
+    version = await registry.create_version(strategy)
+
+    assert version.strategy_id == "default"
+    assert version.strategy_version_id == compute_strategy_version_id(*strategy.snapshot())
+    assert version.created_at == created_at.astimezone(UTC)
+    assert connection.transaction_manager.entered == 1
+    assert connection.transaction_manager.exited == 1
+    assert len(connection.execute_calls) == 2
+    assert connection.fetchval_calls[0][1] == (
+        version.strategy_version_id,
+        "default",
+        serialize_strategy_config_json(*strategy.snapshot()),
+    )
+    assert connection.execute_calls[-1][1] == ("default", version.strategy_version_id)
+
+
+@pytest.mark.asyncio
+async def test_create_version_reuses_existing_timestamp_when_insert_is_idempotent() -> None:
+    strategy = _strategy()
+    existing_created_at = datetime(2026, 4, 17, 8, 0, tzinfo=timezone(timedelta(hours=2)))
+    connection = FakeConnection(fetchval_results=[None, existing_created_at])
+    registry = PostgresStrategyRegistry(FakePool(connection))
+
+    version = await registry.create_version(strategy)
+
+    assert len(connection.fetchval_calls) == 2
+    assert connection.fetchval_calls[1][1] == ("default", version.strategy_version_id)
+    assert version.created_at == existing_created_at.astimezone(UTC)
+
+
+@pytest.mark.asyncio
+async def test_create_version_raises_type_error_when_created_at_is_not_a_datetime() -> None:
+    connection = FakeConnection(fetchval_results=[None, "not-a-timestamp"])
+    registry = PostgresStrategyRegistry(FakePool(connection))
+
+    with pytest.raises(TypeError, match="did not return a timestamp"):
+        await registry.create_version(_strategy())
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_round_trips_json_string_and_handles_missing_rows() -> None:
+    strategy = _strategy()
+    connection = FakeConnection(
+        fetchrow_results=[
+            {"config_json": serialize_strategy_config_json(*strategy.snapshot())},
+            {"config_json": None},
+            None,
+        ]
+    )
+    registry = PostgresStrategyRegistry(FakePool(connection))
+
+    assert await registry.get_by_id("default") == strategy
+    assert await registry.get_by_id("inactive") is None
+    assert await registry.get_by_id("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_list_strategies_and_versions_return_utc_projection_rows() -> None:
+    created_at = datetime(2026, 4, 17, 15, 0, tzinfo=timezone(timedelta(hours=9)))
+    connection = FakeConnection(
+        fetch_results=[
+            [
+                {
+                    "strategy_id": "default",
+                    "active_version_id": "default-v1",
+                    "created_at": created_at,
+                }
+            ],
+            [
+                {
+                    "strategy_id": "default",
+                    "strategy_version_id": "default-v1",
+                    "created_at": created_at,
+                }
+            ],
+        ]
+    )
+    registry = PostgresStrategyRegistry(FakePool(connection))
+
+    strategies = await registry.list_strategies()
+    versions = await registry.list_versions("default")
+
+    assert strategies[0].strategy_id == "default"
+    assert strategies[0].active_version_id == "default-v1"
+    assert strategies[0].created_at == created_at.astimezone(UTC)
+    assert versions[0].strategy_version_id == "default-v1"
+    assert versions[0].created_at == created_at.astimezone(UTC)
+
+
+def test_ensure_utc_rejects_non_datetime_values() -> None:
+    with pytest.raises(TypeError, match="expected datetime"):
+        _ensure_utc("2026-04-17")
+
+
+def test_load_json_object_accepts_dict_or_json_string() -> None:
+    payload = {"config": {"strategy_id": "default"}}
+
+    assert _load_json_object(payload) == payload
+    assert _load_json_object(json.dumps(payload)) == payload
+
+
+def test_load_json_object_rejects_non_object_payload() -> None:
+    with pytest.raises(TypeError, match="JSON object"):
+        _load_json_object(["not", "an", "object"])
+
+
+def test_json_object_rejects_non_dict() -> None:
+    with pytest.raises(TypeError, match="risk must decode to a JSON object"):
+        _json_object([], "risk")
+
+
+def test_json_pairs_rejects_non_array_and_bad_pair_shape() -> None:
+    with pytest.raises(TypeError, match="JSON array of pairs"):
+        _json_pairs("bad")
+    with pytest.raises(TypeError, match="JSON array pair"):
+        _json_pairs([["ok", 1], ["missing-value"]])
+
+
+def test_json_string_and_string_list_validate_types() -> None:
+    assert _json_string("default", "config.strategy_id") == "default"
+    assert _json_string_list(["brier", "pnl"], "eval_spec.metrics") == ["brier", "pnl"]
+
+    with pytest.raises(TypeError, match="config.strategy_id must decode to a string"):
+        _json_string(7, "config.strategy_id")
+    with pytest.raises(TypeError, match="eval_spec.metrics must decode to a JSON array"):
+        _json_string_list("brier", "eval_spec.metrics")
+    with pytest.raises(TypeError, match="eval_spec.metrics must decode to a string"):
+        _json_string_list(["brier", 1], "eval_spec.metrics")
+
+
+def test_json_optional_int_and_float_validate_types() -> None:
+    assert _json_optional_int(None, "market_selection.resolution_time_max_horizon_days") is None
+    assert _json_optional_int(7, "market_selection.resolution_time_max_horizon_days") == 7
+    assert _json_float("1.25", "risk.min_order_size_usdc") == pytest.approx(1.25)
+
+    with pytest.raises(TypeError, match="must decode to an int or null"):
+        _json_optional_int(True, "market_selection.resolution_time_max_horizon_days")
+    with pytest.raises(TypeError, match="float-compatible"):
+        _json_float(object(), "risk.min_order_size_usdc")
+
+
+def test_strategy_from_config_json_validates_nested_fields() -> None:
+    strategy = _strategy()
+    payload = json.loads(serialize_strategy_config_json(*strategy.snapshot()))
+    payload["config"]["factor_composition"] = [["factor-a", 0.6], ["factor-b"]]
+
+    with pytest.raises(TypeError, match="JSON array pair"):
+        _strategy_from_config_json(payload)
+
+    payload = json.loads(serialize_strategy_config_json(*strategy.snapshot()))
+    payload["market_selection"]["resolution_time_max_horizon_days"] = True
+
+    with pytest.raises(
+        TypeError,
+        match="market_selection.resolution_time_max_horizon_days must decode to an int or null",
+    ):
+        _strategy_from_config_json(payload)

--- a/tests/unit/test_strategy_registry.py
+++ b/tests/unit/test_strategy_registry.py
@@ -300,6 +300,8 @@ def test_json_optional_int_and_float_validate_types() -> None:
     with pytest.raises(TypeError, match="must decode to an int or null"):
         _json_optional_int(True, "market_selection.resolution_time_max_horizon_days")
     with pytest.raises(TypeError, match="float-compatible"):
+        _json_float(True, "risk.min_order_size_usdc")
+    with pytest.raises(TypeError, match="float-compatible"):
         _json_float(object(), "risk.min_order_size_usdc")
 
 
@@ -317,5 +319,14 @@ def test_strategy_from_config_json_validates_nested_fields() -> None:
     with pytest.raises(
         TypeError,
         match="market_selection.resolution_time_max_horizon_days must decode to an int or null",
+    ):
+        _strategy_from_config_json(payload)
+
+    payload = json.loads(serialize_strategy_config_json(*strategy.snapshot()))
+    payload["risk"]["max_daily_drawdown_pct"] = True
+
+    with pytest.raises(
+        TypeError,
+        match="risk.max_daily_drawdown_pct must decode to a float-compatible value",
     ):
         _strategy_from_config_json(payload)

--- a/tests/unit/test_version_hash_stability.py
+++ b/tests/unit/test_version_hash_stability.py
@@ -70,7 +70,7 @@ def test_versioning_module_docstring_documents_canonicalization_contract() -> No
     assert docstring is not None
     assert 'json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=True)' in docstring
     assert "Enum" in docstring
-    assert "dataclasses.asdict" in docstring
+    assert "plain builtins" in docstring
     assert "byte-identical across Python minor-version bumps and process restarts" in docstring
 
 
@@ -100,6 +100,28 @@ def test_metadata_ordering_does_not_change_strategy_version_id() -> None:
         **_build_projection_inputs(
             metadata=(("tier", "default"), ("owner", "system")),
         )
+    )
+
+    assert reordered_hash == canonical_hash
+
+
+def test_forecaster_ordering_does_not_change_strategy_version_id() -> None:
+    compute_strategy_version_id = _load_symbol(
+        "pms.strategies.versioning",
+        "compute_strategy_version_id",
+    )
+
+    canonical_hash = compute_strategy_version_id(**_build_projection_inputs())
+    reordered_hash = compute_strategy_version_id(
+        **{
+            **_build_projection_inputs(),
+            "forecaster": _load_symbol("pms.strategies.projections", "ForecasterSpec")(
+                forecasters=(
+                    ("stats", (("window", "15m"),)),
+                    ("rules", (("threshold", "0.55"),)),
+                )
+            ),
+        }
     )
 
     assert reordered_hash == canonical_hash

--- a/tests/unit/test_version_hash_stability.py
+++ b/tests/unit/test_version_hash_stability.py
@@ -10,7 +10,7 @@ import pytest
 
 
 EXPECTED_DEFAULT_VERSION_ID = (
-    "b538f4d37ffedb2d22c29bcd13579763ed392a830530d3e9d5848af98f010757"
+    "d50c4db65699c222620c85f0cf84c0324c148a34b212c5f69903dbf4b950757c"
 )
 
 
@@ -125,6 +125,25 @@ def test_forecaster_ordering_does_not_change_strategy_version_id() -> None:
     )
 
     assert reordered_hash == canonical_hash
+
+
+def test_pair_element_swap_produces_distinct_strategy_version_id() -> None:
+    # Pair records carry (key, value) semantics — swapping their elements
+    # must produce a distinct hash, even though the outer tuple is treated
+    # as an unordered collection.
+    compute_strategy_version_id = _load_symbol(
+        "pms.strategies.versioning",
+        "compute_strategy_version_id",
+    )
+
+    baseline_hash = compute_strategy_version_id(
+        **_build_projection_inputs(metadata=(("owner", "alice"),))
+    )
+    swapped_hash = compute_strategy_version_id(
+        **_build_projection_inputs(metadata=(("alice", "owner"),))
+    )
+
+    assert swapped_hash != baseline_hash
 
 
 def test_risk_param_changes_produce_a_new_strategy_version_id() -> None:

--- a/tests/unit/test_version_hash_stability.py
+++ b/tests/unit/test_version_hash_stability.py
@@ -9,7 +9,9 @@ from typing import Any
 import pytest
 
 
-EXPECTED_DEFAULT_VERSION_ID = "REPLACE_ME_CP02_DEFAULT_HASH"
+EXPECTED_DEFAULT_VERSION_ID = (
+    "b538f4d37ffedb2d22c29bcd13579763ed392a830530d3e9d5848af98f010757"
+)
 
 
 def _load_symbol(module_name: str, symbol_name: str) -> Any:

--- a/tests/unit/test_version_hash_stability.py
+++ b/tests/unit/test_version_hash_stability.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+EXPECTED_DEFAULT_VERSION_ID = "REPLACE_ME_CP02_DEFAULT_HASH"
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in red phase
+        pytest.fail(f"{module_name} is missing: {exc}")
+
+    return getattr(module, symbol_name)
+
+
+def _build_projection_inputs(
+    *,
+    metadata: tuple[tuple[str, str], ...] = (("owner", "system"), ("tier", "default")),
+    max_daily_drawdown_pct: float = 2.5,
+) -> dict[str, Any]:
+    strategy_config = _load_symbol("pms.strategies.projections", "StrategyConfig")
+    risk_params = _load_symbol("pms.strategies.projections", "RiskParams")
+    eval_spec = _load_symbol("pms.strategies.projections", "EvalSpec")
+    forecaster_spec = _load_symbol("pms.strategies.projections", "ForecasterSpec")
+    market_selection_spec = _load_symbol(
+        "pms.strategies.projections",
+        "MarketSelectionSpec",
+    )
+
+    return {
+        "config": strategy_config(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=metadata,
+        ),
+        "risk": risk_params(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=max_daily_drawdown_pct,
+            min_order_size_usdc=1.0,
+        ),
+        "eval_spec": eval_spec(metrics=("brier", "pnl", "fill_rate")),
+        "forecaster": forecaster_spec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        "market_selection": market_selection_spec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    }
+
+
+def test_versioning_module_docstring_documents_canonicalization_contract() -> None:
+    versioning = importlib.import_module("pms.strategies.versioning")
+    docstring = inspect.getdoc(versioning)
+
+    assert docstring is not None
+    assert 'json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=True)' in docstring
+    assert "Enum" in docstring
+    assert "dataclasses.asdict" in docstring
+    assert "byte-identical across Python minor-version bumps and process restarts" in docstring
+
+
+def test_default_strategy_version_id_matches_locked_fixture() -> None:
+    compute_strategy_version_id = _load_symbol(
+        "pms.strategies.versioning",
+        "compute_strategy_version_id",
+    )
+
+    version_id = compute_strategy_version_id(**_build_projection_inputs())
+
+    assert version_id == EXPECTED_DEFAULT_VERSION_ID
+
+
+def test_metadata_ordering_does_not_change_strategy_version_id() -> None:
+    compute_strategy_version_id = _load_symbol(
+        "pms.strategies.versioning",
+        "compute_strategy_version_id",
+    )
+
+    canonical_hash = compute_strategy_version_id(
+        **_build_projection_inputs(
+            metadata=(("owner", "system"), ("tier", "default")),
+        )
+    )
+    reordered_hash = compute_strategy_version_id(
+        **_build_projection_inputs(
+            metadata=(("tier", "default"), ("owner", "system")),
+        )
+    )
+
+    assert reordered_hash == canonical_hash
+
+
+def test_risk_param_changes_produce_a_new_strategy_version_id() -> None:
+    compute_strategy_version_id = _load_symbol(
+        "pms.strategies.versioning",
+        "compute_strategy_version_id",
+    )
+
+    baseline_hash = compute_strategy_version_id(**_build_projection_inputs())
+    changed_hash = compute_strategy_version_id(
+        **_build_projection_inputs(max_daily_drawdown_pct=4.0)
+    )
+
+    assert changed_hash != baseline_hash
+
+
+def test_strategy_version_id_is_stable_across_subprocesses() -> None:
+    compute_strategy_version_id = _load_symbol(
+        "pms.strategies.versioning",
+        "compute_strategy_version_id",
+    )
+
+    expected_hash = compute_strategy_version_id(**_build_projection_inputs())
+    repo_root = Path(__file__).resolve().parents[2]
+    script = """
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from pms.strategies.versioning import compute_strategy_version_id
+
+print(
+    compute_strategy_version_id(
+        config=StrategyConfig(
+            strategy_id="default",
+            factor_composition=(("factor-a", 0.6), ("factor-b", 0.4)),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+)
+""".strip()
+
+    result = subprocess.run(
+        ["uv", "run", "python", "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.stdout.strip() == expected_hash

--- a/uv.lock
+++ b/uv.lock
@@ -269,6 +269,99 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/46/79764cfb61a3ac80dadae5d94fb10acdb7800e31fecf4113cf3d345e4952/grimp-3.14.tar.gz", hash = "sha256:645fbd835983901042dae4e1b24fde3a89bf7ac152f9272dd17a97e55cb4f871", size = 830882, upload-time = "2025-12-10T17:55:01.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/31/d4a86207c38954b6c3d859a1fc740a80b04bbe6e3b8a39f4e66f9633dfa4/grimp-3.14-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f1c91e3fa48c2196bf62e3c71492140d227b2bfcd6d15e735cbc0b3e2d5308e0", size = 2185572, upload-time = "2025-12-10T17:53:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/61/ed4cba5bd75d37fe46e17a602f616619a9e4f74ad8adfcf560ce4b2a1697/grimp-3.14-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c6291c8f1690a9fe21b70923c60b075f4a89676541999e3d33084cbc69ac06a1", size = 2118002, upload-time = "2025-12-10T17:53:18.546Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6a/688f6144d0b207d7845bd8ab403820a83630ce3c9420cbbc7c9e9282f9c0/grimp-3.14-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ec312383935c2d09e4085c8435780ada2e13ebef14e105609c2988a02a5b2ce", size = 2283939, upload-time = "2025-12-10T17:52:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/98/4c540de151bf3fd58d6d7b3fe2269b6a6af6c61c915de1bc991802bfaff8/grimp-3.14-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4f43cbf640e73ee703ad91639591046828d20103a1c363a02516e77a66a4ac07", size = 2233693, upload-time = "2025-12-10T17:52:18.938Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/7b/84b4b52b6c6dd5bf083cb1a72945748f56ea2e61768bbebf87e8d9d0ef75/grimp-3.14-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a93c9fddccb9ff16f5c6b5fca44227f5f86cba7cffc145d2176119603d2d7c7", size = 2389745, upload-time = "2025-12-10T17:53:00.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/33/31b96907c7dd78953df5e1ce67c558bd6057220fa1203d28d52566315a2e/grimp-3.14-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5653a2769fdc062cb7598d12200352069c9c6559b6643af6ada3639edb98fcc3", size = 2569055, upload-time = "2025-12-10T17:52:33.556Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/24/ce1a8110f3d5b178153b903aafe54b6a9216588b5bff3656e30af43e9c29/grimp-3.14-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:071c7ddf5e5bb7b2fdf79aefdf6e1c237cd81c095d6d0a19620e777e85bf103c", size = 2358044, upload-time = "2025-12-10T17:52:47.545Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7f/16d98c02287bc99884843478b9a68b04a2ef13b5cb8b9f36a9ca7daea75b/grimp-3.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e01b7a4419f535b667dfdcb556d3815b52981474f791fb40d72607228389a31", size = 2310304, upload-time = "2025-12-10T17:53:09.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8c/0fde9781b0f6b4f9227d485685f48f6bcc70b95af22e2f85ff7f416cbfc1/grimp-3.14-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c29682f336151d1d018d0c3aa9eeaa35734b970e4593fa396b901edca7ef5c79", size = 2463682, upload-time = "2025-12-10T17:53:49.185Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cb/2baff301c2c2cc2792b6e225ea0784793ca587c81b97572be0bad122cfc8/grimp-3.14-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:a5c4fd71f363ea39e8aab0630010ced77a8de9789f27c0acdd0d7e6269d4a8ef", size = 2500573, upload-time = "2025-12-10T17:54:03.899Z" },
+    { url = "https://files.pythonhosted.org/packages/96/69/797e4242f42d6665da5fe22cb250cae3f14ece4cb22ad153e9cd97158179/grimp-3.14-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:766911e3ba0b13d833fdd03ad1f217523a8a2b2527b5507335f71dca1153183d", size = 2503005, upload-time = "2025-12-10T17:54:32.993Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/45/da1a27a6377807ca427cd56534231f0920e1895e16630204f382a0df14c5/grimp-3.14-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:154e84a2053e9f858ae48743de23a5ad4eb994007518c29371276f59b8419036", size = 2515776, upload-time = "2025-12-10T17:54:47.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8d/b918a29ce98029cd7a9e33a584be43a93288d5283fb7ccef5b6b2ba39ede/grimp-3.14-cp311-cp311-win32.whl", hash = "sha256:3189c86c3e73016a1907ee3ba9f7a6ca037e3601ad09e60ce9bf12b88877f812", size = 1873189, upload-time = "2025-12-10T17:55:11.872Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d7/2327c203f83a25766fbd62b0df3b24230d422b6e53518ff4d1c5e69793f1/grimp-3.14-cp311-cp311-win_amd64.whl", hash = "sha256:201f46a6a4e5ee9dfba4a2f7d043f7deab080d1d84233f4a1aee812678c25307", size = 2014277, upload-time = "2025-12-10T17:55:04.144Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d6/a35ff62f35aa5fd148053506eddd7a8f2f6afaed31870dc608dd0eb38e4f/grimp-3.14-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ffabc6940301214753bad89ec0bfe275892fa1f64b999e9a101f6cebfc777133", size = 2178573, upload-time = "2025-12-10T17:53:42.836Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/bd2e80273da4d46110969fc62252e5372e0249feb872bc7fe76fdc7f1818/grimp-3.14-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:075d9a1c78d607792d0ed8d4d3d7754a621ef04c8a95eaebf634930dc9232bb2", size = 2110452, upload-time = "2025-12-10T17:53:19.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c3/7307249c657d34dca9d250d73ba027d6cfe15a98fb3119b6e5210bc388b7/grimp-3.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ff52addeb20955a4d6aa097bee910573ffc9ef0d3c8a860844f267ad958156", size = 2283064, upload-time = "2025-12-10T17:52:07.673Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d2/cae4cf32dc8d4188837cc4ab183300d655f898969b0f169e240f3b7c25be/grimp-3.14-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d10e0663e961fcbe8d0f54608854af31f911f164c96a44112d5173050132701f", size = 2235893, upload-time = "2025-12-10T17:52:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/3f58bc3064fc305dac107d08003ba65713a5bc89a6d327f1c06b30cce752/grimp-3.14-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ab874d7ddddc7a1291259cf7c31a4e7b5c612e9da2e24c67c0eb1a44a624e67", size = 2393376, upload-time = "2025-12-10T17:53:02.397Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b8/f476f30edf114f04cb58e8ae162cb4daf52bda0ab01919f3b5b7edb98430/grimp-3.14-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54fec672ec83355636a852177f5a470c964bede0f6730f9ba3c7b5c8419c9eab", size = 2571342, upload-time = "2025-12-10T17:52:35.214Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ae/2e44d3c4f591f95f86322a8f4dbb5aac17001d49e079f3a80e07e7caaf09/grimp-3.14-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b9e221b5e8070a916c780e88c877fee2a61c95a76a76a2a076396e459511b0bb", size = 2359022, upload-time = "2025-12-10T17:52:49.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ac/42b4d6bc0ea119ce2e91e1788feabf32c5433e9617dbb495c2a3d0dc7f12/grimp-3.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea6b495f9b4a8d82f5ce544921e76d0d12017f5d1ac3a3bd2f5ac88ab055b1c", size = 2309424, upload-time = "2025-12-10T17:53:11.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/6a731989625c1790f4da7602dcbf9d6525512264e853cda77b3b3602d5e0/grimp-3.14-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:655e8d3f79cd99bb859e09c9dd633515150e9d850879ca71417d5ac31809b745", size = 2462754, upload-time = "2025-12-10T17:53:50.886Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4d/3d1571c0a39a59dd68be4835f766da64fe64cbab0d69426210b716a8bdf0/grimp-3.14-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a14f10b1b71c6c37647a76e6a49c226509648107abc0f48c1e3ecd158ba05531", size = 2501356, upload-time = "2025-12-10T17:54:06.014Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d1/8950b8229095ebda5c54c8784e4d1f0a6e19423f2847289ef9751f878798/grimp-3.14-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:81685111ee24d3e25f8ed9e77ed00b92b58b2414e1a1c2937236026900972744", size = 2504631, upload-time = "2025-12-10T17:54:34.441Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/23bed3da9206138d36d01890b656c7fb7adfb3a37daac8842d84d8777ade/grimp-3.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ce8352a8ea0e27b143136ea086582fc6653419aa8a7c15e28ed08c898c42b185", size = 2514751, upload-time = "2025-12-10T17:54:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/6f1f55c97ee982f133ec5ccb22fc99bf5335aee70c208f4fb86cd833b8d5/grimp-3.14-cp312-cp312-win32.whl", hash = "sha256:3fc0f98b3c60d88e9ffa08faff3200f36604930972f8b29155f323b76ea25a06", size = 1875041, upload-time = "2025-12-10T17:55:13.326Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/03ba01288e2a41a948bc8526f32c2eeaddd683ed34be1b895e31658d5a4c/grimp-3.14-cp312-cp312-win_amd64.whl", hash = "sha256:6bca77d1d50c8dc402c96af21f4e28e2f1e9938eeabd7417592a22bd83cde3c3", size = 2013868, upload-time = "2025-12-10T17:55:05.907Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bd/d12a9c821b79ba31fc52243e564712b64140fc6d011c2bdbb483d9092a12/grimp-3.14-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af8a625554beea84530b98cc471902155b5fc042b42dc47ec846fa3e32b0c615", size = 2178632, upload-time = "2025-12-10T17:53:44.55Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8c/d6620dbc245149d5a5a7a9342733556ba91a672f358259c0ab31d889b56b/grimp-3.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0dd1942ffb419ad342f76b0c3d3d2d7f312b264ddc578179d13ce8d5acec1167", size = 2110288, upload-time = "2025-12-10T17:53:21.662Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9d/ea51edc4eb295c99786040051c66466bfa235fd1def9f592057b36e03d0f/grimp-3.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537f784ce9b4acf8657f0b9714ab69a6c72ffa752eccc38a5a85506103b1a194", size = 2282197, upload-time = "2025-12-10T17:52:09.304Z" },
+    { url = "https://files.pythonhosted.org/packages/28/6e/7db27818ced6a797f976ca55d981a3af5c12aec6aeda12d63965847cd028/grimp-3.14-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:78ab18c08770aa005bef67b873bc3946d33f65727e9f3e508155093db5fa57d6", size = 2235720, upload-time = "2025-12-10T17:52:21.806Z" },
+    { url = "https://files.pythonhosted.org/packages/37/26/0e3bbae4826bd6eaabf404738400414071e73ddb1e65bf487dcce17858c4/grimp-3.14-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28ca58728c27e7292c99f964e6ece9295c2f9cfdefc37c18dea0679c783ffb6f", size = 2393023, upload-time = "2025-12-10T17:53:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f2/7da91db5703da34c7ef4c7cddcbb1a8fc30cd85fe54756eba942c6fb27d8/grimp-3.14-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9b5577de29c6c5ae6e08d4ca0ac361b45dba323aa145796e6b320a6ea35414b7", size = 2571108, upload-time = "2025-12-10T17:52:36.523Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5e/4d6278f18032c7208696edf8be24a4b5f7fad80acc20ffca737344bcecb5/grimp-3.14-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d7d1f9f42306f455abcec34db877e4887ff15f2777a43491f7ccbd6936c449b", size = 2358531, upload-time = "2025-12-10T17:52:50.521Z" },
+    { url = "https://files.pythonhosted.org/packages/24/fb/231c32493161ac82f27af6a56965daefa0ec6030fdaf5b948ddd5d68d000/grimp-3.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39bd5c9b7cef59ee30a05535e9cb4cbf45a3c503f22edce34d0aa79362a311a9", size = 2308831, upload-time = "2025-12-10T17:53:12.587Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/f6db325bf5efbbebc9c85cad0af865e821a12a0ba58ee309e938cbd5fedf/grimp-3.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fec3116b4f780a1bc54176b19e6b9f2e36e2ef3164b8fc840660566af35df88", size = 2462138, upload-time = "2025-12-10T17:53:52.403Z" },
+    { url = "https://files.pythonhosted.org/packages/41/2e/cc3fe29cf07f70364018086840c228a190539ab8105147e34588db590792/grimp-3.14-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0233a35a5bbb23688d63e1736b54415fa9994ace8dfeb7de8514ed9dee212968", size = 2501393, upload-time = "2025-12-10T17:54:22.486Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/eb/54cada9a726455148da23f64577b5cd164164d23a6449e3fa14551157356/grimp-3.14-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e46b2fef0f1da7e7e2f8129eb93c7e79db716ff7810140a22ce5504e10ed86df", size = 2504514, upload-time = "2025-12-10T17:54:36.34Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/e6afe4f0652df07e8762f61899d1202b73c22c559c804d0a09e5aab2ff17/grimp-3.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3e6d9b50623ee1c3d2a1927ec3f5d408995ea1f92f3e91ed996c908bb40e856f", size = 2514018, upload-time = "2025-12-10T17:54:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/75/13/2b8550acc1f010301f02c4fe9664810929fd9277cd032ab608b8534a96fb/grimp-3.14-cp313-cp313-win32.whl", hash = "sha256:fd57c56f5833c99320ec77e8ba5508d56f6fb48ec8032a942f7931cc6ebb80ce", size = 1874922, upload-time = "2025-12-10T17:55:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c7/bc9db5a54ef22972cd17d15ad80a8fee274a471bd3f02300405702d29ea5/grimp-3.14-cp313-cp313-win_amd64.whl", hash = "sha256:173307cf881a126fe5120b7bbec7d54384002e3c83dcd8c4df6ce7f0fee07c53", size = 2013705, upload-time = "2025-12-10T17:55:07.488Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7e/02710bf5e50997168c84ac622b10dd41d35515efd0c67549945ad20996a0/grimp-3.14-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebe29f8f13fbd7c314908ed535183a36e6db71839355b04869b27f23c58fa082", size = 2281868, upload-time = "2025-12-10T17:52:10.589Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/2e440c6762cc78bd50582e1b092357d2255f0852ccc6218d8db25170ab31/grimp-3.14-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:073d285b00100153fd86064c7726bb1b6d610df1356d33bb42d3fd8809cb6e72", size = 2230917, upload-time = "2025-12-10T17:52:23.212Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bb/2e7dce129b88f07fc525fe5c97f28cfb7ed7b62c59386d39226b4d08969c/grimp-3.14-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f6d6efc37e1728bbfcd881b89467be5f7b046292597b3ebe5f8e44e89ea8b6cb", size = 2571371, upload-time = "2025-12-10T17:52:37.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2b/8f1be8294af60c953687db7dec25525d87ed9c2aa26b66dcbe5244abaca2/grimp-3.14-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5337d65d81960b712574c41e85b480d4480bbb5c6f547c94e634f6c60d730889", size = 2356980, upload-time = "2025-12-10T17:52:52.004Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ca/ead91e04b3ddd4774ae74601860ea0f0f21bcf6b970b6769ba9571eb2904/grimp-3.14-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:84a7fea63e352b325daa89b0b7297db411b7f0036f8d710c32f8e5090e1fc3ca", size = 2461540, upload-time = "2025-12-10T17:53:53.749Z" },
+    { url = "https://files.pythonhosted.org/packages/94/aa/f8a085ff73c37d6e6a37de9f58799a3fea9e16badf267aaef6f11c9a53a3/grimp-3.14-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:d0b19a3726377165fe1f7184a8af317734d80d32b371b6c5578747867ab53c0b", size = 2497925, upload-time = "2025-12-10T17:54:23.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a3/db3c2d6df07fe74faf5a28fcf3b44fad2831d323ba4a3c2ff66b77a6520c/grimp-3.14-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9caa4991f530750f88474a3f5ecf6ef9f0d064034889d92db00cfb4ecb78aa24", size = 2501794, upload-time = "2025-12-10T17:54:38.05Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/095f4e3765e7b60425a41e9fbd2b167f8b0acb957cc88c387f631778a09d/grimp-3.14-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1876efc119b99332a5cc2b08a6bdaada2f0ad94b596f0372a497e2aa8bda4d94", size = 2515203, upload-time = "2025-12-10T17:54:52.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5f/ee02a3a1237282d324f596a50923bf9d2cb1b1230ef2fef49fb4d3563c2c/grimp-3.14-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3ccf03e65864d6bc7bf1c003c319f5330a7627b3677f31143f11691a088464c2", size = 2177150, upload-time = "2025-12-10T17:53:46.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/64/2a92889e5fc78e8ef5c548e6a5c6fed78b817eeb0253aca586c28108393a/grimp-3.14-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9ecd58fa58a270e7523f8bec9e6452f4fdb9c21e4cd370640829f1e43fa87a69", size = 2109280, upload-time = "2025-12-10T17:53:23.345Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/5d0b9ab54821e7fbdeb02f3919fa2cb8b9f0c3869fa6e4b969a5766f0ffa/grimp-3.14-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d75d1f8f7944978b39b08d870315174f1ffcd5123be6ccff8ce90467ace648a", size = 2283367, upload-time = "2025-12-10T17:52:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/96/a77c40c92faf7500f42ac019ab8de108b04ffe3db8ec8d6f90416d2322ce/grimp-3.14-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6f70bbb1dd6055d08d29e39a78a11c4118c1778b39d17cd8271e18e213524ca7", size = 2237125, upload-time = "2025-12-10T17:52:24.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/3e1483721c83057bff921cf454dd5ff3e661ae1d2e63150a380382d116c2/grimp-3.14-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f21b7c003626c902669dc26ede83a91220cf0a81b51b27128370998c2f247b4", size = 2391735, upload-time = "2025-12-10T17:53:05.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cb/25fad4a174fe672d42f3e5616761a8120a3b03c8e9e2ae3f31159561968a/grimp-3.14-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80d9f056415c936b45561310296374c4319b5df0003da802c84d2830a103792a", size = 2571388, upload-time = "2025-12-10T17:52:39.337Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7e/456df7f6a765ce3f160eb32a0f64ed0c1c3cd39b518555dde02087f9b6e4/grimp-3.14-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0332963cd63a45863775d4237e59dedf95455e0a1ea50c356be23100c5fc1d7c", size = 2359637, upload-time = "2025-12-10T17:52:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/3e5005ef21a4e2243f0da489aba86aaaff0bc11d5240d67113482cba88e0/grimp-3.14-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f4144350d074f2058fe7c89230a26b34296b161f085b0471a692cb2fe27036f", size = 2308335, upload-time = "2025-12-10T17:53:13.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/03/4e055f756946d6f71ab7e9d1f8536a9e476777093dd7a050f40412d1a2b1/grimp-3.14-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e148e67975e92f90a8435b1b4c02180b9a3f3d725b7a188ba63793f1b1e445a0", size = 2463680, upload-time = "2025-12-10T17:53:55.507Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b9/3c76b7c2e1587e4303a6eff6587c2117c3a7efe1b100cd13d8a4a5613572/grimp-3.14-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1093f7770cb5f3ca6f99fb152f9c949381cc0b078dfdfe598c8ab99abaccda3b", size = 2502808, upload-time = "2025-12-10T17:54:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/20/80/ada10b85ad3125ebedea10256d9c568b6bf28339d2f79d2d196a7b94f633/grimp-3.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a213f45ec69e9c2b28ffd3ba5ab12cc9859da17083ba4dc39317f2083b618111", size = 2504013, upload-time = "2025-12-10T17:54:39.762Z" },
+    { url = "https://files.pythonhosted.org/packages/05/45/7c369f749d50b0ceac23cd6874ca4695cc1359a96091c7010301e5c8b619/grimp-3.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f003ac3f226d2437a49af0b6036f26edba57f8a32d329275dbde1b2b2a00a56", size = 2515043, upload-time = "2025-12-10T17:54:54.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/85135fe83826ce11ae56a340d32a1391b91eed94d25ce7bc318019f735de/grimp-3.14-cp314-cp314-win32.whl", hash = "sha256:eec81be65a18f4b2af014b1e97296cc9ee20d1115529bf70dd7e06f457eac30b", size = 1877509, upload-time = "2025-12-10T17:55:17.062Z" },
+    { url = "https://files.pythonhosted.org/packages/db/61/e4a2234edecb3bb3cff8963bc4ec5cc482a9e3c54f8df0946d7d90003830/grimp-3.14-cp314-cp314-win_amd64.whl", hash = "sha256:cd3bab6164f1d5e313678f0ab4bf45955afe7f5bdb0f2f481014aa9cca7e81ba", size = 2014364, upload-time = "2025-12-10T17:55:08.896Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/3d304443fbf1df4d60c09668846d0c8a605c6c95646226e41d8f5c3254da/grimp-3.14-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1df33de479be4d620f69633d1876858a8e64a79c07907d47cf3aaf896af057", size = 2281385, upload-time = "2025-12-10T17:52:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/13/493e2648dbb83b3fc517ee675e464beb0154551d726053c7982a3138c6a8/grimp-3.14-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07096d4402e9d5a2c59c402ea3d601f4b7f99025f5e32f077468846fc8d3821b", size = 2231470, upload-time = "2025-12-10T17:52:26.104Z" },
+    { url = "https://files.pythonhosted.org/packages/80/84/e772b302385a6b7ec752c88f84ffe35c33d14076245ae27a635aed9c63a2/grimp-3.14-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:712bc28f46b354316af50c469c77953ba3d6cb4166a62b8fb086436a8b05d301", size = 2571579, upload-time = "2025-12-10T17:52:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/5b23aa7b89c5f4f2cfa636cbeaf33e784378a6b0a823d77a3448670dfacc/grimp-3.14-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abe2bbef1cf8e27df636c02f60184319f138dee4f3a949405c21a4b491980397", size = 2356545, upload-time = "2025-12-10T17:52:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/bcf2116f4b1c3939ab35f9cdddd9ca59e953e57e9a0ac0c143deaf9f29cc/grimp-3.14-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2f9ae3fabb7a7a8468ddc96acc84ecabd84f168e7ca508ee94d8f32ea9bd5de2", size = 2461022, upload-time = "2025-12-10T17:53:56.923Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ce/1a076dce6bc22bca4b9ad5d1bbcd7e1023dcf7bf20ea9404c6462d78f049/grimp-3.14-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:efaf11ea73f7f12d847c54a5d6edcbe919e0369dce2d1aabae6c50792e16f816", size = 2498256, upload-time = "2025-12-10T17:54:27.214Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ea/ac735bed202c1c5c019e611b92d3861779e0cfbe2d20fdb0dec94266d248/grimp-3.14-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e089c9ab8aa755ff5af88c55891727783b4eb6b228e7bdf278e17209d954aa1e", size = 2502056, upload-time = "2025-12-10T17:54:41.537Z" },
+    { url = "https://files.pythonhosted.org/packages/80/8f/774ce522de6a7e70fbeceeaeb6fbe502f5dfb8365728fb3bb4cb23463da8/grimp-3.14-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a424ad14d5deb56721ac24ab939747f72ab3d378d42e7d1f038317d33b052b77", size = 2515157, upload-time = "2025-12-10T17:54:55.874Z" },
+    { url = "https://files.pythonhosted.org/packages/65/cc/dbc00210d0324b8fc1242d8e857757c7e0b62ff0fc0c1bc8dcc42342da85/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c8a8aab9b4310a7e69d7d845cac21cf14563aa0520ea322b948eadeae56d303", size = 2284804, upload-time = "2025-12-10T17:52:16.379Z" },
+    { url = "https://files.pythonhosted.org/packages/80/89/851d3d345342e9bcec3fe85d3997db29501fa59f958c1566bf3e24d9d7d9/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d781943b27e5875a41c8f9cfc80f8f0a349f864379192b8c3faa0e6a22593313", size = 2235176, upload-time = "2025-12-10T17:52:30.795Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/5f94702a8d5c121cafcdc9664de34c34f19d0d91a1127bf3946a2631f7a3/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9630d4633607aff94d0ac84b9c64fef1382cdb05b00d9acbde47f8745e264871", size = 2391258, upload-time = "2025-12-10T17:53:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a2/df8c79de5c9e227856d048cc1551c4742a5f97660c40304ac278bd48607f/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7cb00e1bcca583668554a8e9e1e4229a1d11b0620969310aae40148829ff6a32", size = 2571443, upload-time = "2025-12-10T17:52:43.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/21/747b7ed9572bbdc34a76dfec12ce510e80164b1aa06d3b21b34994e5f567/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3389da4ceaaa7f7de24a668c0afc307a9f95997bd90f81ec359a828a9bd1d270", size = 2357767, upload-time = "2025-12-10T17:52:57.84Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e6/485c5e3b64933e71f72f0cc45b0d7130418a6a5a13cedc2e8411bd76f290/grimp-3.14-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd7a32970ef97e42d4e7369397c7795287d84a736d788ccb90b6c14f0561d975", size = 2309069, upload-time = "2025-12-10T17:53:15.203Z" },
+    { url = "https://files.pythonhosted.org/packages/31/bd/12024a8cba1c77facc1422a7b48cd0d04c252fc9178fd6f99dc05a8af57b/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:fd1278623fa09f62abc0fd8a6500f31b421a1fd479980f44c2926020a0becf02", size = 2466429, upload-time = "2025-12-10T17:54:00.286Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7f/0e5977887e1c8f00f84bb4125217534806ffdcef9cf52f3580aa3b151f4b/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:9cfa52c89333d3d8fe9dc782529e888270d060231c3783e036d424044671dde0", size = 2501190, upload-time = "2025-12-10T17:54:30.107Z" },
+    { url = "https://files.pythonhosted.org/packages/42/6b/06acb94b6d0d8c7277bb3e33f93224aa3be5b04643f853479d3bf7b23ace/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:48a5be4a12fca6587e6885b4fc13b9e242ab8bf874519292f0f13814aecf52cc", size = 2503440, upload-time = "2025-12-10T17:54:44.444Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4d/2e531370d12e7a564f67f680234710bbc08554238a54991cd244feb61fb6/grimp-3.14-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:3fcc332466783a12a42cd317fd344c30fe734ba4fa2362efff132dc3f8d36da7", size = 2516525, upload-time = "2025-12-10T17:54:58.987Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -312,6 +405,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/55b697a17bb15c6cb88d97d73716813f5427281527b90f02cc0a600abc6e/import_linter-2.11.tar.gz", hash = "sha256:5abc3394797a54f9bae315e7242dc98715ba485f840ac38c6d3192c370d0085e", size = 1153682, upload-time = "2026-03-06T12:11:38.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/aa/2ed2c89543632ded7196e0d93dcc6c7fe87769e88391a648c4a298ea864a/import_linter-2.11-py3-none-any.whl", hash = "sha256:3dc54cae933bae3430358c30989762b721c77aa99d424f56a08265be0eeaa465", size = 637315, upload-time = "2026-03-06T12:11:36.599Z" },
 ]
 
 [[package]]
@@ -482,6 +590,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -589,6 +718,7 @@ llm = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "import-linter" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -612,6 +742,7 @@ provides-extras = ["llm"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "import-linter", specifier = ">=2.0" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -859,6 +990,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add the frozen strategy aggregate and projection surface, plus deterministic strategy version hashing and canonical config JSON serialization
- add strategy persistence in PostgreSQL: `strategies`, `strategy_versions`, `strategy_factors`, registry reads/writes, import-linter contracts, and downstream default strategy/version tagging
- add the live `/strategies` API route and dashboard page backed by the registry, then close the review-loop and full-verify gaps with stricter seed/config validation and focused coverage tests

## Testing Verification
- `uv run pytest -q` -> `144 passed, 42 skipped`
- `uv run pytest --cov=src/pms --cov-report=term -q` -> `144 passed, 42 skipped`, `85%` total coverage
- `PMS_RUN_INTEGRATION=1 PMS_TEST_DATABASE_URL=postgresql://postgres@127.0.0.1:<ephemeral-port>/postgres uv run pytest -q -m integration` -> `42 passed, 144 deselected`
- `uv run mypy src/ tests/ --strict`
- `uv run lint-imports`
- `cd dashboard && npm run build`
- `cd dashboard && env DATABASE_URL=postgresql://postgres@127.0.0.1:<ephemeral-port>/postgres PMS_TEST_DATABASE_URL=postgresql://postgres@127.0.0.1:<ephemeral-port>/postgres npx playwright test strategies.spec.ts` -> `1 passed`

## API Sample
`GET /strategies`

```json
{
  "strategies": [
    {
      "strategy_id": "default",
      "active_version_id": "default-v1",
      "created_at": "<ISO-8601 UTC timestamp>"
    }
  ]
}
```

## UI Evidence
- `/strategies` Playwright path passed with zero console errors
- screenshot captured at `.harness/pms-strategy-aggregate-v1/checkpoints/07/iter-1/evidence/strategies-page.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Strategies" dashboard page with live refresh, disconnected status, and a table of strategies (id, active version, created).
  * API endpoint to list strategies.

* **Infrastructure**
  * CI now runs import-linting and uses marker-based selection for integration tests.

* **Database**
  * Persistent strategy schema added with seeded default strategy and version.

* **Tests**
  * Extensive unit, integration and E2E coverage for strategies, schema, migration, and linter contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->