### PR TITLE
feat: implement active perception v1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ uv run pytest -q                         # full suite — see baseline below
 uv run mypy src/ tests/ --strict         # strict on every committed module
 ```
 
-**Baseline (as of 2026-04-17, feat/pms-strategy-aggregate-v1):** `pytest`
-145 passing, 42 skipped. The 42 skips are PostgreSQL-backed integration
+**Baseline (as of 2026-04-18, feat/pms-active-perception-v1):** `pytest`
+246 passing, 54 skipped. The 54 skips are PostgreSQL-backed integration
 checks gated on `PMS_RUN_INTEGRATION=1` and, where needed,
 `PMS_TEST_DATABASE_URL`. mypy strict must be clean. If the baseline
 fails on a fresh clone, fix the config — not the test — and commit

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ src/pms/               # Python package
   controller/          # decision pipeline
   core/                # frozen dataclasses, enums, Protocol interfaces
   evaluation/          # metrics collector + eval spool + feedback engine
+  market_selection/    # active-perception selector + subscription controller
   sensor/              # HistoricalSensor + MarketDiscoverySensor + stream
   storage/             # JSONL stores + Postgres market-data persistence
   runner.py            # orchestrator wiring all four layers
@@ -64,13 +65,13 @@ panel that calls these endpoints directly.
 
 ```bash
 uv sync
-uv run pytest -q                              # full suite (79 pass, 17 skip)
+uv run pytest -q                              # full suite (246 pass, 54 skip)
 uv run mypy src/ tests/ --strict              # strict type check
 PMS_RUN_INTEGRATION=1 uv run pytest -m integration   # PostgreSQL + live-network tests
 ```
 
 Baseline invariants enforced by CI:
-- pytest 145 passing, 42 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
+- pytest 246 passing, 54 skipped (integration gated on `PMS_RUN_INTEGRATION=1`).
 - mypy strict must be clean on every committed source file.
 
 ### Isolating dev state

--- a/agent_docs/architecture-invariants.md
+++ b/agent_docs/architecture-invariants.md
@@ -262,13 +262,13 @@ or execution.
 
 **Statement.** The Sensor's subscription list is not static
 configuration; it is derived at runtime from the union of all
-active strategies' market selection output. A `MarketSelector`
-component reads the market universe (from the outer ring), applies
-each strategy's `select_markets(universe)` method, and produces a
-merged `market_ids: list[str]` that a `SensorSubscriptionController`
-pushes to the Market Data Sensor. On strategy change, the
-subscription updates; on Sensor disconnect, the subscription is
-replayed.
+active strategies' market-selection projections. A `MarketSelector`
+component reads the market universe (from the outer ring), reads each
+active strategy's `MarketSelectionSpec` projection from the strategy
+registry, applies the projection filters, and produces a merged
+`market_ids: list[str]` that a `SensorSubscriptionController` pushes
+to the Market Data Sensor. On strategy change, the subscription
+updates; on Sensor disconnect, the subscription is replayed.
 
 **Rationale.** Static subscription lists waste bandwidth and miss
 markets that become relevant only after a strategy is deployed. More
@@ -282,13 +282,17 @@ while still achieving this requires a dedicated orchestration layer
 (the `MarketSelector` + `SensorSubscriptionController` pair) that
 lives above Sensor and below Strategy.
 
-**Runtime evidence (forward-looking).** Implemented in S4.
+**Runtime evidence.** Landed in S4.
 - `src/pms/market_selection/selector.py` — reads universe, applies
-  strategy specs, returns merged market-id list.
+  `MarketSelectionSpec` projections, returns merged market-id list.
 - `src/pms/market_selection/subscription_controller.py` —
   propagates updates to Sensor.
-- `src/pms/strategies/aggregate.py::Strategy.select_markets(universe)`
-  — the hook each strategy implements.
+- `src/pms/storage/strategy_registry.py::list_market_selections()` —
+  yields `(strategy_id, strategy_version_id, MarketSelectionSpec)` for
+  the selector.
+- `src/pms/runner.py::_wire_active_perception()` — wires
+  `MarketSelector` + `SensorSubscriptionController` into the live
+  runtime.
 
 **Anti-patterns.**
 - Sensor module reading Strategy directly (violates Invariant 5).
@@ -307,10 +311,11 @@ lives above Sensor and below Strategy.
 market universe, and the universe comes from Sensor. This is
 resolved by Invariant 7: the outer ring is filled by the
 `MarketDiscoverySensor` (which runs unconditionally with no strategy
-input) before any strategy runs its `select_markets`. Boot order:
+input) before market-selection projections are applied. Boot order:
 
 1. `MarketDiscoverySensor` populates `markets` / `tokens` tables.
-2. `MarketSelector` reads the tables, applies strategy specs.
+2. `MarketSelector` reads the tables, reads active
+   `MarketSelectionSpec` projections, and applies the filters.
 3. `SensorSubscriptionController` subscribes `MarketDataSensor` to
    the resulting market ids.
 4. Subsequent strategy config changes trigger steps 2–3 again

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,15 @@ name = "Sensor: no market_selection import"
 type = "forbidden"
 source_modules = ["pms.sensor"]
 forbidden_modules = ["pms.market_selection"]
+
+[[tool.importlinter.contracts]]
+name = "Actuator: no market_selection import"
+type = "forbidden"
+source_modules = ["pms.actuator"]
+forbidden_modules = ["pms.market_selection"]
+
+[[tool.importlinter.contracts]]
+name = "Market selection: no aggregate import"
+type = "forbidden"
+source_modules = ["pms.market_selection"]
+forbidden_modules = ["pms.strategies.aggregate"]

--- a/schema.sql
+++ b/schema.sql
@@ -9,8 +9,12 @@ CREATE TABLE IF NOT EXISTS markets (
     venue TEXT NOT NULL CHECK (venue IN ('polymarket', 'kalshi')),
     resolves_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL,
-    last_seen_at TIMESTAMPTZ NOT NULL
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    volume_24h DOUBLE PRECISION
 );
+
+ALTER TABLE markets
+    ADD COLUMN IF NOT EXISTS volume_24h DOUBLE PRECISION;
 
 CREATE TABLE IF NOT EXISTS tokens (
     token_id TEXT PRIMARY KEY,

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -37,6 +37,12 @@ class ConfigUpdate(BaseModel):
     mode: RunMode
 
 
+class SubscriptionStateResponse(BaseModel):
+    asset_ids: list[str]
+    count: int
+    last_updated_at: str | None
+
+
 def create_app(
     runner: Runner | None = None,
     *,
@@ -163,6 +169,29 @@ def create_app(
             cast(dict[str, Any], _jsonable(item))
             for item in await list_feedback_items(active_runner.feedback_store, resolved=resolved)
         ]
+
+    @app.get("/subscriptions")
+    async def subscriptions() -> dict[str, Any]:
+        subscription_controller = active_runner.subscription_controller
+        if (
+            active_runner.state.runner_started_at is None
+            or active_runner.state.mode == RunMode.BACKTEST
+            or subscription_controller is None
+        ):
+            response = SubscriptionStateResponse(
+                asset_ids=[],
+                count=0,
+                last_updated_at=None,
+            )
+            return response.model_dump(mode="json")
+
+        asset_ids = sorted(subscription_controller.current_asset_ids)
+        response = SubscriptionStateResponse(
+            asset_ids=asset_ids,
+            count=len(asset_ids),
+            last_updated_at=_jsonable(subscription_controller.last_updated_at),
+        )
+        return response.model_dump(mode="json")
 
     @app.get("/strategies")
     async def strategies() -> dict[str, Any]:

--- a/src/pms/controller/CLAUDE.md
+++ b/src/pms/controller/CLAUDE.md
@@ -38,10 +38,10 @@ that governs this layer:
   `pms.market_selection.*`. This is the designed responsibility
   boundary.
 - **Invariant 6 — MarketSelector home.** The market selection
-  logic (Strategy's `select_markets(universe)`) is invoked from
-  within Controller (or from a sibling module `pms.market_selection`
-  that Controller depends on — S4 decides which placement is
-  cleaner). The output feeds `SensorSubscriptionController`.
+  logic is implemented in the sibling `pms.market_selection` module.
+  It reads `MarketSelectionSpec` projections from the strategy
+  registry, filters the discovered universe, and feeds the result
+  into `SensorSubscriptionController`.
 - **Invariant 8 — Reads middle, writes inner.** Controller reads
   `factor_values` (middle ring); writes `TradeDecision` records to
   the inner ring (via Actuator for order products, via Evaluator
@@ -73,9 +73,10 @@ that governs this layer:
   fields on `TradeDecision`.
 - Never write outside the inner ring (Invariant 8).
 - Never compute per-market subscription lists inside sensor code.
-  The flow is: Strategy.select_markets → MarketSelector →
-  SensorSubscriptionController → Sensor. Controller owns the first
-  two steps.
+  The flow is: `MarketSelectionSpec` projection →
+  `MarketSelector` → `SensorSubscriptionController` → Sensor.
+  Controller owns the strategy side of that handoff; Sensor remains
+  strategy-agnostic.
 
 ## When adding a new forecaster / calibrator / sizer
 

--- a/src/pms/core/interfaces.py
+++ b/src/pms/core/interfaces.py
@@ -1,20 +1,61 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-from typing import Protocol
+from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import datetime
+from typing import Any, Protocol
 
 from pms.core.models import (
     EvalRecord,
     FillRecord,
+    Market,
     MarketSignal,
     OrderState,
     Portfolio,
+    Token,
     TradeDecision,
 )
+from pms.strategies.projections import MarketSelectionSpec
 
 
 class ISensor(Protocol):
     def __aiter__(self) -> AsyncIterator[MarketSignal]: ...
+
+
+class DiscoveryPollCompleteSensor(Protocol):
+    on_poll_complete: Callable[[], Awaitable[None]] | None
+
+
+class SubscriptionManagedSensor(Protocol):
+    async def update_subscription(self, asset_ids: list[str]) -> None: ...
+
+
+class MarketDataStore(Protocol):
+    async def read_eligible_markets(
+        self,
+        venue: str,
+        max_horizon_days: int | None,
+        min_volume_usdc: float,
+    ) -> list[tuple[Market, list[Token]]]: ...
+
+
+class StrategySelectionRegistry(Protocol):
+    async def list_market_selections(
+        self,
+    ) -> list[tuple[str, str, MarketSelectionSpec]]: ...
+
+
+class MarketSelectorLike(Protocol):
+    async def select(self) -> Any: ...
+
+
+class SubscriptionControllerLike(Protocol):
+    async def update(self, asset_ids: list[str]) -> bool: ...
+
+    @property
+    def current_asset_ids(self) -> frozenset[str]: ...
+
+    @property
+    def last_updated_at(self) -> datetime | None: ...
 
 
 class IController(Protocol):

--- a/src/pms/core/models.py
+++ b/src/pms/core/models.py
@@ -145,6 +145,7 @@ class Market:
     resolves_at: datetime | None
     created_at: datetime
     last_seen_at: datetime
+    volume_24h: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/pms/market_selection/CLAUDE.md
+++ b/src/pms/market_selection/CLAUDE.md
@@ -1,0 +1,63 @@
+# Identity & Context Awareness
+
+**CRITICAL**: Address the user as "Stometa" at the start of EVERY response.
+
+This serves as a context-awareness signal — if missing, indicates
+context drift.
+
+---
+
+# Market selection layer
+
+**Part of:** [prediction-market-system](../../../CLAUDE.md)
+**Role:** derive active-perception market subscriptions from strategy
+projections, merge strategy-level market sets, and push subscription
+updates into the Sensor boundary.
+
+## Layer-relevant invariants
+
+Full detail in `@agent_docs/architecture-invariants.md`. The subset
+that governs this layer:
+
+- **Invariant 2 — Projection-only strategy reads.** This layer reads
+  `MarketSelectionSpec` projections, not the `Strategy` aggregate.
+- **Invariant 3 — Tag every selection.** Any market-selection result
+  that is persisted or logged with strategy identity must carry both
+  `strategy_id` and `strategy_version_id`.
+- **Invariant 5 — Strategy-aware orchestration lives here, not in
+  Sensor.** `MarketSelector` is the strategy-aware boundary for
+  active perception; Sensor modules remain strategy-agnostic.
+- **Invariant 6 — Active perception loop.** `MarketSelector` and
+  `SensorSubscriptionController` are the landed implementation of the
+  feedback edge from strategy projections back to Sensor
+  subscriptions.
+- **Invariant 8 — Outer ring only.** Market selection reads outer-ring
+  market data and writes only subscription state, never strategy
+  products.
+
+## Current files
+
+- `selector.py` — loads eligible markets for each `MarketSelectionSpec`
+  and returns merged asset ids.
+- `merge.py` — merge policies and conflict reporting for strategy
+  market sets.
+- `subscription_controller.py` — serializes subscription updates and
+  forwards them to the Sensor sink.
+
+## Import rules
+
+- May import from `pms.core.*`, `pms.storage.market_data_store`,
+  `pms.strategies.projections`, and local module helpers.
+- May not import from `pms.sensor.*` or `pms.actuator.*`.
+- Must not import `pms.strategies.aggregate.Strategy`; consume
+  projection dataclasses only.
+- Must not reach into controller internals beyond the sink protocol
+  boundary.
+
+## Do not
+
+- Never read live subscriptions from Sensor state to derive the next
+  selection.
+- Never compute selection inside Sensor adapters.
+- Never widen the module into a general strategy orchestrator; it is
+  only the active-perception market-selection boundary.

--- a/src/pms/market_selection/__init__.py
+++ b/src/pms/market_selection/__init__.py
@@ -1,0 +1,19 @@
+"""Market selection and merge policies for active-perception feedback."""
+
+from .merge import (
+    MergeConflict,
+    MergePolicy,
+    MergeResult,
+    StrategyMarketSet,
+    UnionMergePolicy,
+)
+from .selector import MarketSelector
+
+__all__ = [
+    "MarketSelector",
+    "MergeConflict",
+    "MergePolicy",
+    "MergeResult",
+    "StrategyMarketSet",
+    "UnionMergePolicy",
+]

--- a/src/pms/market_selection/__init__.py
+++ b/src/pms/market_selection/__init__.py
@@ -7,6 +7,7 @@ from .merge import (
     StrategyMarketSet,
     UnionMergePolicy,
 )
+from .subscription_controller import SensorSubscriptionController, SubscriptionSink
 from .selector import MarketSelector
 
 __all__ = [
@@ -14,6 +15,8 @@ __all__ = [
     "MergeConflict",
     "MergePolicy",
     "MergeResult",
+    "SensorSubscriptionController",
     "StrategyMarketSet",
+    "SubscriptionSink",
     "UnionMergePolicy",
 ]

--- a/src/pms/market_selection/merge.py
+++ b/src/pms/market_selection/merge.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyMarketSet:
+    strategy_id: str
+    strategy_version_id: str
+    asset_ids: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class MergeConflict:
+    market_id: str
+    strategy_ids: tuple[str, ...]
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class MergeResult:
+    asset_ids: list[str]
+    conflicts: list[MergeConflict]
+
+
+class MergePolicy(Protocol):
+    def merge(self, selections: Sequence[StrategyMarketSet]) -> MergeResult: ...
+
+
+class UnionMergePolicy:
+    def merge(self, selections: Sequence[StrategyMarketSet]) -> MergeResult:
+        return MergeResult(
+            asset_ids=sorted(
+                {
+                    asset_id
+                    for selection in selections
+                    for asset_id in selection.asset_ids
+                }
+            ),
+            conflicts=[],
+        )

--- a/src/pms/market_selection/selector.py
+++ b/src/pms/market_selection/selector.py
@@ -2,33 +2,23 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 import logging
-from typing import Protocol
 
-import asyncpg
-
+from pms.core.interfaces import MarketDataStore, StrategySelectionRegistry
 from pms.core.models import Market, Token
 from pms.market_selection.merge import MergePolicy, MergeResult, StrategyMarketSet
-from pms.storage.market_data_store import PostgresMarketDataStore
-from pms.strategies.projections import MarketSelectionSpec
 
 
 logger = logging.getLogger(__name__)
 
 
-class StrategySelectionRegistry(Protocol):
-    async def list_market_selections(
-        self,
-    ) -> list[tuple[str, str, MarketSelectionSpec]]: ...
-
-
 class MarketSelector:
     def __init__(
         self,
-        pool: asyncpg.Pool,
+        store: MarketDataStore,
         registry: StrategySelectionRegistry,
         merge_policy: MergePolicy,
     ) -> None:
-        self._store = PostgresMarketDataStore(pool)
+        self._store = store
         self._registry = registry
         self._merge_policy = merge_policy
 
@@ -49,6 +39,7 @@ class MarketSelector:
             eligible_markets = await self._store.read_eligible_markets(
                 spec.venue,
                 spec.resolution_time_max_horizon_days,
+                spec.volume_min_usdc,
             )
             selections.append(
                 StrategyMarketSet(

--- a/src/pms/market_selection/selector.py
+++ b/src/pms/market_selection/selector.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+import logging
+from typing import Protocol
+
+import asyncpg
+
+from pms.core.models import Market, Token
+from pms.market_selection.merge import MergePolicy, MergeResult, StrategyMarketSet
+from pms.storage.market_data_store import PostgresMarketDataStore
+from pms.strategies.projections import MarketSelectionSpec
+
+
+logger = logging.getLogger(__name__)
+
+
+class StrategySelectionRegistry(Protocol):
+    async def list_market_selections(
+        self,
+    ) -> list[tuple[str, str, MarketSelectionSpec]]: ...
+
+
+class MarketSelector:
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        registry: StrategySelectionRegistry,
+        merge_policy: MergePolicy,
+    ) -> None:
+        self._store = PostgresMarketDataStore(pool)
+        self._registry = registry
+        self._merge_policy = merge_policy
+
+    async def select(self) -> MergeResult:
+        strategy_specs = await self._registry.list_market_selections()
+        logger.info(
+            "market selector processed %d active strategies",
+            len(strategy_specs),
+        )
+        if not strategy_specs:
+            logger.warning(
+                "no active_version_id rows found; data sensor will idle until "
+                "a strategy is activated",
+            )
+
+        selections: list[StrategyMarketSet] = []
+        for strategy_id, strategy_version_id, spec in strategy_specs:
+            eligible_markets = await self._store.read_eligible_markets(
+                spec.venue,
+                spec.resolution_time_max_horizon_days,
+            )
+            selections.append(
+                StrategyMarketSet(
+                    strategy_id=strategy_id,
+                    strategy_version_id=strategy_version_id,
+                    asset_ids=_asset_ids_from_eligible_markets(eligible_markets),
+                )
+            )
+        return self._merge_policy.merge(selections)
+
+
+def _asset_ids_from_eligible_markets(
+    eligible_markets: Sequence[tuple[Market, Sequence[Token]]],
+) -> frozenset[str]:
+    return frozenset(
+        token.token_id
+        for _, tokens in eligible_markets
+        for token in tokens
+    )

--- a/src/pms/market_selection/subscription_controller.py
+++ b/src/pms/market_selection/subscription_controller.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Protocol
+
+
+class SubscriptionSink(Protocol):
+    async def update_subscription(self, asset_ids: list[str]) -> None: ...
+
+
+class SensorSubscriptionController:
+    def __init__(self, sink: SubscriptionSink) -> None:
+        self._sink = sink
+        self._lock = asyncio.Lock()
+        self._current_asset_ids: frozenset[str] = frozenset()
+        self._last_updated_at: datetime | None = None
+
+    @property
+    def current_asset_ids(self) -> frozenset[str]:
+        return self._current_asset_ids
+
+    @property
+    def last_updated_at(self) -> datetime | None:
+        return self._last_updated_at
+
+    async def update(self, asset_ids: list[str]) -> bool:
+        async with self._lock:
+            next_asset_ids = frozenset(asset_ids)
+            if next_asset_ids == self._current_asset_ids:
+                return False
+
+            await self._sink.update_subscription(asset_ids)
+            self._current_asset_ids = next_asset_ids
+            self._last_updated_at = datetime.now(tz=UTC)
+            return True

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Awaitable, Protocol, TypeVar, cast, runtime_checkable
 
 import asyncpg
 import httpx
@@ -33,6 +34,11 @@ from pms.evaluation.spool import EvalSpool
 from pms.factors.catalog import ensure_factor_catalog
 from pms.factors.definitions import REGISTERED
 from pms.factors.service import FactorService
+from pms.market_selection import (
+    MarketSelector,
+    SensorSubscriptionController,
+    UnionMergePolicy,
+)
 from pms.sensor.adapters.historical import HistoricalSensor
 from pms.sensor.adapters.market_data import MarketDataSensor
 from pms.sensor.adapters.market_discovery import MarketDiscoverySensor
@@ -50,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BACKTEST_FIXTURE = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
 RUNNER_STATE_LIMIT = 1000
+RESELECTION_INTERVAL_S = 300.0
 RAW_FACTOR_COMPOSITION_ROLES = frozenset(
     {
         "weighted",
@@ -68,6 +75,22 @@ T = TypeVar("T")
 @runtime_checkable
 class AsyncCloseable(Protocol):
     async def aclose(self) -> None: ...
+
+
+class DiscoveryPollCompleteSensor(Protocol):
+    on_poll_complete: Callable[[], Awaitable[None]] | None
+
+
+class SubscriptionManagedSensor(Protocol):
+    async def update_subscription(self, asset_ids: list[str]) -> None: ...
+
+
+class MarketSelectorLike(Protocol):
+    async def select(self) -> Any: ...
+
+
+class SubscriptionControllerLike(Protocol):
+    async def update(self, asset_ids: list[str]) -> bool: ...
 
 
 @dataclass
@@ -109,6 +132,14 @@ class Runner:
     _task: asyncio.Task[None] | None = field(init=False, default=None)
     _pg_pool: asyncpg.Pool | None = field(init=False, default=None)
     _owns_pg_pool: bool = field(init=False, default=False)
+    _market_selector: MarketSelectorLike | None = field(init=False, default=None)
+    _subscription_controller: SubscriptionControllerLike | None = field(
+        init=False,
+        default=None,
+    )
+    _reselection_task: asyncio.Task[None] | None = field(init=False, default=None)
+    _reselection_lock: asyncio.Lock = field(init=False)
+    _reselection_requested: asyncio.Event = field(init=False)
     _active_sensors: tuple[ISensor, ...] = field(init=False, default=())
     _paper_orderbooks: dict[str, dict[str, Any]] = field(
         init=False, default_factory=dict
@@ -120,6 +151,8 @@ class Runner:
         self._evaluator_spool = EvalSpool(store=self.eval_store, scorer=Scorer())
         self._decision_queue = asyncio.Queue()
         self._stop_event = asyncio.Event()
+        self._reselection_lock = asyncio.Lock()
+        self._reselection_requested = asyncio.Event()
         self.actuator_executor = self._build_executor(self.config.mode)
 
     @property
@@ -187,6 +220,8 @@ class Runner:
             tasks.append(self._controller_task)
         if self._actuator_task is not None:
             tasks.append(self._actuator_task)
+        if self._reselection_task is not None:
+            tasks.append(self._reselection_task)
         if self.evaluator_task is not None:
             tasks.append(self.evaluator_task)
         return tuple(tasks)
@@ -221,6 +256,7 @@ class Runner:
                 )
                 self._factor_service_task = asyncio.create_task(self._factor_service.run())
             self._active_sensors = self._build_sensors()
+            self._wire_active_perception(self._active_sensors)
             await self.sensor_stream.start(self._active_sensors)
             await self._evaluator_spool.start()
             self._controller_task = asyncio.create_task(self._controller_loop())
@@ -236,6 +272,11 @@ class Runner:
         factor_task = self._factor_service_task
         if factor_task is not None and not factor_task.done():
             factor_task.cancel()
+        reselection_task = self._reselection_task
+        self._reselection_requested.set()
+        self._clear_discovery_poll_complete_hook()
+        if reselection_task is not None and not reselection_task.done():
+            reselection_task.cancel()
 
         try:
             await self.sensor_stream.stop()
@@ -275,10 +316,19 @@ class Runner:
             if error is None:
                 error = exc
 
+        try:
+            await self._await_cancelled_task(reselection_task)
+        except BaseException as exc:  # pragma: no cover - defensive
+            if error is None:
+                error = exc
+
         self._factor_service = None
         self._factor_service_task = None
         self._controller_task = None
         self._actuator_task = None
+        self._market_selector = None
+        self._subscription_controller = None
+        self._reselection_task = None
 
         try:
             await self._close_pg_pool()
@@ -347,6 +397,32 @@ class Runner:
             ),
             market_data_sensor,
         )
+
+    def _wire_active_perception(self, sensors: tuple[ISensor, ...]) -> None:
+        self._clear_discovery_poll_complete_hook()
+        self._market_selector = None
+        self._subscription_controller = None
+        self._reselection_task = None
+        self._reselection_requested.clear()
+        if self.config.mode == RunMode.BACKTEST:
+            return
+        if self._pg_pool is None:
+            msg = "Runner PostgreSQL pool is not initialized"
+            raise RuntimeError(msg)
+
+        discovery_sensor = _find_discovery_sensor(sensors)
+        subscription_sink = _find_subscription_sink(sensors)
+        if discovery_sensor is None or subscription_sink is None:
+            return
+
+        self._market_selector = MarketSelector(
+            self._pg_pool,
+            PostgresStrategyRegistry(self._pg_pool),
+            UnionMergePolicy(),
+        )
+        self._subscription_controller = SensorSubscriptionController(subscription_sink)
+        discovery_sensor.on_poll_complete = self._request_reselection
+        self._reselection_task = asyncio.create_task(self._periodic_reselection_loop())
 
     def _assert_no_legacy_jsonl_paths(self) -> None:
         for store in (self.eval_store, self.feedback_store):
@@ -499,6 +575,7 @@ class Runner:
         )
 
     async def _close_active_sensors(self) -> None:
+        self._clear_discovery_poll_complete_hook()
         for sensor in self._active_sensors:
             if isinstance(sensor, AsyncCloseable):
                 await sensor.aclose()
@@ -511,11 +588,27 @@ class Runner:
         stop_error: BaseException | None = None
         if self._factor_service_task is not None and not self._factor_service_task.done():
             self._factor_service_task.cancel()
+        reselection_task = self._reselection_task
+        self._reselection_requested.set()
+        self._clear_discovery_poll_complete_hook()
+        if reselection_task is not None and not reselection_task.done():
+            reselection_task.cancel()
         try:
-            if self._factor_service_task is not None:
-                await asyncio.gather(self._factor_service_task, return_exceptions=True)
+            await asyncio.gather(
+                *(
+                    task
+                    for task in (self._factor_service_task,)
+                    if task is not None
+                ),
+                return_exceptions=True,
+            )
         except BaseException as exc:  # pragma: no cover - defensive
             stop_error = exc
+        try:
+            await self._await_cancelled_task(reselection_task)
+        except BaseException as exc:  # pragma: no cover - defensive
+            if stop_error is None:
+                stop_error = exc
         try:
             await self.sensor_stream.stop()
         except BaseException as exc:  # pragma: no cover - defensive
@@ -538,10 +631,58 @@ class Runner:
         self._factor_service_task = None
         self._controller_task = None
         self._actuator_task = None
+        self._market_selector = None
+        self._subscription_controller = None
+        self._reselection_task = None
         await self._close_pg_pool()
 
         if stop_error is not None:
             raise stop_error
+
+    async def _reselect(self) -> None:
+        selector = self._market_selector
+        subscription_controller = self._subscription_controller
+        if selector is None or subscription_controller is None:
+            return
+        async with self._reselection_lock:
+            result = await selector.select()
+            await subscription_controller.update(list(result.asset_ids))
+
+    async def _periodic_reselection_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.wait_for(
+                    self._reselection_requested.wait(),
+                    timeout=RESELECTION_INTERVAL_S,
+                )
+                self._reselection_requested.clear()
+                if self._stop_event.is_set():
+                    return
+                await self._reselect()
+            except TimeoutError:
+                if self._stop_event.is_set():
+                    return
+                try:
+                    await self._reselect()
+                except Exception as error:  # noqa: BLE001
+                    logger.warning("periodic reselection failed: %s", error)
+
+    def _clear_discovery_poll_complete_hook(self) -> None:
+        discovery_sensor = _find_discovery_sensor(self._active_sensors)
+        if discovery_sensor is not None:
+            discovery_sensor.on_poll_complete = None
+
+    async def _request_reselection(self) -> None:
+        self._reselection_requested.set()
+
+    async def _await_cancelled_task(
+        self,
+        task: asyncio.Task[None] | None,
+    ) -> None:
+        if task is None:
+            return
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 def _append_bounded(items: list[T], item: T) -> None:
@@ -549,6 +690,25 @@ def _append_bounded(items: list[T], item: T) -> None:
     overflow = len(items) - RUNNER_STATE_LIMIT
     if overflow > 0:
         del items[:overflow]
+
+
+def _find_discovery_sensor(
+    sensors: Sequence[ISensor],
+) -> DiscoveryPollCompleteSensor | None:
+    for sensor in sensors:
+        if hasattr(sensor, "on_poll_complete"):
+            return cast(DiscoveryPollCompleteSensor, sensor)
+    return None
+
+
+def _find_subscription_sink(
+    sensors: Sequence[ISensor],
+) -> SubscriptionManagedSensor | None:
+    for sensor in sensors:
+        update_subscription = getattr(sensor, "update_subscription", None)
+        if callable(update_subscription):
+            return cast(SubscriptionManagedSensor, sensor)
+    return None
 
 
 def _fill_from_order(

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Awaitable, Protocol, TypeVar, cast, runtime_checkable
+from typing import Any, Protocol, TypeVar, cast, runtime_checkable
 
 import asyncpg
 import httpx
@@ -20,7 +20,13 @@ from pms.actuator.risk import RiskManager
 from pms.config import PMSSettings
 from pms.controller.pipeline import ControllerPipeline
 from pms.core.enums import OrderStatus, RunMode
-from pms.core.interfaces import ISensor
+from pms.core.interfaces import (
+    DiscoveryPollCompleteSensor,
+    ISensor,
+    MarketSelectorLike,
+    SubscriptionControllerLike,
+    SubscriptionManagedSensor,
+)
 from pms.core.models import (
     FillRecord,
     MarketSignal,
@@ -75,28 +81,6 @@ T = TypeVar("T")
 @runtime_checkable
 class AsyncCloseable(Protocol):
     async def aclose(self) -> None: ...
-
-
-class DiscoveryPollCompleteSensor(Protocol):
-    on_poll_complete: Callable[[], Awaitable[None]] | None
-
-
-class SubscriptionManagedSensor(Protocol):
-    async def update_subscription(self, asset_ids: list[str]) -> None: ...
-
-
-class MarketSelectorLike(Protocol):
-    async def select(self) -> Any: ...
-
-
-class SubscriptionControllerLike(Protocol):
-    async def update(self, asset_ids: list[str]) -> bool: ...
-
-    @property
-    def current_asset_ids(self) -> frozenset[str]: ...
-
-    @property
-    def last_updated_at(self) -> datetime | None: ...
 
 
 @dataclass
@@ -221,11 +205,8 @@ class Runner:
         return self._active_sensors
 
     @property
-    def subscription_controller(self) -> SensorSubscriptionController | None:
-        controller = self._subscription_controller
-        if controller is None:
-            return None
-        return cast(SensorSubscriptionController, controller)
+    def subscription_controller(self) -> SubscriptionControllerLike | None:
+        return self._subscription_controller
 
     @property
     def strategy_registry(self) -> PostgresStrategyRegistry | None:
@@ -445,7 +426,7 @@ class Runner:
             msg = "Runner strategy registry is not initialized"
             raise RuntimeError(msg)
         self._market_selector = MarketSelector(
-            self._pg_pool,
+            PostgresMarketDataStore(self._pg_pool),
             self._strategy_registry,
             UnionMergePolicy(),
         )

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -143,6 +143,10 @@ class Runner:
         init=False,
         default=None,
     )
+    _strategy_registry: PostgresStrategyRegistry | None = field(
+        init=False,
+        default=None,
+    )
     _reselection_task: asyncio.Task[None] | None = field(init=False, default=None)
     _reselection_lock: asyncio.Lock = field(init=False)
     _reselection_requested: asyncio.Event = field(init=False)
@@ -224,6 +228,10 @@ class Runner:
         return cast(SensorSubscriptionController, controller)
 
     @property
+    def strategy_registry(self) -> PostgresStrategyRegistry | None:
+        return self._strategy_registry
+
+    @property
     def tasks(self) -> tuple[asyncio.Task[None], ...]:
         tasks: list[asyncio.Task[None]] = []
         tasks.extend(self.sensor_stream.tasks)
@@ -254,6 +262,10 @@ class Runner:
                 if self._pg_pool is None:
                     msg = "Runner PostgreSQL pool is not initialized"
                     raise RuntimeError(msg)
+                self._strategy_registry = PostgresStrategyRegistry(
+                    self._pg_pool,
+                    on_strategy_change=self._request_reselection,
+                )
                 await ensure_factor_catalog(self._pg_pool)
                 await self._ensure_default_v2_version()
                 if self._pg_pool is None:
@@ -341,6 +353,7 @@ class Runner:
         self._actuator_task = None
         self._market_selector = None
         self._subscription_controller = None
+        self._strategy_registry = None
         self._reselection_task = None
 
         try:
@@ -428,12 +441,12 @@ class Runner:
         if discovery_sensor is None or subscription_sink is None:
             return
 
+        if self._strategy_registry is None:
+            msg = "Runner strategy registry is not initialized"
+            raise RuntimeError(msg)
         self._market_selector = MarketSelector(
             self._pg_pool,
-            PostgresStrategyRegistry(
-                self._pg_pool,
-                on_strategy_change=self._request_reselection,
-            ),
+            self._strategy_registry,
             UnionMergePolicy(),
         )
         self._subscription_controller = SensorSubscriptionController(subscription_sink)
@@ -471,7 +484,10 @@ class Runner:
         if active_version_id != "default-v1":
             return
 
-        registry = PostgresStrategyRegistry(self._pg_pool)
+        registry = self._strategy_registry
+        if registry is None:
+            msg = "Runner strategy registry is not initialized"
+            raise RuntimeError(msg)
         strategy = await registry.get_by_id("default")
         if strategy is None:
             return
@@ -649,6 +665,7 @@ class Runner:
         self._actuator_task = None
         self._market_selector = None
         self._subscription_controller = None
+        self._strategy_registry = None
         self._reselection_task = None
         await self._close_pg_pool()
 
@@ -674,7 +691,10 @@ class Runner:
                 self._reselection_requested.clear()
                 if self._stop_event.is_set():
                     return
-                await self._reselect()
+                try:
+                    await self._reselect()
+                except Exception as error:  # noqa: BLE001
+                    logger.warning("periodic reselection failed: %s", error)
             except TimeoutError:
                 if self._stop_event.is_set():
                     return

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -417,7 +417,10 @@ class Runner:
 
         self._market_selector = MarketSelector(
             self._pg_pool,
-            PostgresStrategyRegistry(self._pg_pool),
+            PostgresStrategyRegistry(
+                self._pg_pool,
+                on_strategy_change=self._request_reselection,
+            ),
             UnionMergePolicy(),
         )
         self._subscription_controller = SensorSubscriptionController(subscription_sink)

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -92,6 +92,12 @@ class MarketSelectorLike(Protocol):
 class SubscriptionControllerLike(Protocol):
     async def update(self, asset_ids: list[str]) -> bool: ...
 
+    @property
+    def current_asset_ids(self) -> frozenset[str]: ...
+
+    @property
+    def last_updated_at(self) -> datetime | None: ...
+
 
 @dataclass
 class RunnerState:
@@ -209,6 +215,13 @@ class Runner:
     @property
     def active_sensors(self) -> tuple[ISensor, ...]:
         return self._active_sensors
+
+    @property
+    def subscription_controller(self) -> SensorSubscriptionController | None:
+        controller = self._subscription_controller
+        if controller is None:
+            return None
+        return cast(SensorSubscriptionController, controller)
 
     @property
     def tasks(self) -> tuple[asyncio.Task[None], ...]:

--- a/src/pms/sensor/CLAUDE.md
+++ b/src/pms/sensor/CLAUDE.md
@@ -29,7 +29,7 @@ that governs this layer:
   `MarketSignal` with no knowledge of which strategy consumes it.
 - **Invariant 6 — Subscription sink.** The `MarketDataSensor`
   accepts subscription updates *from outside* (pushed by
-  `SensorSubscriptionController`, lands in S4). It never pulls the
+  `SensorSubscriptionController`, landed in S4). It never pulls the
   subscription list itself; it receives it.
 - **Invariant 7 — Two-layer structure.** There are exactly two
   sensor types per venue:

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -127,6 +127,9 @@ def _gamma_market_to_market(row: dict[str, Any], fetched_at: datetime) -> Market
         resolves_at=_optional_datetime(row.get("endDateIso")),
         created_at=created_at,
         last_seen_at=fetched_at,
+        volume_24h=_optional_float(
+            _first_non_empty_value(row.get("volume24hr"), row.get("volume_24h"))
+        ),
     )
 
 
@@ -185,3 +188,19 @@ def _optional_datetime(value: object) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=UTC)
     return parsed
+
+
+def _first_non_empty_value(*values: object) -> object | None:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        msg = "expected a float-compatible value"
+        raise TypeError(msg)
+    return float(value)

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any, Awaitable, Callable, cast
 
 import asyncpg
 import httpx
@@ -23,6 +23,7 @@ class MarketDiscoverySensor:
     store: PostgresMarketDataStore
     http_client: httpx.AsyncClient
     poll_interval_s: float = 60.0
+    on_poll_complete: Callable[[], Awaitable[None]] | None = None
 
     _INITIAL_BACKOFF_S = 1.0
     _MAX_BACKOFF_S = 30.0
@@ -39,6 +40,11 @@ class MarketDiscoverySensor:
         while True:
             try:
                 await self.poll_once()
+                if self.on_poll_complete is not None:
+                    try:
+                        await self.on_poll_complete()
+                    except Exception as error:  # noqa: BLE001
+                        logger.warning("discovery poll completion hook failed: %s", error)
                 backoff = self._INITIAL_BACKOFF_S
                 await asyncio.sleep(self.poll_interval_s)
             except httpx.HTTPStatusError as error:

--- a/src/pms/storage/market_data_store.py
+++ b/src/pms/storage/market_data_store.py
@@ -27,7 +27,7 @@ class PostgresMarketDataStore:
 
     async def read_market(self, market_id: str) -> Market | None:
         query = """
-        SELECT condition_id, slug, question, venue, resolves_at, created_at, last_seen_at
+        SELECT condition_id, slug, question, venue, resolves_at, created_at, last_seen_at, volume_24h
         FROM markets
         WHERE condition_id = $1
         """
@@ -43,6 +43,7 @@ class PostgresMarketDataStore:
             resolves_at=row["resolves_at"],
             created_at=row["created_at"],
             last_seen_at=row["last_seen_at"],
+            volume_24h=row["volume_24h"],
         )
 
     async def read_tokens_for_market(self, market_id: str) -> list[Token]:
@@ -67,6 +68,7 @@ class PostgresMarketDataStore:
         self,
         venue: str,
         max_horizon_days: int | None,
+        min_volume_usdc: float,
     ) -> list[tuple[Market, list[Token]]]:
         now = datetime.now(tz=UTC)
         upper_bound = (
@@ -83,12 +85,20 @@ class PostgresMarketDataStore:
             markets.resolves_at,
             markets.created_at,
             markets.last_seen_at,
+            markets.volume_24h,
             tokens.token_id,
             tokens.outcome
         FROM markets
         LEFT JOIN tokens
             ON tokens.condition_id = markets.condition_id
         WHERE markets.venue = $1
+          AND (
+                $4::double precision <= 0
+                OR (
+                    markets.volume_24h IS NOT NULL
+                    AND markets.volume_24h >= $4
+                )
+          )
           AND (
                 (
                     $3::timestamptz IS NULL
@@ -110,7 +120,7 @@ class PostgresMarketDataStore:
             tokens.token_id ASC
         """
         async with self._pool.acquire() as connection:
-            rows = await connection.fetch(query, venue, now, upper_bound)
+            rows = await connection.fetch(query, venue, now, upper_bound, min_volume_usdc)
 
         eligible_markets: list[tuple[Market, list[Token]]] = []
         current_market_id: str | None = None
@@ -131,6 +141,7 @@ class PostgresMarketDataStore:
                             resolves_at=cast(datetime | None, row["resolves_at"]),
                             created_at=cast(datetime, row["created_at"]),
                             last_seen_at=cast(datetime, row["last_seen_at"]),
+                            volume_24h=cast(float | None, row["volume_24h"]),
                         ),
                         current_tokens,
                     )
@@ -162,14 +173,16 @@ class PostgresMarketDataStore:
             venue,
             resolves_at,
             created_at,
-            last_seen_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            last_seen_at,
+            volume_24h
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         ON CONFLICT (condition_id) DO UPDATE
         SET slug = EXCLUDED.slug,
             question = EXCLUDED.question,
             venue = EXCLUDED.venue,
             resolves_at = EXCLUDED.resolves_at,
-            last_seen_at = EXCLUDED.last_seen_at
+            last_seen_at = EXCLUDED.last_seen_at,
+            volume_24h = EXCLUDED.volume_24h
         """
         async with self._pool.acquire() as connection:
             await connection.execute(
@@ -181,6 +194,7 @@ class PostgresMarketDataStore:
                 market.resolves_at,
                 market.created_at,
                 market.last_seen_at,
+                market.volume_24h,
             )
 
     async def write_token(self, token: Token) -> None:

--- a/src/pms/storage/market_data_store.py
+++ b/src/pms/storage/market_data_store.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
 import asyncpg
 
 from pms.core.models import (
     BookLevel,
     BookSnapshot,
     Market,
+    Outcome,
     PriceChange,
     Token,
     Trade,
+    Venue,
 )
 
 
@@ -57,6 +62,96 @@ class PostgresMarketDataStore:
             )
             for row in rows
         ]
+
+    async def read_eligible_markets(
+        self,
+        venue: str,
+        max_horizon_days: int | None,
+    ) -> list[tuple[Market, list[Token]]]:
+        now = datetime.now(tz=UTC)
+        upper_bound = (
+            None
+            if max_horizon_days is None
+            else now + timedelta(days=max_horizon_days)
+        )
+        query = """
+        SELECT
+            markets.condition_id,
+            markets.slug,
+            markets.question,
+            markets.venue,
+            markets.resolves_at,
+            markets.created_at,
+            markets.last_seen_at,
+            tokens.token_id,
+            tokens.outcome
+        FROM markets
+        LEFT JOIN tokens
+            ON tokens.condition_id = markets.condition_id
+        WHERE markets.venue = $1
+          AND (
+                (
+                    $3::timestamptz IS NULL
+                    AND (
+                        markets.resolves_at IS NULL
+                        OR markets.resolves_at > $2
+                    )
+                )
+                OR (
+                    $3::timestamptz IS NOT NULL
+                    AND markets.resolves_at IS NOT NULL
+                    AND markets.resolves_at > $2
+                    AND markets.resolves_at <= $3
+                )
+          )
+        ORDER BY
+            markets.condition_id ASC,
+            CASE tokens.outcome WHEN 'YES' THEN 0 WHEN 'NO' THEN 1 ELSE 2 END,
+            tokens.token_id ASC
+        """
+        async with self._pool.acquire() as connection:
+            rows = await connection.fetch(query, venue, now, upper_bound)
+
+        eligible_markets: list[tuple[Market, list[Token]]] = []
+        current_market_id: str | None = None
+        current_tokens: list[Token] | None = None
+
+        for row in rows:
+            market_id = cast(str, row["condition_id"])
+            if market_id != current_market_id:
+                current_market_id = market_id
+                current_tokens = []
+                eligible_markets.append(
+                    (
+                        Market(
+                            condition_id=market_id,
+                            slug=cast(str, row["slug"]),
+                            question=cast(str, row["question"]),
+                            venue=cast(Venue, row["venue"]),
+                            resolves_at=cast(datetime | None, row["resolves_at"]),
+                            created_at=cast(datetime, row["created_at"]),
+                            last_seen_at=cast(datetime, row["last_seen_at"]),
+                        ),
+                        current_tokens,
+                    )
+                )
+
+            token_id = row["token_id"]
+            outcome = row["outcome"]
+            if (
+                current_tokens is not None
+                and token_id is not None
+                and outcome is not None
+            ):
+                current_tokens.append(
+                    Token(
+                        token_id=cast(str, token_id),
+                        condition_id=market_id,
+                        outcome=cast(Outcome, outcome),
+                    )
+                )
+
+        return eligible_markets
 
     async def write_market(self, market: Market) -> None:
         query = """

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime
+import logging
 from typing import Any, cast
 
 import asyncpg
@@ -24,9 +25,17 @@ from pms.strategies.versioning import (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 class PostgresStrategyRegistry:
-    def __init__(self, pool: asyncpg.Pool) -> None:
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        on_strategy_change: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
         self._pool = pool
+        self._on_strategy_change = on_strategy_change
 
     async def create_strategy(
         self,
@@ -117,6 +126,7 @@ class PostgresStrategyRegistry:
                     strategy_id,
                     strategy_version_id,
                 )
+        await self._notify_strategy_change()
         return StrategyVersion(
             strategy_id=strategy_id,
             strategy_version_id=strategy_version_id,
@@ -216,6 +226,7 @@ class PostgresStrategyRegistry:
         """
         async with self._pool.acquire() as connection:
             await connection.execute(query, strategy_id, strategy_version_id)
+        await self._notify_strategy_change()
 
     async def populate_strategy_factors(
         self,
@@ -246,6 +257,14 @@ class PostgresStrategyRegistry:
                         step.weight,
                         "long",
                     )
+
+    async def _notify_strategy_change(self) -> None:
+        if self._on_strategy_change is None:
+            return
+        try:
+            await self._on_strategy_change()
+        except Exception as error:  # noqa: BLE001
+            logger.warning("strategy change callback failed: %s", error)
 
 
 def _ensure_utc(value: object) -> datetime:

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -172,6 +172,38 @@ class PostgresStrategyRegistry:
             for row in rows
         ]
 
+    async def list_market_selections(
+        self,
+    ) -> list[tuple[str, str, MarketSelectionSpec]]:
+        query = """
+        SELECT
+            strategies.strategy_id,
+            strategies.active_version_id AS strategy_version_id,
+            versions.config_json
+        FROM strategies
+        JOIN strategy_versions AS versions
+            ON versions.strategy_id = strategies.strategy_id
+           AND versions.strategy_version_id = strategies.active_version_id
+        WHERE strategies.active_version_id IS NOT NULL
+        ORDER BY strategies.strategy_id ASC
+        """
+        async with self._pool.acquire() as connection:
+            rows = await connection.fetch(query)
+        selections: list[tuple[str, str, MarketSelectionSpec]] = []
+        for row in rows:
+            strategy_version_id = row["strategy_version_id"]
+            if not isinstance(strategy_version_id, str):
+                msg = "strategies.active_version_id did not return a string"
+                raise TypeError(msg)
+            selections.append(
+                (
+                    _json_string(row["strategy_id"], "strategy_id"),
+                    strategy_version_id,
+                    _market_selection_from_config_json(row["config_json"]),
+                )
+            )
+        return selections
+
     async def set_active(
         self,
         strategy_id: str,
@@ -291,6 +323,25 @@ def _strategy_from_config_json(raw_value: object) -> Strategy:
                 market_selection_payload["volume_min_usdc"],
                 "market_selection.volume_min_usdc",
             ),
+        ),
+    )
+
+
+def _market_selection_from_config_json(raw_value: object) -> MarketSelectionSpec:
+    payload = _load_json_object(raw_value)
+    market_selection_payload = _json_object(
+        payload["market_selection"],
+        "market_selection",
+    )
+    return MarketSelectionSpec(
+        venue=_json_string(market_selection_payload["venue"], "market_selection.venue"),
+        resolution_time_max_horizon_days=_json_optional_int(
+            market_selection_payload["resolution_time_max_horizon_days"],
+            "market_selection.resolution_time_max_horizon_days",
+        ),
+        volume_min_usdc=_json_float(
+            market_selection_payload["volume_min_usdc"],
+            "market_selection.volume_min_usdc",
         ),
     )
 

--- a/tests/integration/test_market_selection_store.py
+++ b/tests/integration/test_market_selection_store.py
@@ -31,6 +31,7 @@ def _market(
     venue: str,
     resolves_at: datetime | None,
     created_at: datetime,
+    volume_24h: float,
 ) -> Market:
     return Market(
         condition_id=condition_id,
@@ -40,6 +41,7 @@ def _market(
         resolves_at=resolves_at,
         created_at=created_at,
         last_seen_at=created_at,
+        volume_24h=volume_24h,
     )
 
 
@@ -68,30 +70,42 @@ async def test_read_eligible_markets_filters_by_venue_and_horizon_and_keeps_null
         venue="polymarket",
         resolves_at=now + timedelta(days=10),
         created_at=now,
+        volume_24h=1_000.0,
     )
     future_out_of_horizon = _market(
         condition_id="market-out-of-horizon",
         venue="polymarket",
         resolves_at=now + timedelta(days=60),
         created_at=now,
+        volume_24h=1_000.0,
     )
     already_resolved = _market(
         condition_id="market-past",
         venue="polymarket",
         resolves_at=now - timedelta(days=1),
         created_at=now,
+        volume_24h=1_000.0,
     )
     no_resolves_at = _market(
         condition_id="market-open-ended",
         venue="polymarket",
         resolves_at=None,
         created_at=now,
+        volume_24h=1_000.0,
     )
     other_venue = _market(
         condition_id="market-kalshi",
         venue="kalshi",
         resolves_at=now + timedelta(days=5),
         created_at=now,
+        volume_24h=1_000.0,
+    )
+    low_volume = _market(
+        condition_id="market-low-volume",
+        venue="polymarket",
+        resolves_at=now + timedelta(days=3),
+        created_at=now,
+        volume_24h=100.0,
     )
 
     for market in (
@@ -100,6 +114,7 @@ async def test_read_eligible_markets_filters_by_venue_and_horizon_and_keeps_null
         already_resolved,
         no_resolves_at,
         other_venue,
+        low_volume,
     ):
         await store.write_market(market)
 
@@ -118,9 +133,12 @@ async def test_read_eligible_markets_filters_by_venue_and_horizon_and_keeps_null
     await store.write_token(
         _token(token_id="other-yes", condition_id=other_venue.condition_id, outcome="YES")
     )
+    await store.write_token(
+        _token(token_id="low-yes", condition_id=low_volume.condition_id, outcome="YES")
+    )
 
-    bounded = await store.read_eligible_markets("polymarket", 30)
-    open_horizon = await store.read_eligible_markets("polymarket", None)
+    bounded = await store.read_eligible_markets("polymarket", 30, 500.0)
+    open_horizon = await store.read_eligible_markets("polymarket", None, 500.0)
 
     assert [market.condition_id for market, _ in bounded] == ["market-in-horizon"]
     assert [token.token_id for token in bounded[0][1]] == ["in-yes", "in-no"]
@@ -140,4 +158,4 @@ async def test_read_eligible_markets_returns_empty_list_when_no_rows_match(
 ) -> None:
     store = PostgresMarketDataStore(pg_pool)
 
-    assert await store.read_eligible_markets("polymarket", 7) == []
+    assert await store.read_eligible_markets("polymarket", 7, 500.0) == []

--- a/tests/integration/test_market_selection_store.py
+++ b/tests/integration/test_market_selection_store.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import asyncpg
+import pytest
+
+from pms.core.models import Market, Token
+from pms.storage.market_data_store import PostgresMarketDataStore
+
+
+PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run PostgreSQL integration tests",
+    ),
+    pytest.mark.skipif(
+        PMS_TEST_DATABASE_URL is None,
+        reason="set PMS_TEST_DATABASE_URL to the compose-backed PostgreSQL URI",
+    ),
+]
+
+
+def _market(
+    *,
+    condition_id: str,
+    venue: str,
+    resolves_at: datetime | None,
+    created_at: datetime,
+) -> Market:
+    return Market(
+        condition_id=condition_id,
+        slug=condition_id,
+        question=f"Will {condition_id} resolve?",
+        venue=venue,  # type: ignore[arg-type]
+        resolves_at=resolves_at,
+        created_at=created_at,
+        last_seen_at=created_at,
+    )
+
+
+def _token(
+    *,
+    token_id: str,
+    condition_id: str,
+    outcome: str,
+) -> Token:
+    return Token(
+        token_id=token_id,
+        condition_id=condition_id,
+        outcome=outcome,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_read_eligible_markets_filters_by_venue_and_horizon_and_keeps_null_resolves_at_for_open_horizon(
+    pg_pool: asyncpg.Pool,
+) -> None:
+    store = PostgresMarketDataStore(pg_pool)
+    now = datetime.now(tz=UTC)
+
+    future_in_horizon = _market(
+        condition_id="market-in-horizon",
+        venue="polymarket",
+        resolves_at=now + timedelta(days=10),
+        created_at=now,
+    )
+    future_out_of_horizon = _market(
+        condition_id="market-out-of-horizon",
+        venue="polymarket",
+        resolves_at=now + timedelta(days=60),
+        created_at=now,
+    )
+    already_resolved = _market(
+        condition_id="market-past",
+        venue="polymarket",
+        resolves_at=now - timedelta(days=1),
+        created_at=now,
+    )
+    no_resolves_at = _market(
+        condition_id="market-open-ended",
+        venue="polymarket",
+        resolves_at=None,
+        created_at=now,
+    )
+    other_venue = _market(
+        condition_id="market-kalshi",
+        venue="kalshi",
+        resolves_at=now + timedelta(days=5),
+        created_at=now,
+    )
+
+    for market in (
+        future_in_horizon,
+        future_out_of_horizon,
+        already_resolved,
+        no_resolves_at,
+        other_venue,
+    ):
+        await store.write_market(market)
+
+    await store.write_token(
+        _token(token_id="in-yes", condition_id=future_in_horizon.condition_id, outcome="YES")
+    )
+    await store.write_token(
+        _token(token_id="in-no", condition_id=future_in_horizon.condition_id, outcome="NO")
+    )
+    await store.write_token(
+        _token(token_id="out-yes", condition_id=future_out_of_horizon.condition_id, outcome="YES")
+    )
+    await store.write_token(
+        _token(token_id="past-yes", condition_id=already_resolved.condition_id, outcome="YES")
+    )
+    await store.write_token(
+        _token(token_id="other-yes", condition_id=other_venue.condition_id, outcome="YES")
+    )
+
+    bounded = await store.read_eligible_markets("polymarket", 30)
+    open_horizon = await store.read_eligible_markets("polymarket", None)
+
+    assert [market.condition_id for market, _ in bounded] == ["market-in-horizon"]
+    assert [token.token_id for token in bounded[0][1]] == ["in-yes", "in-no"]
+
+    assert [market.condition_id for market, _ in open_horizon] == [
+        "market-in-horizon",
+        "market-open-ended",
+        "market-out-of-horizon",
+    ]
+    assert [token.token_id for token in open_horizon[0][1]] == ["in-yes", "in-no"]
+    assert open_horizon[1][1] == []
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_read_eligible_markets_returns_empty_list_when_no_rows_match(
+    pg_pool: asyncpg.Pool,
+) -> None:
+    store = PostgresMarketDataStore(pg_pool)
+
+    assert await store.read_eligible_markets("polymarket", 7) == []

--- a/tests/integration/test_market_selector.py
+++ b/tests/integration/test_market_selector.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import asyncpg
 import pytest
 
-from pms.core.models import Market, Outcome, Token, Venue
+from pms.core.models import Market, Token, Venue
 from pms.storage.market_data_store import PostgresMarketDataStore
 from pms.storage.strategy_registry import PostgresStrategyRegistry
 from pms.strategies.aggregate import Strategy
@@ -122,14 +122,14 @@ async def _seed_market(
         Token(
             token_id=f"{market_id}-yes",
             condition_id=market_id,
-            outcome=cast(Outcome, "YES"),
+            outcome="YES",
         )
     )
     await store.write_token(
         Token(
             token_id=f"{market_id}-no",
             condition_id=market_id,
-            outcome=cast(Outcome, "NO"),
+            outcome="NO",
         )
     )
 
@@ -164,31 +164,31 @@ async def test_market_selector_returns_merged_asset_ids_from_active_strategies(
     await _seed_market(
         store,
         market_id="pm-fast",
-        venue=cast(Venue, "polymarket"),
+        venue="polymarket",
         resolves_at=now + timedelta(days=5),
     )
     await _seed_market(
         store,
         market_id="pm-slow",
-        venue=cast(Venue, "polymarket"),
+        venue="polymarket",
         resolves_at=now + timedelta(days=45),
     )
     await _seed_market(
         store,
         market_id="pm-past",
-        venue=cast(Venue, "polymarket"),
+        venue="polymarket",
         resolves_at=now - timedelta(days=1),
     )
     await _seed_market(
         store,
         market_id="ka-near",
-        venue=cast(Venue, "kalshi"),
+        venue="kalshi",
         resolves_at=now + timedelta(days=4),
     )
     await _seed_market(
         store,
         market_id="ka-far",
-        venue=cast(Venue, "kalshi"),
+        venue="kalshi",
         resolves_at=now + timedelta(days=20),
     )
 

--- a/tests/integration/test_market_selector.py
+++ b/tests/integration/test_market_selector.py
@@ -69,6 +69,7 @@ def _strategy(
     *,
     venue: str,
     resolution_time_max_horizon_days: int | None,
+    volume_min_usdc: float = 500.0,
 ) -> Strategy:
     return Strategy(
         config=StrategyConfig(
@@ -94,7 +95,7 @@ def _strategy(
         market_selection=MarketSelectionSpec(
             venue=venue,
             resolution_time_max_horizon_days=resolution_time_max_horizon_days,
-            volume_min_usdc=500.0,
+            volume_min_usdc=volume_min_usdc,
         ),
     )
 
@@ -105,6 +106,7 @@ async def _seed_market(
     market_id: str,
     venue: Venue,
     resolves_at: datetime | None,
+    volume_24h: float,
 ) -> None:
     created_at = datetime(2026, 4, 18, 9, 0, tzinfo=UTC)
     await store.write_market(
@@ -116,6 +118,7 @@ async def _seed_market(
             resolves_at=resolves_at,
             created_at=created_at,
             last_seen_at=created_at,
+            volume_24h=volume_24h,
         )
     )
     await store.write_token(
@@ -157,6 +160,7 @@ async def test_market_selector_returns_merged_asset_ids_from_active_strategies(
             "kalshi-near",
             venue="kalshi",
             resolution_time_max_horizon_days=10,
+            volume_min_usdc=1_000.0,
         )
     )
     await registry.create_strategy("inactive", metadata={"owner": "system"})
@@ -166,34 +170,53 @@ async def test_market_selector_returns_merged_asset_ids_from_active_strategies(
         market_id="pm-fast",
         venue="polymarket",
         resolves_at=now + timedelta(days=5),
+        volume_24h=800.0,
     )
     await _seed_market(
         store,
         market_id="pm-slow",
         venue="polymarket",
         resolves_at=now + timedelta(days=45),
+        volume_24h=800.0,
     )
     await _seed_market(
         store,
         market_id="pm-past",
         venue="polymarket",
         resolves_at=now - timedelta(days=1),
+        volume_24h=800.0,
+    )
+    await _seed_market(
+        store,
+        market_id="pm-low-volume",
+        venue="polymarket",
+        resolves_at=now + timedelta(days=2),
+        volume_24h=100.0,
     )
     await _seed_market(
         store,
         market_id="ka-near",
         venue="kalshi",
         resolves_at=now + timedelta(days=4),
+        volume_24h=1_500.0,
     )
     await _seed_market(
         store,
         market_id="ka-far",
         venue="kalshi",
         resolves_at=now + timedelta(days=20),
+        volume_24h=1_500.0,
+    )
+    await _seed_market(
+        store,
+        market_id="ka-low-volume",
+        venue="kalshi",
+        resolves_at=now + timedelta(days=3),
+        volume_24h=200.0,
     )
 
     selector = market_selector_cls(
-        pool=pool,
+        store=store,
         registry=registry,
         merge_policy=union_merge_policy_cls(),
     )

--- a/tests/integration/test_market_selector.py
+++ b/tests/integration/test_market_selector.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import importlib
+import os
+from typing import Any, cast
+
+import asyncpg
+import pytest
+
+from pms.core.models import Market, Outcome, Token, Venue
+from pms.storage.market_data_store import PostgresMarketDataStore
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+
+PMS_TEST_DATABASE_URL = os.environ.get("PMS_TEST_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run PostgreSQL integration tests",
+    ),
+    pytest.mark.skipif(
+        PMS_TEST_DATABASE_URL is None,
+        reason="set PMS_TEST_DATABASE_URL to the compose-backed PostgreSQL URI",
+    ),
+]
+
+
+class _AcquireConnection:
+    def __init__(self, connection: asyncpg.Connection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> asyncpg.Connection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class _SingleConnectionPool:
+    def __init__(self, connection: asyncpg.Connection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> _AcquireConnection:
+        return _AcquireConnection(self._connection)
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in red phase
+        pytest.fail(f"{module_name} is missing: {exc}")
+    return getattr(module, symbol_name)
+
+
+def _strategy(
+    strategy_id: str,
+    *,
+    venue: str,
+    resolution_time_max_horizon_days: int | None,
+) -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=strategy_id,
+            factor_composition=(
+                FactorCompositionStep(
+                    factor_id="factor-a",
+                    role="weighted",
+                    param="",
+                    weight=1.0,
+                    threshold=None,
+                ),
+            ),
+            metadata=(("owner", "system"), ("tier", "default")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier",)),
+        forecaster=ForecasterSpec(forecasters=(("rules", (("threshold", "0.55"),)),)),
+        market_selection=MarketSelectionSpec(
+            venue=venue,
+            resolution_time_max_horizon_days=resolution_time_max_horizon_days,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
+async def _seed_market(
+    store: PostgresMarketDataStore,
+    *,
+    market_id: str,
+    venue: Venue,
+    resolves_at: datetime | None,
+) -> None:
+    created_at = datetime(2026, 4, 18, 9, 0, tzinfo=UTC)
+    await store.write_market(
+        Market(
+            condition_id=market_id,
+            slug=f"slug-{market_id}",
+            question=f"Question {market_id}",
+            venue=venue,
+            resolves_at=resolves_at,
+            created_at=created_at,
+            last_seen_at=created_at,
+        )
+    )
+    await store.write_token(
+        Token(
+            token_id=f"{market_id}-yes",
+            condition_id=market_id,
+            outcome=cast(Outcome, "YES"),
+        )
+    )
+    await store.write_token(
+        Token(
+            token_id=f"{market_id}-no",
+            condition_id=market_id,
+            outcome=cast(Outcome, "NO"),
+        )
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_market_selector_returns_merged_asset_ids_from_active_strategies(
+    db_conn: asyncpg.Connection,
+) -> None:
+    market_selector_cls = _load_symbol("pms.market_selection.selector", "MarketSelector")
+    union_merge_policy_cls = _load_symbol("pms.market_selection.merge", "UnionMergePolicy")
+    pool = cast(asyncpg.Pool, _SingleConnectionPool(db_conn))
+    registry = PostgresStrategyRegistry(pool)
+    store = PostgresMarketDataStore(pool)
+    now = datetime.now(tz=UTC)
+
+    await registry.create_version(
+        _strategy(
+            "polymarket-fast",
+            venue="polymarket",
+            resolution_time_max_horizon_days=30,
+        )
+    )
+    await registry.create_version(
+        _strategy(
+            "kalshi-near",
+            venue="kalshi",
+            resolution_time_max_horizon_days=10,
+        )
+    )
+    await registry.create_strategy("inactive", metadata={"owner": "system"})
+
+    await _seed_market(
+        store,
+        market_id="pm-fast",
+        venue=cast(Venue, "polymarket"),
+        resolves_at=now + timedelta(days=5),
+    )
+    await _seed_market(
+        store,
+        market_id="pm-slow",
+        venue=cast(Venue, "polymarket"),
+        resolves_at=now + timedelta(days=45),
+    )
+    await _seed_market(
+        store,
+        market_id="pm-past",
+        venue=cast(Venue, "polymarket"),
+        resolves_at=now - timedelta(days=1),
+    )
+    await _seed_market(
+        store,
+        market_id="ka-near",
+        venue=cast(Venue, "kalshi"),
+        resolves_at=now + timedelta(days=4),
+    )
+    await _seed_market(
+        store,
+        market_id="ka-far",
+        venue=cast(Venue, "kalshi"),
+        resolves_at=now + timedelta(days=20),
+    )
+
+    selector = market_selector_cls(
+        pool=pool,
+        registry=registry,
+        merge_policy=union_merge_policy_cls(),
+    )
+
+    result = await selector.select()
+
+    assert result.asset_ids == [
+        "ka-near-no",
+        "ka-near-yes",
+        "pm-fast-no",
+        "pm-fast-yes",
+    ]
+    assert result.conflicts == []

--- a/tests/unit/test_api_subscriptions.py
+++ b/tests/unit/test_api_subscriptions.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from pms.api.app import create_app
+from pms.config import PMSSettings, RiskSettings
+from pms.core.enums import RunMode
+from pms.market_selection.subscription_controller import SensorSubscriptionController
+
+
+@dataclass
+class _RunnerState:
+    mode: RunMode
+    runner_started_at: datetime | None = None
+
+
+@dataclass
+class _RunnerDouble:
+    config: PMSSettings
+    state: _RunnerState
+    tasks: tuple[asyncio.Future[None], ...] = ()
+    _subscription_controller: SensorSubscriptionController | None = None
+
+    @property
+    def subscription_controller(self) -> SensorSubscriptionController | None:
+        return self._subscription_controller
+
+
+def _settings(mode: RunMode) -> PMSSettings:
+    return PMSSettings(
+        mode=mode,
+        auto_migrate_default_v2=False,
+        risk=RiskSettings(
+            max_position_per_market=1000.0,
+            max_total_exposure=10_000.0,
+        ),
+    )
+
+
+def _runner(
+    *,
+    mode: RunMode,
+    started: bool,
+    current_asset_ids: list[str],
+    last_updated_at: datetime | None,
+    running: bool,
+) -> _RunnerDouble:
+    controller = SensorSubscriptionController(_SubscriptionSink())
+    setattr(controller, "_current_asset_ids", frozenset(current_asset_ids))
+    setattr(controller, "_last_updated_at", last_updated_at)
+    future: asyncio.Future[None] | None = None
+    if running:
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+    return _RunnerDouble(
+        config=_settings(mode),
+        state=_RunnerState(
+            mode=mode,
+            runner_started_at=(
+                datetime(2026, 4, 16, tzinfo=UTC) if started else None
+            ),
+        ),
+        tasks=(() if future is None else (future,)),
+        _subscription_controller=controller,
+    )
+
+
+class _SubscriptionSink:
+    async def update_subscription(self, asset_ids: list[str]) -> None:
+        del asset_ids
+        return None
+
+
+async def _get_subscriptions_payload(runner: _RunnerDouble) -> dict[str, Any]:
+    app = create_app(cast(Any, runner))
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/subscriptions")
+
+    assert response.status_code == 200
+    return cast(dict[str, Any], response.json())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "started", "running", "controller_ids", "controller_updated_at"),
+    [
+        (
+            RunMode.LIVE,
+            False,
+            False,
+            ["asset-a", "asset-b"],
+            datetime(2026, 4, 17, 8, 30, tzinfo=UTC),
+        ),
+        (
+            RunMode.BACKTEST,
+            True,
+            True,
+            ["asset-a", "asset-b"],
+            datetime(2026, 4, 17, 8, 30, tzinfo=UTC),
+        ),
+    ],
+)
+async def test_get_subscriptions_returns_empty_payload_when_inactive(
+    mode: RunMode,
+    started: bool,
+    running: bool,
+    controller_ids: list[str],
+    controller_updated_at: datetime,
+) -> None:
+    payload = await _get_subscriptions_payload(
+        _runner(
+            mode=mode,
+            started=started,
+            current_asset_ids=controller_ids,
+            last_updated_at=controller_updated_at,
+            running=running,
+        )
+    )
+
+    assert payload == {
+        "asset_ids": [],
+        "count": 0,
+        "last_updated_at": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_subscriptions_returns_runner_controller_state_when_live_and_running() -> None:
+    last_updated_at = datetime(2026, 4, 17, 8, 30, tzinfo=UTC)
+    payload = await _get_subscriptions_payload(
+        _runner(
+            mode=RunMode.LIVE,
+            started=True,
+            current_asset_ids=["asset-b", "asset-a"],
+            last_updated_at=last_updated_at,
+            running=True,
+        )
+    )
+
+    assert payload == {
+        "asset_ids": ["asset-a", "asset-b"],
+        "count": 2,
+        "last_updated_at": last_updated_at.isoformat(),
+    }

--- a/tests/unit/test_import_linter_contracts.py
+++ b/tests/unit/test_import_linter_contracts.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SENSOR_AGGREGATE_CONTRACT = "Sensor strategy-agnostic: no aggregate import"
+ACTUATOR_AGGREGATE_CONTRACT = "Actuator strategy-agnostic: no aggregate import"
+SENSOR_ACTUATOR_CONTROLLER_CONTRACT = "Sensor + Actuator: no controller import"
+SENSOR_MARKET_SELECTION_CONTRACT = "Sensor: no market_selection import"
+ACTUATOR_MARKET_SELECTION_CONTRACT = "Actuator: no market_selection import"
+MARKET_SELECTION_AGGREGATE_CONTRACT = "Market selection: no aggregate import"
 
 IMPORT_LINTER_CONFIG = """
 [project]
@@ -39,10 +46,52 @@ name = "Sensor: no market_selection import"
 type = "forbidden"
 source_modules = ["pms.sensor"]
 forbidden_modules = ["pms.market_selection"]
+
+[[tool.importlinter.contracts]]
+name = "Actuator: no market_selection import"
+type = "forbidden"
+source_modules = ["pms.actuator"]
+forbidden_modules = ["pms.market_selection"]
+
+[[tool.importlinter.contracts]]
+name = "Market selection: no aggregate import"
+type = "forbidden"
+source_modules = ["pms.market_selection"]
+forbidden_modules = ["pms.strategies.aggregate"]
 """.strip()
 
 
-def test_import_linter_rejects_sensor_aggregate_violation(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("violating_module", "source_text", "expected_contract"),
+    [
+        (
+            "pms/sensor/bad.py",
+            "from pms.strategies.aggregate import Strategy\n",
+            SENSOR_AGGREGATE_CONTRACT,
+        ),
+        (
+            "pms/sensor/bad.py",
+            "from pms.market_selection.selector import MarketSelector\n",
+            SENSOR_MARKET_SELECTION_CONTRACT,
+        ),
+        (
+            "pms/actuator/bad.py",
+            "from pms.market_selection.selector import MarketSelector\n",
+            ACTUATOR_MARKET_SELECTION_CONTRACT,
+        ),
+        (
+            "pms/market_selection/bad.py",
+            "from pms.strategies.aggregate import Strategy\n",
+            MARKET_SELECTION_AGGREGATE_CONTRACT,
+        ),
+    ],
+)
+def test_import_linter_rejects_forbidden_dependencies(
+    tmp_path: Path,
+    violating_module: str,
+    source_text: str,
+    expected_contract: str,
+) -> None:
     (tmp_path / "pyproject.toml").write_text(f"{IMPORT_LINTER_CONFIG}\n")
     for package in [
         "pms",
@@ -50,14 +99,16 @@ def test_import_linter_rejects_sensor_aggregate_violation(tmp_path: Path) -> Non
         "pms/actuator",
         "pms/controller",
         "pms/strategies",
+        "pms/market_selection",
     ]:
         package_dir = tmp_path / package
         package_dir.mkdir(parents=True, exist_ok=True)
         (package_dir / "__init__.py").write_text("")
     (tmp_path / "pms/strategies/aggregate.py").write_text("class Strategy: ...\n")
-    (tmp_path / "pms/sensor/bad.py").write_text(
-        "from pms.strategies.aggregate import Strategy\n"
+    (tmp_path / "pms/market_selection/selector.py").write_text(
+        "class MarketSelector: ...\n"
     )
+    (tmp_path / violating_module).write_text(source_text)
 
     result = subprocess.run(
         [
@@ -76,7 +127,7 @@ def test_import_linter_rejects_sensor_aggregate_violation(tmp_path: Path) -> Non
     )
 
     assert result.returncode != 0
-    assert SENSOR_AGGREGATE_CONTRACT in result.stdout
+    assert expected_contract in result.stdout
 
 
 def test_current_tree_lints_clean() -> None:
@@ -89,3 +140,12 @@ def test_current_tree_lints_clean() -> None:
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+    for contract in [
+        SENSOR_AGGREGATE_CONTRACT,
+        ACTUATOR_AGGREGATE_CONTRACT,
+        SENSOR_ACTUATOR_CONTROLLER_CONTRACT,
+        SENSOR_MARKET_SELECTION_CONTRACT,
+        ACTUATOR_MARKET_SELECTION_CONTRACT,
+        MARKET_SELECTION_AGGREGATE_CONTRACT,
+    ]:
+        assert contract in result.stdout

--- a/tests/unit/test_import_linter_contracts.py
+++ b/tests/unit/test_import_linter_contracts.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -61,6 +63,21 @@ forbidden_modules = ["pms.strategies.aggregate"]
 """.strip()
 
 
+def _lint_imports_command() -> list[str]:
+    executable = REPO_ROOT / ".venv" / "bin" / "lint-imports"
+    if executable.exists():
+        return [str(executable)]
+
+    executable = Path(sys.executable).resolve().with_name("lint-imports")
+    if executable.exists():
+        return [str(executable)]
+
+    resolved = shutil.which("lint-imports")
+    if resolved is None:
+        pytest.fail("lint-imports executable is not available in the active environment")
+    return [resolved]
+
+
 @pytest.mark.parametrize(
     ("violating_module", "source_text", "expected_contract"),
     [
@@ -112,11 +129,7 @@ def test_import_linter_rejects_forbidden_dependencies(
 
     result = subprocess.run(
         [
-            "uv",
-            "run",
-            "--project",
-            str(REPO_ROOT),
-            "lint-imports",
+            *_lint_imports_command(),
             "--config",
             str(tmp_path / "pyproject.toml"),
         ],
@@ -132,7 +145,7 @@ def test_import_linter_rejects_forbidden_dependencies(
 
 def test_current_tree_lints_clean() -> None:
     result = subprocess.run(
-        ["uv", "run", "lint-imports"],
+        _lint_imports_command(),
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/tests/unit/test_market_discovery_sensor.py
+++ b/tests/unit/test_market_discovery_sensor.py
@@ -25,6 +25,7 @@ def _gamma_market(
     token_ids: list[str] | None = None,
     outcomes: list[str] | None = None,
     include_condition_id: bool = True,
+    volume_24hr: float | None = 1234.0,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "id": condition_id,
@@ -37,6 +38,8 @@ def _gamma_market(
     }
     if include_condition_id:
         payload["conditionId"] = condition_id
+    if volume_24hr is not None:
+        payload["volume24hr"] = volume_24hr
     if token_ids is not None:
         payload["clobTokenIds"] = json.dumps(token_ids)
     if outcomes is not None:
@@ -94,9 +97,43 @@ async def test_market_discovery_sensor_polls_gamma_once_and_writes_markets_and_t
     first_market = store_mock.write_market_mock.await_args_list[0].args[0]
     assert first_market.condition_id == "pm-live-0"
     assert first_market.venue == "polymarket"
+    assert first_market.volume_24h == 1234.0
     first_token = store_mock.write_token_mock.await_args_list[0].args[0]
     assert first_token.condition_id == "pm-live-0"
     assert first_token.outcome == "YES"
+
+
+@pytest.mark.asyncio
+async def test_market_discovery_sensor_preserves_zero_volume_rows() -> None:
+    store = _store_mock()
+    store_mock = cast(StoreMock, store)
+    payload = [
+        _gamma_market(
+            "pm-zero-volume",
+            token_ids=["yes-token", "no-token"],
+            outcomes=["Yes", "No"],
+            volume_24hr=0.0,
+        )
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/markets"
+        return httpx.Response(200, json=payload)
+
+    sensor = MarketDiscoverySensor(
+        store=store,
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://gamma.example.test",
+        ),
+        poll_interval_s=60.0,
+    )
+
+    await sensor.poll_once()
+    await sensor.aclose()
+
+    written_market = store_mock.write_market_mock.await_args_list[0].args[0]
+    assert written_market.volume_24h == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_market_discovery_sensor.py
+++ b/tests/unit/test_market_discovery_sensor.py
@@ -387,6 +387,111 @@ async def test_market_discovery_sensor_continues_when_token_write_fails(
 
 
 @pytest.mark.asyncio
+async def test_market_discovery_sensor_invokes_poll_complete_hook() -> None:
+    store = _store_mock()
+    callback_called = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/markets"
+        return httpx.Response(
+            200,
+            json=[
+                _gamma_market(
+                    "pm-live-complete-hook",
+                    token_ids=["yes-token", "no-token"],
+                    outcomes=["Yes", "No"],
+                )
+            ],
+        )
+
+    async def on_poll_complete() -> None:
+        callback_called.set()
+
+    sensor = MarketDiscoverySensor(
+        store=store,
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://gamma.example.test",
+        ),
+        poll_interval_s=60.0,
+        on_poll_complete=on_poll_complete,
+    )
+
+    async def consume() -> None:
+        async for _ in cast(AsyncGenerator[object, None], sensor.__aiter__()):
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        await asyncio.wait_for(callback_called.wait(), timeout=2.0)
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        await sensor.aclose()
+
+
+@pytest.mark.asyncio
+async def test_market_discovery_sensor_logs_poll_complete_hook_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _store_mock()
+    store_mock = cast(StoreMock, store)
+    poll_complete = asyncio.Event()
+    write_market_called = asyncio.Event()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/markets"
+        return httpx.Response(
+            200,
+            json=[
+                _gamma_market(
+                    "pm-live-hook-error",
+                    token_ids=["yes-token", "no-token"],
+                    outcomes=["Yes", "No"],
+                )
+            ],
+        )
+
+    async def on_poll_complete() -> None:
+        msg = "completion hook failed"
+        poll_complete.set()
+        raise RuntimeError(msg)
+
+    async def tracked_write_market(*args: Any, **kwargs: Any) -> None:
+        write_market_called.set()
+        return None
+
+    store_mock.write_market_mock.side_effect = tracked_write_market
+    sensor = MarketDiscoverySensor(
+        store=store,
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://gamma.example.test",
+        ),
+        poll_interval_s=60.0,
+        on_poll_complete=on_poll_complete,
+    )
+
+    async def consume() -> None:
+        async for _ in cast(AsyncGenerator[object, None], sensor.__aiter__()):
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        with caplog.at_level(logging.WARNING):
+            await asyncio.wait_for(write_market_called.wait(), timeout=2.0)
+            await asyncio.wait_for(poll_complete.wait(), timeout=2.0)
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        await sensor.aclose()
+
+    assert "discovery poll completion hook failed" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_sensor_stream_accepts_market_discovery_sensor() -> None:
     store = _store_mock()
 

--- a/tests/unit/test_market_selection_store.py
+++ b/tests/unit/test_market_selection_store.py
@@ -104,7 +104,7 @@ async def test_read_eligible_markets_groups_joined_tokens_and_keeps_zero_token_m
             ]
         ]
     )
-    store = PostgresMarketDataStore(FakePool(connection))  # type: ignore[arg-type]
+    store = PostgresMarketDataStore(FakePool(connection))
 
     markets = await store.read_eligible_markets("polymarket", 30)
 
@@ -121,7 +121,7 @@ async def test_read_eligible_markets_groups_joined_tokens_and_keeps_zero_token_m
 @pytest.mark.asyncio
 async def test_read_eligible_markets_returns_empty_list_and_uses_null_upper_bound_for_open_horizon() -> None:
     connection = FakeConnection(fetch_results=[[]])
-    store = PostgresMarketDataStore(FakePool(connection))  # type: ignore[arg-type]
+    store = PostgresMarketDataStore(FakePool(connection))
 
     markets = await store.read_eligible_markets("kalshi", None)
 

--- a/tests/unit/test_market_selection_store.py
+++ b/tests/unit/test_market_selection_store.py
@@ -48,6 +48,7 @@ def _row(
     resolves_at: datetime | None,
     created_at: datetime,
     last_seen_at: datetime,
+    volume_24h: float | None = 1000.0,
     token_id: str | None,
     outcome: str | None,
 ) -> dict[str, object]:
@@ -59,6 +60,7 @@ def _row(
         "resolves_at": resolves_at,
         "created_at": created_at,
         "last_seen_at": last_seen_at,
+        "volume_24h": volume_24h,
         "token_id": token_id,
         "outcome": outcome,
     }
@@ -106,16 +108,18 @@ async def test_read_eligible_markets_groups_joined_tokens_and_keeps_zero_token_m
     )
     store = PostgresMarketDataStore(FakePool(connection))
 
-    markets = await store.read_eligible_markets("polymarket", 30)
+    markets = await store.read_eligible_markets("polymarket", 30, 500.0)
 
     assert [market.condition_id for market, _ in markets] == ["market-1", "market-2"]
     assert [token.token_id for token in markets[0][1]] == ["token-yes", "token-no"]
     assert markets[1][1] == []
+    assert markets[0][0].volume_24h == 1000.0
     assert len(connection.fetch_calls) == 1
     _, args = connection.fetch_calls[0]
     assert args[0] == "polymarket"
     assert isinstance(args[1], datetime)
     assert isinstance(args[2], datetime)
+    assert args[3] == 500.0
 
 
 @pytest.mark.asyncio
@@ -123,7 +127,7 @@ async def test_read_eligible_markets_returns_empty_list_and_uses_null_upper_boun
     connection = FakeConnection(fetch_results=[[]])
     store = PostgresMarketDataStore(FakePool(connection))
 
-    markets = await store.read_eligible_markets("kalshi", None)
+    markets = await store.read_eligible_markets("kalshi", None, 0.0)
 
     assert markets == []
     assert len(connection.fetch_calls) == 1
@@ -131,3 +135,4 @@ async def test_read_eligible_markets_returns_empty_list_and_uses_null_upper_boun
     assert args[0] == "kalshi"
     assert isinstance(args[1], datetime)
     assert args[2] is None
+    assert args[3] == 0.0

--- a/tests/unit/test_market_selection_store.py
+++ b/tests/unit/test_market_selection_store.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from pms.storage.market_data_store import PostgresMarketDataStore
+
+
+@dataclass
+class FakeConnection:
+    fetch_results: list[list[dict[str, object]]] = field(default_factory=list)
+    fetch_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+        self.fetch_calls.append((query, args))
+        if not self.fetch_results:
+            return []
+        return self.fetch_results.pop(0)
+
+
+class FakeAcquire:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class FakePool:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self._connection)
+
+
+def _row(
+    *,
+    condition_id: str,
+    slug: str,
+    question: str,
+    venue: str = "polymarket",
+    resolves_at: datetime | None,
+    created_at: datetime,
+    last_seen_at: datetime,
+    token_id: str | None,
+    outcome: str | None,
+) -> dict[str, object]:
+    return {
+        "condition_id": condition_id,
+        "slug": slug,
+        "question": question,
+        "venue": venue,
+        "resolves_at": resolves_at,
+        "created_at": created_at,
+        "last_seen_at": last_seen_at,
+        "token_id": token_id,
+        "outcome": outcome,
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_eligible_markets_groups_joined_tokens_and_keeps_zero_token_markets() -> None:
+    created_at = datetime(2026, 4, 20, tzinfo=UTC)
+    resolves_at = created_at + timedelta(days=10)
+    connection = FakeConnection(
+        fetch_results=[
+            [
+                _row(
+                    condition_id="market-1",
+                    slug="market-1",
+                    question="Will market 1 resolve?",
+                    resolves_at=resolves_at,
+                    created_at=created_at,
+                    last_seen_at=created_at,
+                    token_id="token-yes",
+                    outcome="YES",
+                ),
+                _row(
+                    condition_id="market-1",
+                    slug="market-1",
+                    question="Will market 1 resolve?",
+                    resolves_at=resolves_at,
+                    created_at=created_at,
+                    last_seen_at=created_at,
+                    token_id="token-no",
+                    outcome="NO",
+                ),
+                _row(
+                    condition_id="market-2",
+                    slug="market-2",
+                    question="Will market 2 resolve?",
+                    resolves_at=None,
+                    created_at=created_at,
+                    last_seen_at=created_at,
+                    token_id=None,
+                    outcome=None,
+                ),
+            ]
+        ]
+    )
+    store = PostgresMarketDataStore(FakePool(connection))  # type: ignore[arg-type]
+
+    markets = await store.read_eligible_markets("polymarket", 30)
+
+    assert [market.condition_id for market, _ in markets] == ["market-1", "market-2"]
+    assert [token.token_id for token in markets[0][1]] == ["token-yes", "token-no"]
+    assert markets[1][1] == []
+    assert len(connection.fetch_calls) == 1
+    _, args = connection.fetch_calls[0]
+    assert args[0] == "polymarket"
+    assert isinstance(args[1], datetime)
+    assert isinstance(args[2], datetime)
+
+
+@pytest.mark.asyncio
+async def test_read_eligible_markets_returns_empty_list_and_uses_null_upper_bound_for_open_horizon() -> None:
+    connection = FakeConnection(fetch_results=[[]])
+    store = PostgresMarketDataStore(FakePool(connection))  # type: ignore[arg-type]
+
+    markets = await store.read_eligible_markets("kalshi", None)
+
+    assert markets == []
+    assert len(connection.fetch_calls) == 1
+    _, args = connection.fetch_calls[0]
+    assert args[0] == "kalshi"
+    assert isinstance(args[1], datetime)
+    assert args[2] is None

--- a/tests/unit/test_market_selector.py
+++ b/tests/unit/test_market_selector.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from pms.core.models import Market, Token
+from pms.core.models import Market, Token, Venue
 from pms.strategies.projections import MarketSelectionSpec
 
 
@@ -23,7 +23,7 @@ def _load_symbol(module_name: str, symbol_name: str) -> Any:
 def _eligible_market(
     market_id: str,
     *,
-    venue: str = "polymarket",
+    venue: Venue = "polymarket",
     token_ids: tuple[str, ...] = ("yes", "no"),
 ) -> tuple[Market, list[Token]]:
     now = datetime(2026, 4, 18, 9, 0, tzinfo=UTC)
@@ -32,7 +32,7 @@ def _eligible_market(
             condition_id=market_id,
             slug=f"slug-{market_id}",
             question=f"Question {market_id}",
-            venue=venue,  # type: ignore[arg-type]
+            venue=venue,
             resolves_at=now + timedelta(days=3),
             created_at=now - timedelta(days=2),
             last_seen_at=now,
@@ -41,7 +41,7 @@ def _eligible_market(
             Token(
                 token_id=token_id,
                 condition_id=market_id,
-                outcome="YES" if index == 0 else "NO",  # type: ignore[arg-type]
+                outcome=("YES" if index == 0 else "NO"),
             )
             for index, token_id in enumerate(token_ids)
         ],
@@ -157,8 +157,20 @@ async def test_market_selector_builds_strategy_sets_before_merging(
         ) -> list[tuple[Market, list[Token]]]:
             self.calls.append((venue, max_horizon_days))
             if venue == "polymarket":
-                return [_eligible_market("market-a", venue=venue, token_ids=("pm-yes", "pm-no"))]
-            return [_eligible_market("market-b", venue=venue, token_ids=("ka-yes", "ka-no"))]
+                return [
+                    _eligible_market(
+                        "market-a",
+                        venue="polymarket",
+                        token_ids=("pm-yes", "pm-no"),
+                    )
+                ]
+            return [
+                _eligible_market(
+                    "market-b",
+                    venue="kalshi",
+                    token_ids=("ka-yes", "ka-no"),
+                )
+            ]
 
     class RecordingMergePolicy:
         def __init__(self) -> None:

--- a/tests/unit/test_market_selector.py
+++ b/tests/unit/test_market_selector.py
@@ -110,7 +110,6 @@ def test_merge_dataclasses_are_frozen() -> None:
 
 @pytest.mark.asyncio
 async def test_market_selector_builds_strategy_sets_before_merging(
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     selector_module = importlib.import_module("pms.market_selection.selector")
     market_selector_cls = getattr(selector_module, "MarketSelector")
@@ -146,16 +145,16 @@ async def test_market_selector_builds_strategy_sets_before_merging(
             ]
 
     class FakeStore:
-        def __init__(self, pool: object) -> None:
-            self.pool = pool
-            self.calls: list[tuple[str, int | None]] = []
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int | None, float]] = []
 
         async def read_eligible_markets(
             self,
             venue: str,
             max_horizon_days: int | None,
+            min_volume_usdc: float,
         ) -> list[tuple[Market, list[Token]]]:
-            self.calls.append((venue, max_horizon_days))
+            self.calls.append((venue, max_horizon_days, min_volume_usdc))
             if venue == "polymarket":
                 return [
                     _eligible_market(
@@ -183,22 +182,20 @@ async def test_market_selector_builds_strategy_sets_before_merging(
                 conflicts=[],
             )
 
-    fake_store = FakeStore(pool=object())
-    monkeypatch.setattr(
-        selector_module,
-        "PostgresMarketDataStore",
-        lambda pool: fake_store,
-    )
+    fake_store = FakeStore()
     merge_policy = RecordingMergePolicy()
     selector = market_selector_cls(
-        pool=object(),
+        store=fake_store,
         registry=FakeRegistry(),
         merge_policy=merge_policy,
     )
 
     result = await selector.select()
 
-    assert fake_store.calls == [("polymarket", 7), ("kalshi", 30)]
+    assert fake_store.calls == [
+        ("polymarket", 7, 500.0),
+        ("kalshi", 30, 1000.0),
+    ]
     assert merge_policy.selections == [
         strategy_market_set_cls(
             strategy_id="alpha",
@@ -218,7 +215,6 @@ async def test_market_selector_builds_strategy_sets_before_merging(
 @pytest.mark.asyncio
 async def test_market_selector_logs_count_and_warns_when_no_active_strategies(
     caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     selector_module = importlib.import_module("pms.market_selection.selector")
     market_selector_cls = getattr(selector_module, "MarketSelector")
@@ -231,13 +227,11 @@ async def test_market_selector_logs_count_and_warns_when_no_active_strategies(
             return []
 
     class UnusedStore:
-        def __init__(self, pool: object) -> None:
-            self.pool = pool
-
         async def read_eligible_markets(
             self,
             venue: str,
             max_horizon_days: int | None,
+            min_volume_usdc: float,
         ) -> list[tuple[Market, list[Token]]]:
             raise AssertionError("read_eligible_markets should not be called")
 
@@ -249,10 +243,9 @@ async def test_market_selector_logs_count_and_warns_when_no_active_strategies(
             self.calls.append(selections)
             return merge_result_cls(asset_ids=[], conflicts=[])
 
-    monkeypatch.setattr(selector_module, "PostgresMarketDataStore", UnusedStore)
     merge_policy = RecordingMergePolicy()
     selector = market_selector_cls(
-        pool=object(),
+        store=UnusedStore(),
         registry=EmptyRegistry(),
         merge_policy=merge_policy,
     )

--- a/tests/unit/test_market_selector.py
+++ b/tests/unit/test_market_selector.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta
+import importlib
+import logging
+from typing import Any
+
+import pytest
+
+from pms.core.models import Market, Token
+from pms.strategies.projections import MarketSelectionSpec
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in red phase
+        pytest.fail(f"{module_name} is missing: {exc}")
+    return getattr(module, symbol_name)
+
+
+def _eligible_market(
+    market_id: str,
+    *,
+    venue: str = "polymarket",
+    token_ids: tuple[str, ...] = ("yes", "no"),
+) -> tuple[Market, list[Token]]:
+    now = datetime(2026, 4, 18, 9, 0, tzinfo=UTC)
+    return (
+        Market(
+            condition_id=market_id,
+            slug=f"slug-{market_id}",
+            question=f"Question {market_id}",
+            venue=venue,  # type: ignore[arg-type]
+            resolves_at=now + timedelta(days=3),
+            created_at=now - timedelta(days=2),
+            last_seen_at=now,
+        ),
+        [
+            Token(
+                token_id=token_id,
+                condition_id=market_id,
+                outcome="YES" if index == 0 else "NO",  # type: ignore[arg-type]
+            )
+            for index, token_id in enumerate(token_ids)
+        ],
+    )
+
+
+def test_union_merge_policy_returns_sorted_union_without_conflicts() -> None:
+    strategy_market_set_cls = _load_symbol(
+        "pms.market_selection.merge",
+        "StrategyMarketSet",
+    )
+    union_merge_policy_cls = _load_symbol(
+        "pms.market_selection.merge",
+        "UnionMergePolicy",
+    )
+
+    result = union_merge_policy_cls().merge(
+        [
+            strategy_market_set_cls(
+                strategy_id="alpha",
+                strategy_version_id="alpha-v1",
+                asset_ids=frozenset({"asset-b", "asset-a"}),
+            ),
+            strategy_market_set_cls(
+                strategy_id="beta",
+                strategy_version_id="beta-v2",
+                asset_ids=frozenset({"asset-c", "asset-a"}),
+            ),
+        ]
+    )
+
+    assert result.asset_ids == ["asset-a", "asset-b", "asset-c"]
+    assert result.conflicts == []
+
+
+def test_merge_dataclasses_are_frozen() -> None:
+    merge_conflict_cls = _load_symbol("pms.market_selection.merge", "MergeConflict")
+    merge_result_cls = _load_symbol("pms.market_selection.merge", "MergeResult")
+    strategy_market_set_cls = _load_symbol(
+        "pms.market_selection.merge",
+        "StrategyMarketSet",
+    )
+
+    strategy_market_set = strategy_market_set_cls(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        asset_ids=frozenset({"asset-a"}),
+    )
+    merge_conflict = merge_conflict_cls(
+        market_id="market-1",
+        strategy_ids=("alpha", "beta"),
+        description="conflict",
+    )
+    merge_result = merge_result_cls(
+        asset_ids=["asset-a"],
+        conflicts=[merge_conflict],
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        strategy_market_set.strategy_id = "mutated"
+    with pytest.raises(FrozenInstanceError):
+        merge_conflict.market_id = "mutated"
+    with pytest.raises(FrozenInstanceError):
+        merge_result.asset_ids = []
+
+
+@pytest.mark.asyncio
+async def test_market_selector_builds_strategy_sets_before_merging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selector_module = importlib.import_module("pms.market_selection.selector")
+    market_selector_cls = getattr(selector_module, "MarketSelector")
+    merge_result_cls = _load_symbol("pms.market_selection.merge", "MergeResult")
+    strategy_market_set_cls = _load_symbol(
+        "pms.market_selection.merge",
+        "StrategyMarketSet",
+    )
+
+    class FakeRegistry:
+        async def list_market_selections(
+            self,
+        ) -> list[tuple[str, str, MarketSelectionSpec]]:
+            return [
+                (
+                    "alpha",
+                    "alpha-v1",
+                    MarketSelectionSpec(
+                        venue="polymarket",
+                        resolution_time_max_horizon_days=7,
+                        volume_min_usdc=500.0,
+                    ),
+                ),
+                (
+                    "beta",
+                    "beta-v2",
+                    MarketSelectionSpec(
+                        venue="kalshi",
+                        resolution_time_max_horizon_days=30,
+                        volume_min_usdc=1000.0,
+                    ),
+                ),
+            ]
+
+    class FakeStore:
+        def __init__(self, pool: object) -> None:
+            self.pool = pool
+            self.calls: list[tuple[str, int | None]] = []
+
+        async def read_eligible_markets(
+            self,
+            venue: str,
+            max_horizon_days: int | None,
+        ) -> list[tuple[Market, list[Token]]]:
+            self.calls.append((venue, max_horizon_days))
+            if venue == "polymarket":
+                return [_eligible_market("market-a", venue=venue, token_ids=("pm-yes", "pm-no"))]
+            return [_eligible_market("market-b", venue=venue, token_ids=("ka-yes", "ka-no"))]
+
+    class RecordingMergePolicy:
+        def __init__(self) -> None:
+            self.selections: list[object] | None = None
+
+        def merge(self, selections: list[object]) -> object:
+            self.selections = selections
+            return merge_result_cls(
+                asset_ids=["ka-no", "ka-yes", "pm-no", "pm-yes"],
+                conflicts=[],
+            )
+
+    fake_store = FakeStore(pool=object())
+    monkeypatch.setattr(
+        selector_module,
+        "PostgresMarketDataStore",
+        lambda pool: fake_store,
+    )
+    merge_policy = RecordingMergePolicy()
+    selector = market_selector_cls(
+        pool=object(),
+        registry=FakeRegistry(),
+        merge_policy=merge_policy,
+    )
+
+    result = await selector.select()
+
+    assert fake_store.calls == [("polymarket", 7), ("kalshi", 30)]
+    assert merge_policy.selections == [
+        strategy_market_set_cls(
+            strategy_id="alpha",
+            strategy_version_id="alpha-v1",
+            asset_ids=frozenset({"pm-yes", "pm-no"}),
+        ),
+        strategy_market_set_cls(
+            strategy_id="beta",
+            strategy_version_id="beta-v2",
+            asset_ids=frozenset({"ka-yes", "ka-no"}),
+        ),
+    ]
+    assert result.asset_ids == ["ka-no", "ka-yes", "pm-no", "pm-yes"]
+    assert result.conflicts == []
+
+
+@pytest.mark.asyncio
+async def test_market_selector_logs_count_and_warns_when_no_active_strategies(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selector_module = importlib.import_module("pms.market_selection.selector")
+    market_selector_cls = getattr(selector_module, "MarketSelector")
+    merge_result_cls = _load_symbol("pms.market_selection.merge", "MergeResult")
+
+    class EmptyRegistry:
+        async def list_market_selections(
+            self,
+        ) -> list[tuple[str, str, MarketSelectionSpec]]:
+            return []
+
+    class UnusedStore:
+        def __init__(self, pool: object) -> None:
+            self.pool = pool
+
+        async def read_eligible_markets(
+            self,
+            venue: str,
+            max_horizon_days: int | None,
+        ) -> list[tuple[Market, list[Token]]]:
+            raise AssertionError("read_eligible_markets should not be called")
+
+    class RecordingMergePolicy:
+        def __init__(self) -> None:
+            self.calls: list[list[object]] = []
+
+        def merge(self, selections: list[object]) -> object:
+            self.calls.append(selections)
+            return merge_result_cls(asset_ids=[], conflicts=[])
+
+    monkeypatch.setattr(selector_module, "PostgresMarketDataStore", UnusedStore)
+    merge_policy = RecordingMergePolicy()
+    selector = market_selector_cls(
+        pool=object(),
+        registry=EmptyRegistry(),
+        merge_policy=merge_policy,
+    )
+
+    with caplog.at_level(logging.INFO):
+        result = await selector.select()
+
+    assert merge_policy.calls == [[]]
+    assert result.asset_ids == []
+    assert "processed 0 active strategies" in caplog.text
+    assert "data sensor will idle until a strategy is activated" in caplog.text

--- a/tests/unit/test_runner_active_perception.py
+++ b/tests/unit/test_runner_active_perception.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -376,3 +377,51 @@ async def test_runner_active_perception_reselection_is_serialized(
 
     discovery.poll_released.set()
     await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_event_triggered_reselection_failure_does_not_kill_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    events: list[str] = []
+    _, discovery, _, _, _ = _install_live_doubles(
+        monkeypatch,
+        events=events,
+        returned_asset_ids=["no-10d", "yes-10d"],
+    )
+
+    runner = _runner(RunMode.LIVE)
+    await runner.start()
+    try:
+        reselection_task = runner._reselection_task
+        assert reselection_task is not None
+        assert not reselection_task.done()
+
+        raising_selector_called = asyncio.Event()
+
+        class RaisingSelector:
+            calls = 0
+
+            async def select(self) -> Any:
+                RaisingSelector.calls += 1
+                raising_selector_called.set()
+                raise RuntimeError("transient postgres error")
+
+        runner._market_selector = RaisingSelector()
+
+        caplog.set_level(logging.WARNING, logger="pms.runner")
+        await runner._request_reselection()
+        await asyncio.wait_for(raising_selector_called.wait(), timeout=2.0)
+        for _ in range(10):
+            await asyncio.sleep(0)
+
+        assert not reselection_task.done(), (
+            "reselection task died when event-triggered _reselect raised; "
+            f"task state: done={reselection_task.done()}"
+        )
+        assert RaisingSelector.calls == 1
+        assert "periodic reselection failed" in caplog.text
+    finally:
+        discovery.poll_released.set()
+        await runner.stop()

--- a/tests/unit/test_runner_active_perception.py
+++ b/tests/unit/test_runner_active_perception.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pms.config import DatabaseSettings, PMSSettings, RiskSettings
+from pms.core.enums import RunMode
+from pms.core.models import MarketSignal
+from pms.runner import Runner
+
+
+FIXTURE_PATH = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
+
+
+@dataclass
+class FakePool:
+    close_calls: int = 0
+    closed: bool = False
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.closed = True
+
+
+class IdleSensor:
+    def __aiter__(self) -> AsyncIterator[MarketSignal]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[MarketSignal]:
+        while True:
+            await asyncio.sleep(60.0)
+            yield _signal()
+
+
+@dataclass
+class RecordingMarketDataSensor:
+    asset_ids: list[str] = field(default_factory=list)
+    updates: list[list[str]] = field(default_factory=list)
+    update_started: asyncio.Event = field(default_factory=asyncio.Event)
+    update_release: asyncio.Event = field(default_factory=asyncio.Event)
+    close_calls: int = 0
+
+    def __aiter__(self) -> AsyncIterator[MarketSignal]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[MarketSignal]:
+        while True:
+            await asyncio.sleep(60.0)
+            yield _signal()
+
+    async def update_subscription(self, asset_ids: list[str]) -> None:
+        self.asset_ids = list(asset_ids)
+        self.updates.append(list(asset_ids))
+        self.update_started.set()
+        await self.update_release.wait()
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class RecordingDiscoverySensor:
+    events: list[str]
+    on_poll_complete: Callable[[], Any] | None = None
+    poll_count: int = 0
+    close_calls: int = 0
+    poll_started: asyncio.Event = field(default_factory=asyncio.Event)
+    poll_released: asyncio.Event = field(default_factory=asyncio.Event)
+    poll_complete_called: asyncio.Event = field(default_factory=asyncio.Event)
+    first_poll_can_finish: asyncio.Event = field(default_factory=asyncio.Event)
+
+    def __aiter__(self) -> AsyncIterator[MarketSignal]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[MarketSignal]:
+        self.events.append("discovery-started")
+        self.poll_started.set()
+        await self.first_poll_can_finish.wait()
+        self.poll_count += 1
+        self.events.append("first-poll-completed")
+        if self.on_poll_complete is not None:
+            await self.on_poll_complete()
+        self.poll_complete_called.set()
+        await self.poll_released.wait()
+        while True:
+            await asyncio.sleep(60.0)
+            yield _signal()
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class RecordingSelector:
+    events: list[str]
+    returned_asset_ids: list[str]
+    calls: int = 0
+    call_started: asyncio.Event = field(default_factory=asyncio.Event)
+    call_release: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def select(self) -> Any:
+        self.calls += 1
+        self.call_started.set()
+        self.events.append("first-selection-complete")
+        await self.call_release.wait()
+        return type(
+            "MergeResult",
+            (),
+            {"asset_ids": tuple(self.returned_asset_ids)},
+        )()
+
+
+@dataclass
+class RecordingSubscriptionController:
+    sink: RecordingMarketDataSensor
+    events: list[str]
+    calls: int = 0
+    updates: list[list[str]] = field(default_factory=list)
+    call_started: asyncio.Event = field(default_factory=asyncio.Event)
+    call_release: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def update(self, asset_ids: list[str]) -> bool:
+        self.calls += 1
+        self.updates.append(list(asset_ids))
+        self.call_started.set()
+        self.events.append("data-sensor-subscribed")
+        await self.call_release.wait()
+        await self.sink.update_subscription(asset_ids)
+        return True
+
+
+def _settings(mode: RunMode) -> PMSSettings:
+    return PMSSettings(
+        mode=mode,
+        auto_migrate_default_v2=False,
+        database=DatabaseSettings(
+            dsn="postgresql://localhost/pms_test_runner",
+            pool_min_size=2,
+            pool_max_size=10,
+        ),
+        risk=RiskSettings(
+            max_position_per_market=1000.0,
+            max_total_exposure=10_000.0,
+        ),
+    )
+
+
+def _runner(mode: RunMode, **kwargs: Any) -> Runner:
+    return Runner(
+        config=_settings(mode),
+        historical_data_path=FIXTURE_PATH,
+        **kwargs,
+    )
+
+
+def _signal() -> MarketSignal:
+    return MarketSignal(
+        market_id="runner-active-perception",
+        token_id="yes-token",
+        venue="polymarket",
+        title="Will active perception tests pass?",
+        yes_price=0.42,
+        volume_24h=1_000.0,
+        resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
+        orderbook={"bids": [], "asks": []},
+        external_signal={"fair_value": 0.55},
+        fetched_at=datetime(2026, 4, 16, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_factor_catalog_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop_ensure_factor_catalog(pool: object, *, factor_ids: object = None) -> None:
+        del pool, factor_ids
+
+    monkeypatch.setattr("pms.runner.ensure_factor_catalog", _noop_ensure_factor_catalog)
+
+
+@pytest.fixture(autouse=True)
+def _stub_factor_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _NoopFactorService:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        async def run(self) -> None:
+            return None
+
+    monkeypatch.setattr("pms.runner.FactorService", _NoopFactorService)
+
+
+def _install_live_doubles(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    events: list[str],
+    returned_asset_ids: list[str],
+) -> tuple[
+    FakePool,
+    RecordingDiscoverySensor,
+    RecordingMarketDataSensor,
+    RecordingSelector,
+    RecordingSubscriptionController,
+]:
+    fake_pool = FakePool()
+    discovery = RecordingDiscoverySensor(events=events)
+    market_data = RecordingMarketDataSensor()
+    selector = RecordingSelector(events=events, returned_asset_ids=returned_asset_ids)
+    subscription_controller = RecordingSubscriptionController(
+        sink=market_data,
+        events=events,
+    )
+
+    async def fake_create_pool(*, dsn: str, min_size: int, max_size: int) -> FakePool:
+        del dsn, min_size, max_size
+        events.append("pool-ready")
+        return fake_pool
+
+    monkeypatch.setattr("pms.runner.asyncpg.create_pool", fake_create_pool)
+    monkeypatch.setattr("pms.runner.MarketDiscoverySensor", lambda **kwargs: discovery)
+    monkeypatch.setattr("pms.runner.MarketDataSensor", lambda **kwargs: market_data)
+    monkeypatch.setattr("pms.runner.MarketSelector", lambda *args, **kwargs: selector)
+    monkeypatch.setattr(
+        "pms.runner.SensorSubscriptionController",
+        lambda sink: subscription_controller,
+    )
+    return fake_pool, discovery, market_data, selector, subscription_controller
+
+
+@pytest.mark.asyncio
+async def test_runner_active_perception_boot_order_and_first_poll_subscription_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _, discovery, market_data, selector, subscription_controller = _install_live_doubles(
+        monkeypatch,
+        events=events,
+        returned_asset_ids=["no-10d", "yes-10d"],
+    )
+
+    runner = _runner(RunMode.LIVE)
+    original_build_sensors = runner._build_sensors
+
+    def wrapped_build_sensors() -> tuple[Any, ...]:
+        events.append("sensors-built")
+        return original_build_sensors()
+
+    monkeypatch.setattr(runner, "_build_sensors", wrapped_build_sensors)
+    start_task = asyncio.create_task(runner.start())
+    try:
+        await asyncio.wait_for(discovery.poll_started.wait(), timeout=2.0)
+        assert events == ["pool-ready", "sensors-built", "discovery-started"]
+        assert discovery.on_poll_complete is not None
+        assert selector.calls == 0
+        assert subscription_controller.calls == 0
+        assert market_data.updates == []
+
+        discovery.first_poll_can_finish.set()
+        await asyncio.wait_for(selector.call_started.wait(), timeout=2.0)
+        assert selector.calls == 1
+        assert subscription_controller.calls == 0
+        assert market_data.updates == []
+
+        selector.call_release.set()
+        await asyncio.wait_for(subscription_controller.call_started.wait(), timeout=2.0)
+        assert subscription_controller.calls == 1
+        assert market_data.updates == []
+
+        subscription_controller.call_release.set()
+        market_data.update_release.set()
+        await asyncio.wait_for(start_task, timeout=2.0)
+    finally:
+        if not start_task.done():
+            start_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await start_task
+
+    assert events == [
+        "pool-ready",
+        "sensors-built",
+        "discovery-started",
+        "first-poll-completed",
+        "first-selection-complete",
+        "data-sensor-subscribed",
+    ]
+    assert market_data.asset_ids == ["no-10d", "yes-10d"]
+
+    discovery.poll_released.set()
+    await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_runner_active_perception_backtest_skips_wiring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_pool = FakePool()
+
+    async def fake_create_pool(*, dsn: str, min_size: int, max_size: int) -> FakePool:
+        del dsn, min_size, max_size
+        return fake_pool
+
+    monkeypatch.setattr("pms.runner.asyncpg.create_pool", fake_create_pool)
+
+    runner = _runner(RunMode.BACKTEST, sensors=[IdleSensor()])
+    await runner.start()
+
+    assert runner._market_selector is None
+    assert runner._subscription_controller is None
+    assert runner._reselection_task is None
+
+    await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_runner_active_perception_stop_cleans_up_references_and_sensors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _, discovery, market_data, _, _ = _install_live_doubles(
+        monkeypatch,
+        events=events,
+        returned_asset_ids=["no-10d", "yes-10d"],
+    )
+
+    runner = _runner(RunMode.LIVE)
+    await runner.start()
+    await runner.stop()
+
+    assert runner._market_selector is None
+    assert runner._subscription_controller is None
+    assert runner._reselection_task is None
+    assert discovery.close_calls == 1
+    assert market_data.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_runner_active_perception_reselection_is_serialized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _, discovery, market_data, selector, subscription_controller = _install_live_doubles(
+        monkeypatch,
+        events=events,
+        returned_asset_ids=["no-10d", "yes-10d"],
+    )
+
+    runner = _runner(RunMode.LIVE)
+    await runner.start()
+
+    assert runner._reselection_task is not None
+
+    first = asyncio.create_task(runner._reselect())
+    second = asyncio.create_task(runner._reselect())
+    await asyncio.wait_for(selector.call_started.wait(), timeout=2.0)
+    assert selector.calls == 1
+    assert subscription_controller.calls == 0
+
+    selector.call_release.set()
+    await asyncio.wait_for(subscription_controller.call_started.wait(), timeout=2.0)
+    assert subscription_controller.calls == 1
+
+    subscription_controller.call_release.set()
+    market_data.update_release.set()
+    await asyncio.wait_for(first, timeout=2.0)
+    await asyncio.wait_for(second, timeout=2.0)
+
+    assert selector.calls == 2
+    assert subscription_controller.calls == 2
+
+    discovery.poll_released.set()
+    await runner.stop()

--- a/tests/unit/test_runner_active_perception.py
+++ b/tests/unit/test_runner_active_perception.py
@@ -272,6 +272,8 @@ async def test_runner_active_perception_boot_order_and_first_poll_subscription_u
         assert market_data.updates == []
 
         subscription_controller.call_release.set()
+        await asyncio.wait_for(market_data.update_started.wait(), timeout=2.0)
+        assert market_data.asset_ids == ["no-10d", "yes-10d"]
         market_data.update_release.set()
         await asyncio.wait_for(start_task, timeout=2.0)
     finally:

--- a/tests/unit/test_strategy_change_reselection.py
+++ b/tests/unit/test_strategy_change_reselection.py
@@ -414,3 +414,107 @@ async def test_runner_strategy_change_trigger_triggers_reselection(
     assert market_data.asset_ids == ["near-no", "near-yes"]
 
     await runner.stop()
+
+
+@dataclass
+class _AcquirableClosablePool:
+    connection: FakeConnection
+    close_calls: int = 0
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self.connection)
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_runner_constructs_single_strategy_registry_with_callback_for_bootstrap_and_wiring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = FakeConnection(fetchval_results=["default-v1"])
+    fake_pool = _AcquirableClosablePool(connection=connection)
+    discovery = IdleDiscoverySensor()
+    market_data = RecordingMarketDataSensor()
+    selector = RecordingSelector(returned_asset_ids=[])
+    subscription_controller = RecordingSubscriptionController(sink=market_data)
+
+    constructed: list[dict[str, object]] = []
+
+    class TrackingRegistry:
+        def __init__(
+            self,
+            pool: object,
+            on_strategy_change: Callable[[], Awaitable[None]] | None = None,
+        ) -> None:
+            constructed.append(
+                {"pool_id": id(pool), "on_strategy_change": on_strategy_change}
+            )
+            self._pool = pool
+            self._on_strategy_change = on_strategy_change
+
+        async def get_by_id(self, strategy_id: str) -> None:
+            del strategy_id
+            return None
+
+        async def list_market_selections(self) -> list[object]:
+            return []
+
+        async def set_active(self, strategy_id: str, version_id: str) -> None:
+            del strategy_id, version_id
+            if self._on_strategy_change is not None:
+                await self._on_strategy_change()
+
+    async def fake_create_pool(
+        *, dsn: str, min_size: int, max_size: int
+    ) -> _AcquirableClosablePool:
+        del dsn, min_size, max_size
+        return fake_pool
+
+    monkeypatch.setattr("pms.runner.asyncpg.create_pool", fake_create_pool)
+    monkeypatch.setattr("pms.runner.MarketDiscoverySensor", lambda **kwargs: discovery)
+    monkeypatch.setattr("pms.runner.MarketDataSensor", lambda **kwargs: market_data)
+    monkeypatch.setattr("pms.runner.PostgresStrategyRegistry", TrackingRegistry)
+    monkeypatch.setattr("pms.runner.MarketSelector", lambda *args, **kwargs: selector)
+    monkeypatch.setattr(
+        "pms.runner.SensorSubscriptionController",
+        lambda sink: subscription_controller,
+    )
+
+    settings = PMSSettings(
+        mode=RunMode.LIVE,
+        auto_migrate_default_v2=True,
+        database=DatabaseSettings(
+            dsn="postgresql://localhost/pms_test_runner",
+            pool_min_size=2,
+            pool_max_size=10,
+        ),
+        risk=RiskSettings(
+            max_position_per_market=1000.0,
+            max_total_exposure=10_000.0,
+        ),
+    )
+
+    runner = Runner(config=settings, historical_data_path=FIXTURE_PATH)
+    await runner.start()
+    try:
+        registry: Any = runner.strategy_registry
+        assert registry is not None
+        assert isinstance(registry, TrackingRegistry)
+
+        assert len(constructed) == 1, (
+            f"Expected a single PostgresStrategyRegistry construction, "
+            f"got {len(constructed)}. Bootstrap migration and "
+            "active-perception wiring must share one registry instance so "
+            "on_strategy_change fires from every mutation site."
+        )
+        assert constructed[0]["on_strategy_change"] == runner._request_reselection
+
+        runner._reselection_requested.clear()
+        await registry.set_active("default", "default-v2")
+        assert runner._reselection_requested.is_set(), (
+            "Mutation through the Runner-owned registry failed to set "
+            "_reselection_requested; callback is not wired."
+        )
+    finally:
+        await runner.stop()

--- a/tests/unit/test_strategy_change_reselection.py
+++ b/tests/unit/test_strategy_change_reselection.py
@@ -332,15 +332,24 @@ async def test_strategy_change_callback_error_is_logged_without_breaking_write(
 
 
 @pytest.mark.asyncio
-async def test_runner_strategy_change_callback_triggers_reselection(
+@pytest.mark.parametrize(
+    ("trigger_name", "trigger_args"),
+    [
+        ("create_version", (_strategy(),)),
+        ("set_active", ("default", "default-v2")),
+    ],
+)
+async def test_runner_strategy_change_trigger_triggers_reselection(
     monkeypatch: pytest.MonkeyPatch,
+    trigger_name: str,
+    trigger_args: tuple[object, ...],
 ) -> None:
     runtime_pool = RuntimePool()
     discovery = IdleDiscoverySensor()
     market_data = RecordingMarketDataSensor()
     selector = RecordingSelector(returned_asset_ids=["near-no", "near-yes"])
     subscription_controller = RecordingSubscriptionController(sink=market_data)
-    callback_box: dict[str, Callable[[], Awaitable[None]] | None] = {"value": None}
+    registry_box: dict[str, object] = {}
 
     async def fake_create_pool(*, dsn: str, min_size: int, max_size: int) -> RuntimePool:
         del dsn, min_size, max_size
@@ -353,7 +362,21 @@ async def test_runner_strategy_change_callback_triggers_reselection(
             on_strategy_change: Callable[[], Awaitable[None]] | None = None,
         ) -> None:
             del pool
-            callback_box["value"] = on_strategy_change
+            self.on_strategy_change = on_strategy_change
+            registry_box["instance"] = self
+
+        async def create_version(self, *_: object) -> object:
+            if self.on_strategy_change is None:
+                msg = "strategy change callback was not wired"
+                raise AssertionError(msg)
+            await self.on_strategy_change()
+            return object()
+
+        async def set_active(self, *_: object) -> None:
+            if self.on_strategy_change is None:
+                msg = "strategy change callback was not wired"
+                raise AssertionError(msg)
+            await self.on_strategy_change()
 
     monkeypatch.setattr("pms.runner.asyncpg.create_pool", fake_create_pool)
     monkeypatch.setattr("pms.runner.MarketDiscoverySensor", lambda **kwargs: discovery)
@@ -371,10 +394,11 @@ async def test_runner_strategy_change_callback_triggers_reselection(
     )
     await runner.start()
 
-    strategy_change_callback = callback_box["value"]
-    assert strategy_change_callback is not None
+    registry = registry_box["instance"]
+    assert isinstance(registry, CapturingRegistry)
+    trigger = getattr(registry, trigger_name)
+    await trigger(*trigger_args)
 
-    await strategy_change_callback()
     await asyncio.wait_for(selector.call_started.wait(), timeout=2.0)
     assert selector.calls == 1
     assert subscription_controller.calls == 0

--- a/tests/unit/test_strategy_change_reselection.py
+++ b/tests/unit/test_strategy_change_reselection.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pms.config import DatabaseSettings, PMSSettings, RiskSettings
+from pms.core.enums import RunMode
+from pms.core.models import MarketSignal
+from pms.runner import Runner
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from pms.strategies.versioning import (
+    compute_strategy_version_id,
+    serialize_strategy_config_json,
+)
+
+
+FIXTURE_PATH = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
+
+
+@dataclass
+class FakeTransaction:
+    entered: int = 0
+    exited: int = 0
+
+    async def __aenter__(self) -> None:
+        self.entered += 1
+        return None
+
+    async def __aexit__(self, *_: object) -> None:
+        self.exited += 1
+        return None
+
+
+@dataclass
+class FakeConnection:
+    fetchval_results: list[object] = field(default_factory=list)
+    execute_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    fetchval_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    transaction_manager: FakeTransaction = field(default_factory=FakeTransaction)
+    acquire_exit_calls: int = 0
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.execute_calls.append((query, args))
+        return "EXECUTE"
+
+    async def fetchval(self, query: str, *args: object) -> object:
+        self.fetchval_calls.append((query, args))
+        if not self.fetchval_results:
+            msg = "fetchval called without a configured result"
+            raise AssertionError(msg)
+        return self.fetchval_results.pop(0)
+
+    def transaction(self) -> FakeTransaction:
+        return self.transaction_manager
+
+
+class FakeAcquire:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> FakeConnection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        self._connection.acquire_exit_calls += 1
+        return None
+
+
+class FakePool:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> FakeAcquire:
+        return FakeAcquire(self._connection)
+
+
+@dataclass
+class RuntimePool:
+    close_calls: int = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class IdleDiscoverySensor:
+    on_poll_complete: Callable[[], Awaitable[None]] | None = None
+    close_calls: int = 0
+
+    def __aiter__(self) -> AsyncIterator[MarketSignal]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[MarketSignal]:
+        while True:
+            await asyncio.sleep(60.0)
+            yield _signal()
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class RecordingMarketDataSensor:
+    asset_ids: list[str] = field(default_factory=list)
+    updates: list[list[str]] = field(default_factory=list)
+    update_started: asyncio.Event = field(default_factory=asyncio.Event)
+    update_release: asyncio.Event = field(default_factory=asyncio.Event)
+
+    def __aiter__(self) -> AsyncIterator[MarketSignal]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[MarketSignal]:
+        while True:
+            await asyncio.sleep(60.0)
+            yield _signal()
+
+    async def update_subscription(self, asset_ids: list[str]) -> None:
+        self.asset_ids = list(asset_ids)
+        self.updates.append(list(asset_ids))
+        self.update_started.set()
+        await self.update_release.wait()
+
+
+@dataclass
+class RecordingSelector:
+    returned_asset_ids: list[str]
+    calls: int = 0
+    call_started: asyncio.Event = field(default_factory=asyncio.Event)
+    call_release: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def select(self) -> Any:
+        self.calls += 1
+        self.call_started.set()
+        await self.call_release.wait()
+        return type(
+            "MergeResult",
+            (),
+            {"asset_ids": tuple(self.returned_asset_ids)},
+        )()
+
+
+@dataclass
+class RecordingSubscriptionController:
+    sink: RecordingMarketDataSensor
+    calls: int = 0
+    call_started: asyncio.Event = field(default_factory=asyncio.Event)
+    call_release: asyncio.Event = field(default_factory=asyncio.Event)
+
+    async def update(self, asset_ids: list[str]) -> bool:
+        self.calls += 1
+        self.call_started.set()
+        await self.call_release.wait()
+        await self.sink.update_subscription(asset_ids)
+        return True
+
+
+def _strategy(strategy_id: str = "default") -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=strategy_id,
+            factor_composition=(
+                FactorCompositionStep(
+                    factor_id="factor-a",
+                    role="weighted",
+                    param="",
+                    weight=1.0,
+                    threshold=None,
+                ),
+            ),
+            metadata=(("owner", "system"),),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier",)),
+        forecaster=ForecasterSpec(forecasters=(("rules", (("threshold", "0.55"),)),)),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=30,
+            volume_min_usdc=0.0,
+        ),
+    )
+
+
+def _signal() -> MarketSignal:
+    return MarketSignal(
+        market_id="strategy-change-market",
+        token_id="yes-token",
+        venue="polymarket",
+        title="Will CP06 pass?",
+        yes_price=0.42,
+        volume_24h=1_000.0,
+        resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
+        orderbook={"bids": [], "asks": []},
+        external_signal={"fair_value": 0.55},
+        fetched_at=datetime(2026, 4, 18, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _settings(mode: RunMode) -> PMSSettings:
+    return PMSSettings(
+        mode=mode,
+        auto_migrate_default_v2=False,
+        database=DatabaseSettings(
+            dsn="postgresql://localhost/pms_test_runner",
+            pool_min_size=2,
+            pool_max_size=10,
+        ),
+        risk=RiskSettings(
+            max_position_per_market=1000.0,
+            max_total_exposure=10_000.0,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_factor_catalog_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop_ensure_factor_catalog(pool: object, *, factor_ids: object = None) -> None:
+        del pool, factor_ids
+
+    monkeypatch.setattr("pms.runner.ensure_factor_catalog", _noop_ensure_factor_catalog)
+
+
+@pytest.fixture(autouse=True)
+def _stub_factor_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _NoopFactorService:
+        def __init__(self, **kwargs: Any) -> None:
+            del kwargs
+
+        async def run(self) -> None:
+            return None
+
+    monkeypatch.setattr("pms.runner.FactorService", _NoopFactorService)
+
+
+@pytest.mark.asyncio
+async def test_create_version_fires_callback_after_write_context_exits() -> None:
+    strategy = _strategy()
+    created_at = datetime(2026, 4, 18, 10, 0, tzinfo=timezone(timedelta(hours=-5)))
+    connection = FakeConnection(fetchval_results=[created_at])
+    observed: dict[str, int] = {}
+
+    async def on_strategy_change() -> None:
+        observed["transaction_exited"] = connection.transaction_manager.exited
+        observed["acquire_exited"] = connection.acquire_exit_calls
+
+    registry = PostgresStrategyRegistry(
+        FakePool(connection), on_strategy_change=on_strategy_change
+    )
+
+    version = await registry.create_version(strategy)
+
+    assert version.strategy_id == strategy.config.strategy_id
+    assert version.strategy_version_id == compute_strategy_version_id(*strategy.snapshot())
+    assert version.created_at == created_at.astimezone(UTC)
+    assert connection.fetchval_calls[0][1] == (
+        version.strategy_version_id,
+        strategy.config.strategy_id,
+        serialize_strategy_config_json(*strategy.snapshot()),
+    )
+    assert observed == {"transaction_exited": 1, "acquire_exited": 1}
+
+
+@pytest.mark.asyncio
+async def test_set_active_fires_callback_after_acquire_exit() -> None:
+    connection = FakeConnection()
+    observed: dict[str, int] = {}
+
+    async def on_strategy_change() -> None:
+        observed["acquire_exited"] = connection.acquire_exit_calls
+
+    registry = PostgresStrategyRegistry(
+        FakePool(connection), on_strategy_change=on_strategy_change
+    )
+
+    await registry.set_active("default", "default-v2")
+
+    assert connection.execute_calls == [
+        (
+            """
+        UPDATE strategies
+        SET active_version_id = $2
+        WHERE strategy_id = $1
+        """,
+            ("default", "default-v2"),
+        )
+    ]
+    assert observed == {"acquire_exited": 1}
+
+
+@pytest.mark.asyncio
+async def test_strategy_change_callback_error_is_logged_without_breaking_write(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    created_at = datetime(2026, 4, 18, 14, 0, tzinfo=UTC)
+    connection = FakeConnection(fetchval_results=[created_at])
+
+    async def broken_callback() -> None:
+        raise RuntimeError("callback boom")
+
+    registry = PostgresStrategyRegistry(
+        FakePool(connection),
+        on_strategy_change=broken_callback,
+    )
+
+    caplog.set_level(logging.WARNING)
+    version = await registry.create_version(_strategy())
+
+    assert version.strategy_id == "default"
+    assert "strategy change callback failed: callback boom" in caplog.text
+    assert connection.transaction_manager.exited == 1
+    assert connection.acquire_exit_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_runner_strategy_change_callback_triggers_reselection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_pool = RuntimePool()
+    discovery = IdleDiscoverySensor()
+    market_data = RecordingMarketDataSensor()
+    selector = RecordingSelector(returned_asset_ids=["near-no", "near-yes"])
+    subscription_controller = RecordingSubscriptionController(sink=market_data)
+    callback_box: dict[str, Callable[[], Awaitable[None]] | None] = {"value": None}
+
+    async def fake_create_pool(*, dsn: str, min_size: int, max_size: int) -> RuntimePool:
+        del dsn, min_size, max_size
+        return runtime_pool
+
+    class CapturingRegistry:
+        def __init__(
+            self,
+            pool: object,
+            on_strategy_change: Callable[[], Awaitable[None]] | None = None,
+        ) -> None:
+            del pool
+            callback_box["value"] = on_strategy_change
+
+    monkeypatch.setattr("pms.runner.asyncpg.create_pool", fake_create_pool)
+    monkeypatch.setattr("pms.runner.MarketDiscoverySensor", lambda **kwargs: discovery)
+    monkeypatch.setattr("pms.runner.MarketDataSensor", lambda **kwargs: market_data)
+    monkeypatch.setattr("pms.runner.PostgresStrategyRegistry", CapturingRegistry)
+    monkeypatch.setattr("pms.runner.MarketSelector", lambda *args, **kwargs: selector)
+    monkeypatch.setattr(
+        "pms.runner.SensorSubscriptionController",
+        lambda sink: subscription_controller,
+    )
+
+    runner = Runner(
+        config=_settings(RunMode.LIVE),
+        historical_data_path=FIXTURE_PATH,
+    )
+    await runner.start()
+
+    strategy_change_callback = callback_box["value"]
+    assert strategy_change_callback is not None
+
+    await strategy_change_callback()
+    await asyncio.wait_for(selector.call_started.wait(), timeout=2.0)
+    assert selector.calls == 1
+    assert subscription_controller.calls == 0
+
+    selector.call_release.set()
+    await asyncio.wait_for(subscription_controller.call_started.wait(), timeout=2.0)
+    assert subscription_controller.calls == 1
+
+    subscription_controller.call_release.set()
+    market_data.update_release.set()
+    await asyncio.wait_for(market_data.update_started.wait(), timeout=2.0)
+
+    assert market_data.asset_ids == ["near-no", "near-yes"]
+
+    await runner.stop()

--- a/tests/unit/test_strategy_registry.py
+++ b/tests/unit/test_strategy_registry.py
@@ -267,6 +267,36 @@ async def test_list_strategies_and_versions_return_utc_projection_rows() -> None
     assert versions[0].created_at == created_at.astimezone(UTC)
 
 
+@pytest.mark.asyncio
+async def test_list_market_selections_returns_projection_rows_for_active_versions() -> None:
+    active_strategy = _strategy("alpha", owner="system", drawdown_pct=2.5)
+    active_version_id = compute_strategy_version_id(*active_strategy.snapshot())
+    connection = FakeConnection(
+        fetch_results=[
+            [
+                {
+                    "strategy_id": "alpha",
+                    "strategy_version_id": active_version_id,
+                    "config_json": serialize_strategy_config_json(*active_strategy.snapshot()),
+                }
+            ]
+        ]
+    )
+    registry = PostgresStrategyRegistry(FakePool(connection))
+
+    selections = await registry.list_market_selections()
+
+    assert selections == [
+        (
+            "alpha",
+            active_version_id,
+            active_strategy.market_selection,
+        )
+    ]
+    assert len(connection.fetch_calls) == 1
+    assert "active_version_id IS NOT NULL" in connection.fetch_calls[0][0]
+
+
 def test_ensure_utc_rejects_non_datetime_values() -> None:
     with pytest.raises(TypeError, match="expected datetime"):
         _ensure_utc("2026-04-17")

--- a/tests/unit/test_subscription_controller.py
+++ b/tests/unit/test_subscription_controller.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+import importlib
+from typing import Any
+
+import pytest
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in red phase
+        pytest.fail(f"{module_name} is missing: {exc}")
+    return getattr(module, symbol_name)
+
+
+@pytest.mark.asyncio
+async def test_subscription_controller_updates_sink_only_when_asset_ids_change() -> None:
+    subscription_controller_cls = _load_symbol(
+        "pms.market_selection.subscription_controller",
+        "SensorSubscriptionController",
+    )
+
+    class RecordingSink:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def update_subscription(self, asset_ids: list[str]) -> None:
+            self.calls.append(list(asset_ids))
+
+    sink = RecordingSink()
+    controller = subscription_controller_cls(sink)
+
+    changed = await controller.update(["asset-a", "asset-b"])
+
+    assert changed is True
+    assert sink.calls == [["asset-a", "asset-b"]]
+    assert controller.current_asset_ids == frozenset({"asset-a", "asset-b"})
+    assert isinstance(controller.last_updated_at, datetime)
+    assert controller.last_updated_at.tzinfo is UTC
+
+
+@pytest.mark.asyncio
+async def test_subscription_controller_is_noop_for_same_asset_set() -> None:
+    subscription_controller_cls = _load_symbol(
+        "pms.market_selection.subscription_controller",
+        "SensorSubscriptionController",
+    )
+
+    class RecordingSink:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def update_subscription(self, asset_ids: list[str]) -> None:
+            self.calls.append(list(asset_ids))
+
+    sink = RecordingSink()
+    controller = subscription_controller_cls(sink)
+
+    first_changed = await controller.update(["asset-a", "asset-b"])
+    first_updated_at = controller.last_updated_at
+    second_changed = await controller.update(["asset-b", "asset-a"])
+
+    assert first_changed is True
+    assert second_changed is False
+    assert sink.calls == [["asset-a", "asset-b"]]
+    assert controller.current_asset_ids == frozenset({"asset-a", "asset-b"})
+    assert controller.last_updated_at == first_updated_at
+
+
+@pytest.mark.asyncio
+async def test_subscription_controller_serializes_concurrent_updates() -> None:
+    subscription_controller_cls = _load_symbol(
+        "pms.market_selection.subscription_controller",
+        "SensorSubscriptionController",
+    )
+
+    class BlockingSink:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+            self.current_concurrency = 0
+            self.max_concurrency = 0
+
+        async def update_subscription(self, asset_ids: list[str]) -> None:
+            self.current_concurrency += 1
+            self.max_concurrency = max(self.max_concurrency, self.current_concurrency)
+            self.calls.append(list(asset_ids))
+            if len(self.calls) == 1:
+                self.started.set()
+                await self.release.wait()
+            self.current_concurrency -= 1
+
+    sink = BlockingSink()
+    controller = subscription_controller_cls(sink)
+
+    first_update = asyncio.create_task(controller.update(["asset-a"]))
+    await sink.started.wait()
+    second_update = asyncio.create_task(controller.update(["asset-b"]))
+    await asyncio.sleep(0)
+    sink.release.set()
+
+    first_changed, second_changed = await asyncio.gather(first_update, second_update)
+
+    assert first_changed is True
+    assert second_changed is True
+    assert sink.max_concurrency == 1
+    assert sink.calls == [["asset-a"], ["asset-b"]]
+    assert controller.current_asset_ids == frozenset({"asset-b"})
+    assert controller.last_updated_at is not None

--- a/tests/unit/test_version_hash_stability.py
+++ b/tests/unit/test_version_hash_stability.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import os
 import subprocess
 from pathlib import Path
+import sys
 from typing import Any
 
 import pytest
@@ -238,12 +240,20 @@ print(
 )
 """.strip()
 
+    env = os.environ.copy()
+    pythonpath_entries = [str(repo_root / "src"), str(repo_root)]
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        pythonpath_entries.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+
     result = subprocess.run(
-        ["uv", "run", "python", "-c", script],
+        [sys.executable, "-c", script],
         cwd=repo_root,
         capture_output=True,
         text=True,
         check=True,
+        env=env,
     )
 
     assert result.stdout.strip() == expected_hash


### PR DESCRIPTION
## Summary
- add active-perception market selection and subscription control flow through runner, strategy registry, and API surface
- enforce market selection import boundaries and document the projection-based active-perception architecture
- include full harness checkpoint progression through E2E and full-verify

## Testing
- `uv run pytest -q --cov=pms --cov-report=term` -> `246 passed, 54 skipped`, `86%` coverage
- `uv run mypy src/ tests/ --strict`
- `PMS_RUN_INTEGRATION=1 uv run pytest -m integration -q` -> `54 skipped, 246 deselected`

## Notes
- full-verify verdict: `PASS_WITH_WARNINGS`
- warning: integration-marked tests remained skipped in the local environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a market selection layer that automatically adjusts market subscriptions based on active strategy configurations
  * Added `GET /subscriptions` API endpoint exposing current subscription state (asset IDs, count, last update time)
  * Market subscriptions now update dynamically when strategies change or markets are discovered

* **Documentation**
  * Updated architecture documentation reflecting new market selection layer and responsibilities
  * Updated system documentation and test baselines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->