### PR TITLE
[codex] Close runtime selection contract

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -239,7 +239,9 @@ CREATE TABLE IF NOT EXISTS opportunities (
     staleness_policy TEXT NOT NULL,
     strategy_id TEXT NOT NULL,
     strategy_version_id TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL
+    created_at TIMESTAMPTZ NOT NULL,
+    factor_snapshot_hash TEXT,
+    composition_trace JSONB NOT NULL DEFAULT '{}'::jsonb
 );
 
 -- research backtest inner-ring tables (Invariants 3, 8)
@@ -391,6 +393,12 @@ ALTER TABLE fills
 ALTER TABLE opportunities
     ALTER COLUMN strategy_id SET NOT NULL,
     ALTER COLUMN strategy_version_id SET NOT NULL;
+
+ALTER TABLE opportunities
+    ADD COLUMN IF NOT EXISTS factor_snapshot_hash TEXT;
+
+ALTER TABLE opportunities
+    ADD COLUMN IF NOT EXISTS composition_trace JSONB NOT NULL DEFAULT '{}'::jsonb;
 
 DO $$
 BEGIN

--- a/src/pms/actuator/adapters/paper.py
+++ b/src/pms/actuator/adapters/paper.py
@@ -27,9 +27,9 @@ class PaperActuator:
 
 def _best_fill_price(orderbook: dict[str, Any], decision: TradeDecision) -> float:
     if decision.outcome == "NO":
-        side_key = "bids" if decision.side == Side.BUY.value else "asks"
+        side_key = "bids" if decision.action == Side.BUY.value else "asks"
     else:
-        side_key = "asks" if decision.side == Side.BUY.value else "bids"
+        side_key = "asks" if decision.action == Side.BUY.value else "bids"
     levels = orderbook.get(side_key)
     if not isinstance(levels, list) or not levels:
         raise InsufficientLiquidityError(f"{side_key} depth is empty")

--- a/src/pms/actuator/adapters/paper.py
+++ b/src/pms/actuator/adapters/paper.py
@@ -26,7 +26,10 @@ class PaperActuator:
 
 
 def _best_fill_price(orderbook: dict[str, Any], decision: TradeDecision) -> float:
-    side_key = "asks" if decision.side == Side.BUY.value else "bids"
+    if decision.outcome == "NO":
+        side_key = "bids" if decision.side == Side.BUY.value else "asks"
+    else:
+        side_key = "asks" if decision.side == Side.BUY.value else "bids"
     levels = orderbook.get(side_key)
     if not isinstance(levels, list) or not levels:
         raise InsufficientLiquidityError(f"{side_key} depth is empty")
@@ -38,7 +41,10 @@ def _best_fill_price(orderbook: dict[str, Any], decision: TradeDecision) -> floa
         raise InsufficientLiquidityError(f"{side_key} depth is empty")
     if available_size < decision.size:
         raise InsufficientLiquidityError(f"{side_key} depth is insufficient")
-    return float(cast(str | int | float, best["price"]))
+    best_price = float(cast(str | int | float, best["price"]))
+    if decision.outcome == "NO":
+        return 1.0 - best_price
+    return best_price
 
 
 def _matched_order_state(

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -95,7 +95,10 @@ def create_app(
             "runner_started_at": _jsonable(active_runner.state.runner_started_at),
             "running": _is_runner_running(active_runner),
             "sensors": _sensor_statuses(active_runner),
-            "controller": {"decisions_total": len(active_runner.state.decisions)},
+            "controller": {
+                "decisions_total": len(active_runner.state.decisions),
+                "diagnostics_total": len(active_runner.state.controller_diagnostics),
+            },
             "actuator": {
                 "fills_total": len(active_runner.state.fills),
                 "mode": active_runner.state.mode.value,

--- a/src/pms/controller/diagnostics.py
+++ b/src/pms/controller/diagnostics.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+
+DiagnosticSeverity = Literal["info", "warning", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class ControllerDiagnostic:
+    code: str
+    message: str
+    market_id: str
+    strategy_id: str
+    strategy_version_id: str
+    token_id: str | None
+    severity: DiagnosticSeverity = "warning"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))

--- a/src/pms/controller/factor_snapshot.py
+++ b/src/pms/controller/factor_snapshot.py
@@ -45,11 +45,22 @@ class NullFactorSnapshotReader:
         strategy_id: str,
         strategy_version_id: str,
     ) -> FactorSnapshot:
-        del market_id, as_of, strategy_id, strategy_version_id
         missing_factors = tuple(
             dict.fromkeys((step.factor_id, step.param) for step in required)
         )
-        return FactorSnapshot(values={}, missing_factors=missing_factors)
+        return FactorSnapshot(
+            values={},
+            missing_factors=missing_factors,
+            snapshot_hash=_snapshot_hash(
+                market_id=market_id,
+                as_of=as_of,
+                strategy_id=strategy_id,
+                strategy_version_id=strategy_version_id,
+                required_keys=missing_factors,
+                values={},
+                missing_factors=missing_factors,
+            ),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,12 +76,23 @@ class PostgresFactorSnapshotReader:
         strategy_id: str,
         strategy_version_id: str,
     ) -> FactorSnapshot:
-        del strategy_id, strategy_version_id
         required_keys = tuple(
             dict.fromkeys((step.factor_id, step.param) for step in required)
         )
         if not required_keys:
-            return FactorSnapshot(values={}, missing_factors=())
+            return FactorSnapshot(
+                values={},
+                missing_factors=(),
+                snapshot_hash=_snapshot_hash(
+                    market_id=market_id,
+                    as_of=as_of,
+                    strategy_id=strategy_id,
+                    strategy_version_id=strategy_version_id,
+                    required_keys=(),
+                    values={},
+                    missing_factors=(),
+                ),
+            )
 
         factor_ids = [factor_id for factor_id, _ in required_keys]
         params = [param for _, param in required_keys]
@@ -120,7 +142,15 @@ class PostgresFactorSnapshotReader:
         return FactorSnapshot(
             values=values,
             missing_factors=tuple(missing_factors),
-            snapshot_hash=_snapshot_hash(market_id=market_id, as_of=as_of, values=values),
+            snapshot_hash=_snapshot_hash(
+                market_id=market_id,
+                as_of=as_of,
+                strategy_id=strategy_id,
+                strategy_version_id=strategy_version_id,
+                required_keys=required_keys,
+                values=values,
+                missing_factors=tuple(missing_factors),
+            ),
         )
 
 
@@ -128,14 +158,28 @@ def _snapshot_hash(
     *,
     market_id: str,
     as_of: datetime,
+    strategy_id: str,
+    strategy_version_id: str,
+    required_keys: Sequence[FactorKey],
     values: Mapping[FactorKey, float],
+    missing_factors: Sequence[FactorKey],
 ) -> str:
     payload = {
         "market_id": market_id,
         "as_of": as_of.isoformat(),
+        "strategy_id": strategy_id,
+        "strategy_version_id": strategy_version_id,
+        "required_keys": [
+            [factor_id, param]
+            for factor_id, param in sorted(required_keys)
+        ],
         "values": [
             [factor_id, param, values[(factor_id, param)]]
             for factor_id, param in sorted(values)
+        ],
+        "missing_factors": [
+            [factor_id, param]
+            for factor_id, param in sorted(missing_factors)
         ],
     }
     return sha256(

--- a/src/pms/controller/factor_snapshot.py
+++ b/src/pms/controller/factor_snapshot.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+import json
+from typing import Protocol
+
+import asyncpg
+
+from pms.strategies.projections import FactorCompositionStep
+
+
+FactorKey = tuple[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class FactorSnapshot:
+    values: Mapping[FactorKey, float]
+    missing_factors: tuple[FactorKey, ...] = ()
+    snapshot_hash: str | None = None
+
+
+class FactorSnapshotReader(Protocol):
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> FactorSnapshot: ...
+
+
+@dataclass(frozen=True, slots=True)
+class NullFactorSnapshotReader:
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> FactorSnapshot:
+        del market_id, as_of, strategy_id, strategy_version_id
+        missing_factors = tuple(
+            dict.fromkeys((step.factor_id, step.param) for step in required)
+        )
+        return FactorSnapshot(values={}, missing_factors=missing_factors)
+
+
+@dataclass(frozen=True, slots=True)
+class PostgresFactorSnapshotReader:
+    pool: asyncpg.Pool
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> FactorSnapshot:
+        del strategy_id, strategy_version_id
+        required_keys = tuple(
+            dict.fromkeys((step.factor_id, step.param) for step in required)
+        )
+        if not required_keys:
+            return FactorSnapshot(values={}, missing_factors=())
+
+        factor_ids = [factor_id for factor_id, _ in required_keys]
+        params = [param for _, param in required_keys]
+        async with self.pool.acquire() as connection:
+            rows = await connection.fetch(
+                """
+                WITH required(factor_id, param) AS (
+                    SELECT * FROM unnest($3::text[], $4::text[])
+                ),
+                latest AS (
+                    SELECT DISTINCT ON (fv.factor_id, fv.param)
+                        fv.factor_id,
+                        fv.param,
+                        fv.value
+                    FROM factor_values AS fv
+                    INNER JOIN required
+                        ON required.factor_id = fv.factor_id
+                       AND required.param = fv.param
+                    WHERE fv.market_id = $1
+                      AND fv.ts <= $2
+                    ORDER BY fv.factor_id ASC, fv.param ASC, fv.ts DESC
+                )
+                SELECT
+                    required.factor_id,
+                    required.param,
+                    latest.value
+                FROM required
+                LEFT JOIN latest
+                    ON latest.factor_id = required.factor_id
+                   AND latest.param = required.param
+                ORDER BY required.factor_id ASC, required.param ASC
+                """,
+                market_id,
+                as_of,
+                factor_ids,
+                params,
+            )
+        values: dict[FactorKey, float] = {}
+        missing_factors: list[FactorKey] = []
+        for row in rows:
+            key = (row["factor_id"], row["param"])
+            value = row["value"]
+            if value is None:
+                missing_factors.append(key)
+                continue
+            values[key] = float(value)
+        return FactorSnapshot(
+            values=values,
+            missing_factors=tuple(missing_factors),
+            snapshot_hash=_snapshot_hash(market_id=market_id, as_of=as_of, values=values),
+        )
+
+
+def _snapshot_hash(
+    *,
+    market_id: str,
+    as_of: datetime,
+    values: Mapping[FactorKey, float],
+) -> str:
+    payload = {
+        "market_id": market_id,
+        "as_of": as_of.isoformat(),
+        "values": [
+            [factor_id, param, values[(factor_id, param)]]
+            for factor_id, param in sorted(values)
+        ],
+    }
+    return sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
+            "utf-8"
+        )
+    ).hexdigest()

--- a/src/pms/controller/factory.py
+++ b/src/pms/controller/factory.py
@@ -5,9 +5,17 @@ from dataclasses import dataclass, field
 
 from pms.config import LLMSettings, PMSSettings, RiskSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.factor_snapshot import (
+    FactorSnapshotReader,
+    NullFactorSnapshotReader,
+)
 from pms.controller.forecasters.llm import LLMForecaster
 from pms.controller.forecasters.rules import RulesForecaster
 from pms.controller.forecasters.statistical import StatisticalForecaster
+from pms.controller.outcome_tokens import (
+    NullOutcomeTokenResolver,
+    OutcomeTokenResolver,
+)
 from pms.controller.pipeline import ControllerPipeline
 from pms.controller.router import Router
 from pms.controller.sizers.kelly import KellySizer
@@ -18,6 +26,12 @@ from pms.strategies.projections import ActiveStrategy
 @dataclass
 class ControllerPipelineFactory:
     settings: PMSSettings = field(default_factory=PMSSettings)
+    factor_reader: FactorSnapshotReader = field(
+        default_factory=NullFactorSnapshotReader
+    )
+    outcome_token_resolver: OutcomeTokenResolver = field(
+        default_factory=NullOutcomeTokenResolver
+    )
 
     def build_many(
         self,
@@ -30,8 +44,11 @@ class ControllerPipelineFactory:
 
     def build(self, strategy: ActiveStrategy) -> ControllerPipeline:
         return ControllerPipeline(
+            strategy=strategy,
             strategy_id=strategy.strategy_id,
             strategy_version_id=strategy.strategy_version_id,
+            factor_reader=self.factor_reader,
+            outcome_token_resolver=self.outcome_token_resolver,
             forecasters=self._build_forecasters(strategy),
             calibrator=NetcalCalibrator(),
             sizer=KellySizer(

--- a/src/pms/controller/outcome_tokens.py
+++ b/src/pms/controller/outcome_tokens.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from pms.core.models import Token
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeTokens:
+    yes_token_id: str | None
+    no_token_id: str | None
+
+
+class OutcomeTokenResolver(Protocol):
+    async def resolve(
+        self,
+        *,
+        market_id: str,
+        signal_token_id: str | None,
+    ) -> OutcomeTokens: ...
+
+
+@dataclass(frozen=True, slots=True)
+class NullOutcomeTokenResolver:
+    async def resolve(
+        self,
+        *,
+        market_id: str,
+        signal_token_id: str | None,
+    ) -> OutcomeTokens:
+        del market_id
+        return OutcomeTokens(yes_token_id=signal_token_id, no_token_id=None)
+
+
+class TokenLookup(Protocol):
+    async def read_tokens_for_market(self, market_id: str) -> list[Token]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class MarketDataOutcomeTokenResolver:
+    store: TokenLookup
+
+    async def resolve(
+        self,
+        *,
+        market_id: str,
+        signal_token_id: str | None,
+    ) -> OutcomeTokens:
+        tokens = await self.store.read_tokens_for_market(market_id)
+        yes_token_id = signal_token_id
+        no_token_id: str | None = None
+        for token in tokens:
+            if token.outcome == "YES" and yes_token_id is None:
+                yes_token_id = token.token_id
+            if token.outcome == "NO":
+                no_token_id = token.token_id
+        return OutcomeTokens(yes_token_id=yes_token_id, no_token_id=no_token_id)

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -6,17 +6,27 @@ from datetime import UTC, datetime
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 from pms.config import PMSSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.factor_snapshot import (
+    FactorSnapshotReader,
+    NullFactorSnapshotReader,
+)
 from pms.controller.forecasters.llm import LLMForecaster
 from pms.controller.forecasters.rules import RulesForecaster
 from pms.controller.forecasters.statistical import StatisticalForecaster
+from pms.controller.outcome_tokens import (
+    NullOutcomeTokenResolver,
+    OutcomeTokenResolver,
+)
 from pms.controller.router import Router
 from pms.controller.sizers.kelly import KellySizer
 from pms.core.interfaces import ICalibrator, IForecaster, ISizer
 from pms.core.models import MarketSignal, Opportunity, Portfolio, TradeDecision
+from pms.factors.composition import apply_composition, evaluate_branch_probabilities
+from pms.strategies.projections import ActiveStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +39,13 @@ T = TypeVar("T")
 class ControllerPipeline:
     strategy_id: str = "default"
     strategy_version_id: str = "default-v1"
+    strategy: ActiveStrategy | None = None
+    factor_reader: FactorSnapshotReader = field(
+        default_factory=NullFactorSnapshotReader
+    )
+    outcome_token_resolver: OutcomeTokenResolver = field(
+        default_factory=NullOutcomeTokenResolver
+    )
     forecasters: Sequence[IForecaster] | None = None
     calibrator: ICalibrator | None = None
     sizer: ISizer | None = None
@@ -36,6 +53,9 @@ class ControllerPipeline:
     settings: PMSSettings = field(default_factory=PMSSettings)
 
     def __post_init__(self) -> None:
+        if self.strategy is not None:
+            self.strategy_id = self.strategy.strategy_id
+            self.strategy_version_id = self.strategy.strategy_version_id
         if self.forecasters is None:
             self.forecasters = (
                 RulesForecaster(),
@@ -70,23 +90,77 @@ class ControllerPipeline:
         probabilities: list[float] = []
         model_ids: list[str] = []
         rationales: list[str] = []
+        runtime_probabilities: dict[str, float] = {}
+        forecaster_names = _strategy_forecaster_names(self.strategy)
         calibrator = _required(self.calibrator, "calibrator")
-        for forecaster, result in zip(forecasters, results, strict=True):
+        for index, (forecaster, result) in enumerate(
+            zip(forecasters, results, strict=True)
+        ):
             if isinstance(result, BaseException):
                 logger.warning("forecaster failed: %s", result)
                 continue
             if result is None:
                 continue
             model_id = _model_id(result, forecaster)
+            calibrated_probability = calibrator.calibrate(
+                float(result[0]),
+                model_id=model_id,
+            )
             model_ids.append(model_id)
-            probabilities.append(calibrator.calibrate(float(result[0]), model_id=model_id))
+            probabilities.append(calibrated_probability)
             if result[2]:
                 rationales.append(f"{model_id}:{result[2]}")
+            runtime_factor_id = _runtime_factor_id(
+                forecaster_names[index] if index < len(forecaster_names) else None
+            )
+            if runtime_factor_id is not None:
+                runtime_probabilities[runtime_factor_id] = calibrated_probability
 
         if not probabilities:
             return None
 
         prob_estimate = sum(probabilities) / len(probabilities)
+        factor_snapshot_hash: str | None = None
+        composition_trace: dict[str, object] = {}
+        if self.strategy is not None and self.strategy.config.factor_composition:
+            factor_snapshot = await self.factor_reader.snapshot(
+                market_id=signal.market_id,
+                as_of=signal.timestamp,
+                required=self.strategy.config.factor_composition,
+                strategy_id=self.strategy.strategy_id,
+                strategy_version_id=self.strategy.strategy_version_id,
+            )
+            factor_values = dict(factor_snapshot.values)
+            factor_values.update(_signal_factor_values(signal))
+            factor_values.update(
+                {
+                    (factor_id, ""): value
+                    for factor_id, value in runtime_probabilities.items()
+                }
+            )
+            try:
+                branch_probabilities = evaluate_branch_probabilities(
+                    self.strategy.config.factor_composition,
+                    factor_values,
+                )
+                prob_estimate = apply_composition(
+                    self.strategy.config.factor_composition,
+                    factor_values,
+                )
+                factor_snapshot_hash = factor_snapshot.snapshot_hash
+                composition_trace = {
+                    "selected_probability": prob_estimate,
+                    "expected_edge": prob_estimate - signal.yes_price,
+                    "factor_snapshot_hash": factor_snapshot.snapshot_hash,
+                    "missing_factors": [
+                        f"{factor_id}:{param}"
+                        for factor_id, param in factor_snapshot.missing_factors
+                    ],
+                    "branch_probabilities": branch_probabilities,
+                }
+            except (KeyError, ValueError) as exc:
+                logger.warning("composition resolution failed: %s", exc)
+                return None
         expected_edge = prob_estimate - signal.yes_price
         active_portfolio = portfolio or _default_portfolio()
         sizer = _required(self.sizer, "sizer")
@@ -96,11 +170,31 @@ class ControllerPipeline:
             portfolio=active_portfolio,
         )
         now = datetime.now(tz=UTC)
+        opportunity_side: Literal["yes", "no"] = (
+            "yes" if expected_edge >= 0.0 else "no"
+        )
+        decision_token_id = signal.token_id
+        decision_outcome: Literal["YES", "NO"] = "YES"
+        decision_price = signal.yes_price
+        if expected_edge < 0.0:
+            outcome_tokens = await self.outcome_token_resolver.resolve(
+                market_id=signal.market_id,
+                signal_token_id=signal.token_id,
+            )
+            if outcome_tokens.no_token_id is None:
+                logger.info(
+                    "skipping bearish decision for %s: no NO token available",
+                    signal.market_id,
+                )
+                return None
+            decision_token_id = outcome_tokens.no_token_id
+            decision_outcome = "NO"
+            decision_price = max(0.0, 1.0 - signal.yes_price)
         opportunity = Opportunity(
             opportunity_id=f"opportunity-{uuid.uuid4().hex}",
             market_id=signal.market_id,
-            token_id=signal.token_id,
-            side="yes" if expected_edge >= 0.0 else "no",
+            token_id=decision_token_id,
+            side=opportunity_side,
             selected_factor_values=_selected_factor_values(signal),
             expected_edge=expected_edge,
             rationale=_rationale_text(rationales),
@@ -110,15 +204,17 @@ class ControllerPipeline:
             strategy_id=self.strategy_id,
             strategy_version_id=self.strategy_version_id,
             created_at=now,
+            factor_snapshot_hash=factor_snapshot_hash,
+            composition_trace=composition_trace,
         )
 
         return opportunity, TradeDecision(
             decision_id=f"decision-{uuid.uuid4().hex}",
             market_id=signal.market_id,
-            token_id=signal.token_id,
+            token_id=decision_token_id,
             venue=signal.venue,
-            side="BUY" if expected_edge >= 0.0 else "SELL",
-            price=signal.yes_price,
+            side="BUY",
+            price=decision_price,
             size=size,
             order_type="limit",
             max_slippage_bps=self.settings.controller.max_slippage_bps,
@@ -129,6 +225,7 @@ class ControllerPipeline:
             opportunity_id=opportunity.opportunity_id,
             strategy_id=self.strategy_id,
             strategy_version_id=self.strategy_version_id,
+            outcome=decision_outcome,
             model_id=_decision_model_id(model_ids),
         )
 
@@ -173,6 +270,32 @@ def _selected_factor_values(signal: MarketSignal) -> dict[str, float]:
         for key, value in signal.external_signal.items()
         if isinstance(value, (int, float)) and not isinstance(value, bool)
     }
+
+
+def _signal_factor_values(signal: MarketSignal) -> dict[tuple[str, str], float]:
+    factor_values = {
+        (key, ""): float(value)
+        for key, value in signal.external_signal.items()
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    }
+    factor_values[("yes_price", "")] = signal.yes_price
+    return factor_values
+
+
+def _strategy_forecaster_names(strategy: ActiveStrategy | None) -> tuple[str, ...]:
+    if strategy is None:
+        return ()
+    return tuple(name for name, _ in strategy.forecaster.forecasters)
+
+
+def _runtime_factor_id(forecaster_name: str | None) -> str | None:
+    if forecaster_name is None:
+        return None
+    if forecaster_name == "stats":
+        return "statistical"
+    if forecaster_name in {"rules", "llm"}:
+        return forecaster_name
+    return None
 
 
 def _rationale_text(rationales: Sequence[str]) -> str:

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -10,7 +10,9 @@ from typing import Literal, TypeVar
 
 from pms.config import PMSSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.diagnostics import ControllerDiagnostic
 from pms.controller.factor_snapshot import (
+    FactorKey,
     FactorSnapshotReader,
     NullFactorSnapshotReader,
 )
@@ -51,6 +53,7 @@ class ControllerPipeline:
     sizer: ISizer | None = None
     router: Router | None = None
     settings: PMSSettings = field(default_factory=PMSSettings)
+    last_diagnostic: ControllerDiagnostic | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         if self.strategy is not None:
@@ -74,6 +77,7 @@ class ControllerPipeline:
         signal: MarketSignal,
         portfolio: Portfolio | None = None,
     ) -> OpportunityEmission | None:
+        self.last_diagnostic = None
         router = _required(self.router, "router")
         if not router.gate(signal):
             return None
@@ -122,6 +126,13 @@ class ControllerPipeline:
         prob_estimate = sum(probabilities) / len(probabilities)
         factor_snapshot_hash: str | None = None
         composition_trace: dict[str, object] = {}
+        factor_values = _signal_factor_values(signal)
+        factor_values.update(
+            {
+                (factor_id, ""): value
+                for factor_id, value in runtime_probabilities.items()
+            }
+        )
         if self.strategy is not None and self.strategy.config.factor_composition:
             factor_snapshot = await self.factor_reader.snapshot(
                 market_id=signal.market_id,
@@ -153,7 +164,7 @@ class ControllerPipeline:
                     "expected_edge": prob_estimate - signal.yes_price,
                     "factor_snapshot_hash": factor_snapshot.snapshot_hash,
                     "missing_factors": [
-                        f"{factor_id}:{param}"
+                        _factor_key_label((factor_id, param))
                         for factor_id, param in factor_snapshot.missing_factors
                     ],
                     "branch_probabilities": branch_probabilities,
@@ -182,9 +193,27 @@ class ControllerPipeline:
                 signal_token_id=signal.token_id,
             )
             if outcome_tokens.no_token_id is None:
+                self.last_diagnostic = ControllerDiagnostic(
+                    code="missing_no_token",
+                    message=(
+                        "Skipping bearish decision because no NO token could be resolved."
+                    ),
+                    market_id=signal.market_id,
+                    strategy_id=self.strategy_id,
+                    strategy_version_id=self.strategy_version_id,
+                    token_id=signal.token_id,
+                    severity="warning",
+                    metadata={
+                        "signal_token_id": signal.token_id,
+                        "yes_token_id": outcome_tokens.yes_token_id,
+                        "outcome": "NO",
+                    },
+                )
                 logger.info(
-                    "skipping bearish decision for %s: no NO token available",
+                    "controller diagnostic %s for %s",
+                    self.last_diagnostic.code,
                     signal.market_id,
+                    extra={"controller_diagnostic": self.last_diagnostic},
                 )
                 return None
             decision_token_id = outcome_tokens.no_token_id
@@ -195,7 +224,7 @@ class ControllerPipeline:
             market_id=signal.market_id,
             token_id=decision_token_id,
             side=opportunity_side,
-            selected_factor_values=_selected_factor_values(signal),
+            selected_factor_values=_selected_factor_values(factor_values),
             expected_edge=expected_edge,
             rationale=_rationale_text(rationales),
             target_size_usdc=size,
@@ -225,6 +254,8 @@ class ControllerPipeline:
             opportunity_id=opportunity.opportunity_id,
             strategy_id=self.strategy_id,
             strategy_version_id=self.strategy_version_id,
+            action="BUY",
+            limit_price=decision_price,
             outcome=decision_outcome,
             model_id=_decision_model_id(model_ids),
         )
@@ -264,11 +295,10 @@ def _decision_model_id(model_ids: Sequence[str]) -> str | None:
     return "ensemble"
 
 
-def _selected_factor_values(signal: MarketSignal) -> dict[str, float]:
+def _selected_factor_values(factor_values: dict[FactorKey, float]) -> dict[str, float]:
     return {
-        key: float(value)
-        for key, value in signal.external_signal.items()
-        if isinstance(value, (int, float)) and not isinstance(value, bool)
+        _factor_key_label(key): value
+        for key, value in sorted(factor_values.items())
     }
 
 
@@ -280,6 +310,13 @@ def _signal_factor_values(signal: MarketSignal) -> dict[tuple[str, str], float]:
     }
     factor_values[("yes_price", "")] = signal.yes_price
     return factor_values
+
+
+def _factor_key_label(key: FactorKey) -> str:
+    factor_id, param = key
+    if not param:
+        return factor_id
+    return f"{factor_id}:{param}"
 
 
 def _strategy_forecaster_names(strategy: ActiveStrategy | None) -> tuple[str, ...]:

--- a/src/pms/core/models.py
+++ b/src/pms/core/models.py
@@ -57,6 +57,8 @@ class Opportunity:
     strategy_id: str
     strategy_version_id: str
     created_at: datetime
+    factor_snapshot_hash: str | None = None
+    composition_trace: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -77,7 +79,16 @@ class TradeDecision:
     opportunity_id: str
     strategy_id: str
     strategy_version_id: str
+    outcome: Outcome = "YES"
     model_id: str | None = None
+
+    @property
+    def action(self) -> str:
+        return self.side
+
+    @property
+    def limit_price(self) -> float:
+        return self.price
 
 
 @dataclass(frozen=True)
@@ -254,3 +265,5 @@ class Feedback:
     resolved_at: datetime | None = None
     category: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    strategy_id: str = "default"
+    strategy_version_id: str = "default-v1"

--- a/src/pms/core/models.py
+++ b/src/pms/core/models.py
@@ -67,7 +67,7 @@ class TradeDecision:
     market_id: str
     token_id: str | None
     venue: Venue
-    side: str
+    side: BookSide
     price: float
     size: float
     order_type: str
@@ -79,16 +79,22 @@ class TradeDecision:
     opportunity_id: str
     strategy_id: str
     strategy_version_id: str
+    action: BookSide | None = None
+    limit_price: float | None = None
     outcome: Outcome = "YES"
     model_id: str | None = None
 
-    @property
-    def action(self) -> str:
-        return self.side
-
-    @property
-    def limit_price(self) -> float:
-        return self.price
+    def __post_init__(self) -> None:
+        action = self.side if self.action is None else self.action
+        if action != self.side:
+            msg = "TradeDecision.action must match TradeDecision.side"
+            raise ValueError(msg)
+        limit_price = self.price if self.limit_price is None else self.limit_price
+        if limit_price != self.price:
+            msg = "TradeDecision.limit_price must match TradeDecision.price"
+            raise ValueError(msg)
+        object.__setattr__(self, "action", action)
+        object.__setattr__(self, "limit_price", limit_price)
 
 
 @dataclass(frozen=True)

--- a/src/pms/evaluation/adapters/scoring.py
+++ b/src/pms/evaluation/adapters/scoring.py
@@ -50,19 +50,22 @@ def _pnl(fill: FillRecord, decision: TradeDecision) -> float:
     if fill.resolved_outcome is None:
         return 0.0
     contract_outcome = _contract_outcome(fill.resolved_outcome, decision)
-    if decision.side == Side.SELL.value:
+    action = decision.action if decision.action is not None else decision.side
+    if action == Side.SELL.value:
         return (fill.fill_price - contract_outcome) * fill.fill_size
     return (contract_outcome - fill.fill_price) * fill.fill_size
 
 
 def _slippage_bps(fill: FillRecord, decision: TradeDecision) -> float:
-    if decision.price == 0.0:
+    limit_price = decision.limit_price if decision.limit_price is not None else decision.price
+    if limit_price == 0.0:
         return 0.0
-    if decision.side == Side.SELL.value:
-        slippage = decision.price - fill.fill_price
+    action = decision.action if decision.action is not None else decision.side
+    if action == Side.SELL.value:
+        slippage = limit_price - fill.fill_price
     else:
-        slippage = fill.fill_price - decision.price
-    return max(0.0, slippage / decision.price * 10_000)
+        slippage = fill.fill_price - limit_price
+    return max(0.0, slippage / limit_price * 10_000)
 
 
 def _contract_outcome(resolved_outcome: float, decision: TradeDecision) -> float:

--- a/src/pms/evaluation/adapters/scoring.py
+++ b/src/pms/evaluation/adapters/scoring.py
@@ -49,9 +49,10 @@ def _model_id(decision: TradeDecision) -> str:
 def _pnl(fill: FillRecord, decision: TradeDecision) -> float:
     if fill.resolved_outcome is None:
         return 0.0
+    contract_outcome = _contract_outcome(fill.resolved_outcome, decision)
     if decision.side == Side.SELL.value:
-        return (fill.fill_price - fill.resolved_outcome) * fill.fill_size
-    return (fill.resolved_outcome - fill.fill_price) * fill.fill_size
+        return (fill.fill_price - contract_outcome) * fill.fill_size
+    return (contract_outcome - fill.fill_price) * fill.fill_size
 
 
 def _slippage_bps(fill: FillRecord, decision: TradeDecision) -> float:
@@ -62,3 +63,9 @@ def _slippage_bps(fill: FillRecord, decision: TradeDecision) -> float:
     else:
         slippage = fill.fill_price - decision.price
     return max(0.0, slippage / decision.price * 10_000)
+
+
+def _contract_outcome(resolved_outcome: float, decision: TradeDecision) -> float:
+    if decision.outcome == "NO":
+        return 1.0 - resolved_outcome
+    return resolved_outcome

--- a/src/pms/research/__init__.py
+++ b/src/pms/research/__init__.py
@@ -14,6 +14,7 @@ from .entities import (
     deserialize_portfolio_target_json,
     serialize_portfolio_target_json,
 )
+from .execution import BacktestExecutionSimulator
 from .policies import (
     SelectionDenominator,
     SelectionSimilarityMetric,
@@ -38,6 +39,7 @@ __all__ = [
     "BacktestLiveComparisonTool",
     "BacktestDataset",
     "BacktestExecutionConfig",
+    "BacktestExecutionSimulator",
     "BacktestRunner",
     "BacktestSpec",
     "EvaluationRankingMetric",

--- a/src/pms/research/execution.py
+++ b/src/pms/research/execution.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, cast
+from uuid import uuid4
+
+from pms.actuator.risk import InsufficientLiquidityError
+from pms.core.enums import OrderStatus, Side
+from pms.core.models import MarketSignal, OrderState, Portfolio, TradeDecision
+from pms.research.specs import ExecutionModel
+
+
+@dataclass(frozen=True)
+class BacktestExecutionSimulator:
+    async def execute(
+        self,
+        *,
+        signal: MarketSignal,
+        decision: TradeDecision,
+        portfolio: Portfolio | None = None,
+        execution_model: ExecutionModel,
+    ) -> OrderState:
+        del portfolio
+        submitted_at = signal.fetched_at + timedelta(milliseconds=execution_model.latency_ms)
+        if signal.resolves_at is not None and submitted_at >= signal.resolves_at:
+            return _unfilled_order_state(
+                decision,
+                submitted_at=submitted_at,
+                status=OrderStatus.CANCELED_MARKET_RESOLVED.value,
+                raw_status="market_resolved_before_execution",
+            )
+        if (
+            not math.isinf(execution_model.staleness_ms)
+            and execution_model.latency_ms > execution_model.staleness_ms
+        ):
+            return _unfilled_order_state(
+                decision,
+                submitted_at=submitted_at,
+                status=OrderStatus.CANCELED.value,
+                raw_status="stale_signal",
+            )
+        market_price = _best_market_price(signal.orderbook, decision)
+        fill_price = _apply_slippage(
+            market_price,
+            action=_action(decision),
+            slippage_bps=execution_model.slippage_bps,
+        )
+        if execution_model.fill_policy == "limit_if_touched" and not _is_touched(
+            action=_action(decision),
+            fill_price=fill_price,
+            limit_price=_limit_price(decision),
+        ):
+            return _unfilled_order_state(
+                decision,
+                submitted_at=submitted_at,
+                status=OrderStatus.UNMATCHED.value,
+                raw_status="limit_not_touched",
+            )
+        return _matched_order_state(
+            decision,
+            fill_price=fill_price,
+            submitted_at=submitted_at,
+        )
+
+
+def _best_market_price(orderbook: dict[str, Any], decision: TradeDecision) -> float:
+    if decision.outcome == "NO":
+        side_key = "bids" if _action(decision) == Side.BUY.value else "asks"
+    else:
+        side_key = "asks" if _action(decision) == Side.BUY.value else "bids"
+    levels = orderbook.get(side_key)
+    if not isinstance(levels, list) or not levels:
+        raise InsufficientLiquidityError(f"{side_key} depth is empty")
+    best = levels[0]
+    if not isinstance(best, dict):
+        raise InsufficientLiquidityError(f"{side_key} depth is invalid")
+    available_size = float(cast(str | int | float, best.get("size", 0.0)))
+    if available_size <= 0.0:
+        raise InsufficientLiquidityError(f"{side_key} depth is empty")
+    if available_size < decision.size:
+        raise InsufficientLiquidityError(f"{side_key} depth is insufficient")
+    best_price = float(cast(str | int | float, best["price"]))
+    if decision.outcome == "NO":
+        return 1.0 - best_price
+    return best_price
+
+
+def _apply_slippage(price: float, *, action: str, slippage_bps: float) -> float:
+    multiplier = slippage_bps / 10_000.0
+    if action == Side.SELL.value:
+        return max(0.0, price * (1.0 - multiplier))
+    return min(1.0, price * (1.0 + multiplier))
+
+
+def _is_touched(*, action: str, fill_price: float, limit_price: float) -> bool:
+    if action == Side.SELL.value:
+        return fill_price >= limit_price
+    return fill_price <= limit_price
+
+
+def _matched_order_state(
+    decision: TradeDecision,
+    *,
+    fill_price: float,
+    submitted_at: datetime,
+) -> OrderState:
+    return OrderState(
+        order_id=f"backtest-sim-{uuid4().hex}",
+        decision_id=decision.decision_id,
+        status=OrderStatus.MATCHED.value,
+        market_id=decision.market_id,
+        token_id=decision.token_id,
+        venue=decision.venue,
+        requested_size=decision.size,
+        filled_size=decision.size,
+        remaining_size=0.0,
+        fill_price=fill_price,
+        submitted_at=submitted_at,
+        last_updated_at=submitted_at,
+        raw_status="matched",
+        strategy_id=decision.strategy_id,
+        strategy_version_id=decision.strategy_version_id,
+    )
+
+
+def _unfilled_order_state(
+    decision: TradeDecision,
+    *,
+    submitted_at: datetime,
+    status: str,
+    raw_status: str,
+) -> OrderState:
+    return OrderState(
+        order_id=f"backtest-sim-{uuid4().hex}",
+        decision_id=decision.decision_id,
+        status=status,
+        market_id=decision.market_id,
+        token_id=decision.token_id,
+        venue=decision.venue,
+        requested_size=decision.size,
+        filled_size=0.0,
+        remaining_size=decision.size,
+        fill_price=None,
+        submitted_at=submitted_at,
+        last_updated_at=submitted_at,
+        raw_status=raw_status,
+        strategy_id=decision.strategy_id,
+        strategy_version_id=decision.strategy_version_id,
+    )
+
+
+def _action(decision: TradeDecision) -> str:
+    return decision.action if decision.action is not None else decision.side
+
+
+def _limit_price(decision: TradeDecision) -> float:
+    return decision.limit_price if decision.limit_price is not None else decision.price

--- a/src/pms/research/runner.py
+++ b/src/pms/research/runner.py
@@ -17,6 +17,8 @@ import asyncpg
 from pms.actuator.adapters.paper import PaperActuator
 from pms.actuator.risk import InsufficientLiquidityError
 from pms.controller.factory import ControllerPipelineFactory
+from pms.controller.factor_snapshot import PostgresFactorSnapshotReader
+from pms.controller.outcome_tokens import MarketDataOutcomeTokenResolver
 from pms.core.enums import OrderStatus
 from pms.core.models import FillRecord, MarketSignal, OrderState, Portfolio, Position
 from pms.evaluation.metrics import StrategyVersionKey
@@ -31,6 +33,7 @@ from pms.research.specs import (
     BacktestSpec,
     ExecutionModel,
 )
+from pms.storage.market_data_store import PostgresMarketDataStore
 from pms.storage.strategy_registry import _strategy_from_config_json
 from pms.strategies.projections import ActiveStrategy
 
@@ -122,7 +125,6 @@ class _StrategyAccumulator:
         self,
         *,
         signal: MarketSignal,
-        opportunity: object,
         decision: object,
         fill_price: float,
     ) -> None:
@@ -132,7 +134,7 @@ class _StrategyAccumulator:
             self.fills_with_resolution += 1
         pnl_delta = _pnl_delta(
             signal=signal,
-            opportunity_side=cast(str, getattr(opportunity, "side")),
+            decision_outcome=cast(str, getattr(decision, "outcome", "YES")),
             decision_size=float(cast(float, getattr(decision, "size"))),
             fill_price=fill_price,
             execution_model=self.execution_model,
@@ -213,6 +215,14 @@ class BacktestRunner:
     def __post_init__(self) -> None:
         if self.replay_engine is None:
             self.replay_engine = MarketUniverseReplayEngine(pool=self.readonly_pool)
+        if isinstance(self.controller_factory, ControllerPipelineFactory):
+            market_data_store = PostgresMarketDataStore(self.readonly_pool)
+            self.controller_factory.factor_reader = PostgresFactorSnapshotReader(
+                self.readonly_pool
+            )
+            self.controller_factory.outcome_token_resolver = (
+                MarketDataOutcomeTokenResolver(market_data_store)
+            )
 
     async def execute(self, run_id: str) -> bool:
         claimed_run = await self._claim_run(run_id)
@@ -302,7 +312,6 @@ class BacktestRunner:
             if fill_price is not None:
                 accumulator.record_fill(
                     signal=signal,
-                    opportunity=opportunity,
                     decision=decision,
                     fill_price=fill_price,
                 )
@@ -589,7 +598,7 @@ def _resolved_outcome(signal: MarketSignal) -> float | None:
 def _pnl_delta(
     *,
     signal: MarketSignal,
-    opportunity_side: str,
+    decision_outcome: str,
     decision_size: float,
     fill_price: float,
     execution_model: ExecutionModel,
@@ -601,16 +610,15 @@ def _pnl_delta(
     notional = Decimal(str(decision_size))
     fill_price_decimal = Decimal(str(fill_price))
     resolved = Decimal(str(resolved_outcome))
-    if opportunity_side == "yes":
+    if decision_outcome == "YES":
         if fill_price_decimal <= 0:
             return Decimal("0")
         shares = notional / fill_price_decimal
         payout = shares * resolved
     else:
-        no_price = Decimal("1") - fill_price_decimal
-        if no_price <= 0:
+        if fill_price_decimal <= 0:
             return Decimal("0")
-        shares = notional / no_price
+        shares = notional / fill_price_decimal
         payout = shares * (Decimal("1") - resolved)
     fee = Decimal(
         str(

--- a/src/pms/research/runner.py
+++ b/src/pms/research/runner.py
@@ -14,15 +14,22 @@ from uuid import uuid4
 
 import asyncpg
 
-from pms.actuator.adapters.paper import PaperActuator
 from pms.actuator.risk import InsufficientLiquidityError
 from pms.controller.factory import ControllerPipelineFactory
 from pms.controller.factor_snapshot import PostgresFactorSnapshotReader
 from pms.controller.outcome_tokens import MarketDataOutcomeTokenResolver
 from pms.core.enums import OrderStatus
-from pms.core.models import FillRecord, MarketSignal, OrderState, Portfolio, Position
+from pms.core.models import (
+    FillRecord,
+    MarketSignal,
+    OrderState,
+    Portfolio,
+    Position,
+    TradeDecision,
+)
 from pms.evaluation.metrics import StrategyVersionKey
 from pms.research.entities import PortfolioTarget, serialize_portfolio_target_json
+from pms.research.execution import BacktestExecutionSimulator
 from pms.research.replay import MarketUniverseReplayEngine
 from pms.research.spec_codec import (
     deserialize_backtest_spec as _codec_deserialize_backtest_spec,
@@ -66,6 +73,17 @@ class ControllerPipelineLike(Protocol):
 
 class ControllerPipelineFactoryLike(Protocol):
     def build(self, strategy: ActiveStrategy) -> ControllerPipelineLike: ...
+
+
+class BacktestExecutionSimulatorLike(Protocol):
+    async def execute(
+        self,
+        *,
+        signal: MarketSignal,
+        decision: TradeDecision,
+        portfolio: Portfolio | None = None,
+        execution_model: ExecutionModel,
+    ) -> OrderState: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -129,7 +147,9 @@ class _StrategyAccumulator:
         fill_price: float,
     ) -> None:
         self.fill_count += 1
-        self.slippage_bps_values.append(Decimal(str(self.execution_model.slippage_bps)))
+        self.slippage_bps_values.append(
+            Decimal(str(_decision_slippage_bps(decision=decision, fill_price=fill_price)))
+        )
         if _resolved_outcome(signal) is not None:
             self.fills_with_resolution += 1
         pnl_delta = _pnl_delta(
@@ -207,6 +227,9 @@ class BacktestRunner:
         default_factory=ControllerPipelineFactory
     )
     replay_engine: ReplayEngineLike | None = None
+    execution_simulator: BacktestExecutionSimulatorLike = field(
+        default_factory=BacktestExecutionSimulator
+    )
     strategy_loader: StrategyLoader | None = None
     cancel_probe: CancelProbe | None = None
     host_provider: HostProvider = socket.gethostname
@@ -299,9 +322,12 @@ class BacktestRunner:
                 decision=decision,
             )
             try:
-                order_state = await PaperActuator(
-                    orderbooks={signal.market_id: signal.orderbook}
-                ).execute(cast(Any, decision), portfolio)
+                order_state = await self.execution_simulator.execute(
+                    signal=signal,
+                    decision=cast(Any, decision),
+                    portfolio=portfolio,
+                    execution_model=spec.execution_model,
+                )
             except InsufficientLiquidityError:
                 continue
             fill = _fill_from_order(order_state, decision, signal)
@@ -566,6 +592,19 @@ def _filled_contracts(fill: FillRecord) -> float:
     if fill.filled_contracts is not None:
         return fill.filled_contracts
     return fill.fill_size / fill.fill_price
+
+
+def _decision_slippage_bps(*, decision: object, fill_price: float) -> float:
+    raw_limit_price = getattr(decision, "limit_price", getattr(decision, "price", 0.0))
+    limit_price = float(cast(float, raw_limit_price))
+    if limit_price <= 0.0:
+        return 0.0
+    action = cast(str, getattr(decision, "action", getattr(decision, "side", "BUY")))
+    if action == "SELL":
+        slippage = limit_price - fill_price
+    else:
+        slippage = fill_price - limit_price
+    return max(0.0, slippage / limit_price * 10_000.0)
 
 
 def _same_position(position: Position, fill: FillRecord) -> bool:

--- a/src/pms/research/runner.py
+++ b/src/pms/research/runner.py
@@ -248,11 +248,13 @@ class BacktestRunner:
             )
 
     async def execute(self, run_id: str) -> bool:
-        claimed_run = await self._claim_run(run_id)
-        if claimed_run is None:
-            return False
-
         try:
+            # Legacy or manually inserted rows can still fail spec deserialization
+            # after the run is claimed; surface that as a failed run instead of
+            # leaving the claimed row stuck in status='running'.
+            claimed_run = await self._claim_run(run_id)
+            if claimed_run is None:
+                return False
             await asyncio.wait_for(
                 self._execute_claimed(claimed_run),
                 timeout=claimed_run.exec_config.time_budget,

--- a/src/pms/research/specs.py
+++ b/src/pms/research/specs.py
@@ -68,30 +68,11 @@ def _normalize_value(value: Any) -> Any:
     raise TypeError(msg)
 
 
-_HASH_IGNORED_EXECUTION_MODEL_FIELDS: frozenset[str] = frozenset(
-    {
-        # staleness_ms and latency_ms are declared on ExecutionModel but the
-        # research replay engine does not yet apply them. Including them in
-        # the hash would treat identical-behavior profiles as distinct runs
-        # and poison cache dedup. Remove from this set once the runner
-        # consumes the field.
-        "latency_ms",
-        "staleness_ms",
-    }
-)
-
-
 def _hashable_execution_model(execution_model: object) -> Any:
-    """Returns the subset of execution_model fields that actually influence
-    backtest output today. See `_HASH_IGNORED_EXECUTION_MODEL_FIELDS`."""
+    """Returns the execution_model fields that influence backtest output."""
     if not is_dataclass(execution_model) or isinstance(execution_model, type):
         return execution_model
-    fields = asdict(execution_model)
-    return {
-        key: value
-        for key, value in fields.items()
-        if key not in _HASH_IGNORED_EXECUTION_MODEL_FIELDS
-    }
+    return asdict(execution_model)
 
 
 def _compute_config_hash(*, spec: BacktestSpec) -> str:

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -18,6 +18,7 @@ from pms.actuator.executor import ActuatorAdapter, ActuatorExecutor
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import RiskManager
 from pms.config import PMSSettings
+from pms.controller.diagnostics import ControllerDiagnostic
 from pms.controller.factory import ControllerPipelineFactory
 from pms.controller.factor_snapshot import PostgresFactorSnapshotReader
 from pms.controller.outcome_tokens import MarketDataOutcomeTokenResolver
@@ -143,6 +144,7 @@ class RunnerState:
     decisions: list[TradeDecision] = field(default_factory=list)
     orders: list[OrderState] = field(default_factory=list)
     fills: list[FillRecord] = field(default_factory=list)
+    controller_diagnostics: list[ControllerDiagnostic] = field(default_factory=list)
 
 
 @dataclass
@@ -691,6 +693,9 @@ class Runner:
                             portfolio=self.portfolio,
                         )
                         if emission is None:
+                            diagnostic = _controller_diagnostic(runtime.controller)
+                            if diagnostic is not None:
+                                _append_bounded(self.state.controller_diagnostics, diagnostic)
                             continue
                         opportunity, decision = emission
                         await self.opportunity_store.insert(opportunity)
@@ -1183,6 +1188,13 @@ def _append_bounded(items: list[T], item: T) -> None:
         del items[:overflow]
 
 
+def _controller_diagnostic(controller: object) -> ControllerDiagnostic | None:
+    diagnostic = getattr(controller, "last_diagnostic", None)
+    if isinstance(diagnostic, ControllerDiagnostic):
+        return diagnostic
+    return None
+
+
 def _find_discovery_sensor(
     sensors: Sequence[ISensor],
 ) -> DiscoveryPollCompleteSensor | None:
@@ -1275,7 +1287,7 @@ def _fill_from_order(
         market_id=order_state.market_id,
         token_id=order_state.token_id,
         venue=order_state.venue,
-        side=decision.side,
+        side=decision.action if decision.action is not None else decision.side,
         fill_price=order_state.fill_price,
         fill_size=order_state.filled_size,
         executed_at=order_state.submitted_at,

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -19,6 +19,8 @@ from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import RiskManager
 from pms.config import PMSSettings
 from pms.controller.factory import ControllerPipelineFactory
+from pms.controller.factor_snapshot import PostgresFactorSnapshotReader
+from pms.controller.outcome_tokens import MarketDataOutcomeTokenResolver
 from pms.controller.pipeline import ControllerPipeline
 from pms.core.enums import OrderStatus, RunMode
 from pms.core.interfaces import (
@@ -610,6 +612,13 @@ class Runner:
         if self._pg_pool is None:
             msg = "Runner PostgreSQL pool is not initialized"
             raise RuntimeError(msg)
+        if isinstance(self._controller_factory, ControllerPipelineFactory):
+            market_data_store = PostgresMarketDataStore(self._pg_pool)
+            self._controller_factory = ControllerPipelineFactory(
+                settings=self.config,
+                factor_reader=PostgresFactorSnapshotReader(self._pg_pool),
+                outcome_token_resolver=MarketDataOutcomeTokenResolver(market_data_store),
+            )
         if isinstance(self.eval_store, EvalStore):
             self.eval_store.bind_pool(self._pg_pool)
         if isinstance(self.feedback_store, FeedbackStore):
@@ -618,6 +627,8 @@ class Runner:
             self.opportunity_store.bind_pool(self._pg_pool)
 
     def _unbind_runtime_stores(self) -> None:
+        if isinstance(self._controller_factory, ControllerPipelineFactory):
+            self._controller_factory = ControllerPipelineFactory(settings=self.config)
         if isinstance(self.eval_store, EvalStore):
             self.eval_store.pool = None
         if isinstance(self.feedback_store, FeedbackStore):

--- a/src/pms/storage/feedback_store.py
+++ b/src/pms/storage/feedback_store.py
@@ -22,7 +22,9 @@ SELECT
     resolved,
     resolved_at,
     category,
-    metadata
+    metadata,
+    strategy_id,
+    strategy_version_id
 FROM feedback
 """
 
@@ -38,7 +40,7 @@ class FeedbackStore:
         self,
         feedback: Feedback,
         *,
-        strategy_id: str = "default",
+        strategy_id: str | None = None,
         strategy_version_id: str | None = None,
     ) -> None:
         async with self._pool().acquire() as connection:
@@ -103,13 +105,17 @@ async def insert_feedback_row(
     connection: asyncpg.Connection,
     feedback: Feedback,
     *,
-    strategy_id: str = "default",
+    strategy_id: str | None = None,
     strategy_version_id: str | None = None,
 ) -> None:
     resolved_strategy_id, resolved_strategy_version_id = await resolve_strategy_tags(
         connection,
-        strategy_id=strategy_id,
-        strategy_version_id=strategy_version_id,
+        strategy_id=feedback.strategy_id if strategy_id is None else strategy_id,
+        strategy_version_id=(
+            feedback.strategy_version_id
+            if strategy_version_id is None
+            else strategy_version_id
+        ),
     )
     await connection.execute(
         """
@@ -157,6 +163,8 @@ def _feedback_from_record(record: asyncpg.Record) -> Feedback:
         resolved_at=cast(datetime | None, record["resolved_at"]),
         category=cast(str | None, record["category"]),
         metadata=_metadata_from_value(record["metadata"]),
+        strategy_id=cast(str, record["strategy_id"]),
+        strategy_version_id=cast(str, record["strategy_version_id"]),
     )
 
 

--- a/src/pms/storage/opportunity_store.py
+++ b/src/pms/storage/opportunity_store.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 import json
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import asyncpg
 
@@ -37,9 +38,12 @@ class OpportunityStore:
                     staleness_policy,
                     strategy_id,
                     strategy_version_id,
-                    created_at
+                    created_at,
+                    factor_snapshot_hash,
+                    composition_trace
                 ) VALUES (
-                    $1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13
+                    $1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13,
+                    $14, $15::jsonb
                 )
                 """,
                 opportunity.opportunity_id,
@@ -55,6 +59,8 @@ class OpportunityStore:
                 opportunity.strategy_id,
                 opportunity.strategy_version_id,
                 opportunity.created_at,
+                opportunity.factor_snapshot_hash,
+                json.dumps(dict(opportunity.composition_trace)),
             )
 
     async def all(self) -> list[Opportunity]:
@@ -77,7 +83,9 @@ class OpportunityStore:
                     staleness_policy,
                     strategy_id,
                     strategy_version_id,
-                    created_at
+                    created_at,
+                    factor_snapshot_hash,
+                    composition_trace
                 FROM opportunities
                 ORDER BY created_at ASC, opportunity_id ASC
                 """
@@ -96,6 +104,7 @@ def _opportunity_from_row(row: asyncpg.Record) -> Opportunity:
         for key, value in cast(dict[str, object], decoded).items()
         if isinstance(value, (int, float)) and not isinstance(value, bool)
     }
+    composition_trace = _json_object(row["composition_trace"])
     return Opportunity(
         opportunity_id=cast(str, row["opportunity_id"]),
         market_id=cast(str, row["market_id"]),
@@ -110,4 +119,17 @@ def _opportunity_from_row(row: asyncpg.Record) -> Opportunity:
         strategy_id=cast(str, row["strategy_id"]),
         strategy_version_id=cast(str, row["strategy_version_id"]),
         created_at=cast(datetime, row["created_at"]),
+        factor_snapshot_hash=cast(str | None, row["factor_snapshot_hash"]),
+        composition_trace=composition_trace,
     )
+
+
+def _json_object(value: object) -> Mapping[str, Any]:
+    if isinstance(value, str):
+        decoded = json.loads(value)
+        if isinstance(decoded, dict):
+            return cast(dict[str, Any], decoded)
+        return {}
+    if isinstance(value, dict):
+        return cast(dict[str, Any], value)
+    return {}

--- a/tests/integration/test_research_runner_cp04b.py
+++ b/tests/integration/test_research_runner_cp04b.py
@@ -74,11 +74,15 @@ class BlockingPipeline:
         strategy_id: str,
         strategy_version_id: str,
         gate: asyncio.Event | None = None,
+        started_event: asyncio.Event | None = None,
+        completed_event: asyncio.Event | None = None,
         error: Exception | None = None,
     ) -> None:
         self._strategy_id = strategy_id
         self._strategy_version_id = strategy_version_id
         self._gate = gate
+        self._started_event = started_event
+        self._completed_event = completed_event
         self._error = error
         self._emitted = False
 
@@ -91,10 +95,14 @@ class BlockingPipeline:
         if self._emitted:
             return None
         self._emitted = True
+        if self._started_event is not None:
+            self._started_event.set()
         if self._gate is not None:
             await self._gate.wait()
         if self._error is not None:
             raise self._error
+        if self._completed_event is not None:
+            self._completed_event.set()
         opportunity = Opportunity(
             opportunity_id=f"opp-{self._strategy_id}",
             market_id=signal.market_id,
@@ -290,12 +298,6 @@ async def _run_status(pool: asyncpg.Pool, run_id: str) -> tuple[str, str | None]
     return cast(str, row["status"]), cast(str | None, row["failure_reason"])
 
 
-async def _wait_for_count(pool: asyncpg.Pool, run_id: str, expected: int) -> None:
-    async with asyncio.timeout(3.0):
-        while await _strategy_run_count(pool, run_id) != expected:
-            await asyncio.sleep(0.01)
-
-
 @pytest.mark.asyncio(loop_scope="session")
 async def test_backtest_runner_claims_one_queued_run_under_race(
     pg_pool: asyncpg.Pool,
@@ -362,12 +364,15 @@ async def test_backtest_runner_rejects_empty_strategy_runs_at_application_layer(
     )
 
     assert await runner.execute(run_id) is False
-    assert await _run_status(pg_pool, run_id) == ("failed", "no_strategy_versions")
+    assert await _run_status(pg_pool, run_id) == (
+        "failed",
+        "BacktestSpec.strategy_versions must be non-empty",
+    )
     assert await _strategy_run_count(pg_pool, run_id) == 0
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_backtest_runner_streams_strategy_rows_as_each_strategy_finishes(
+async def test_backtest_runner_defers_strategy_rows_until_all_strategies_finish(
     pg_pool: asyncpg.Pool,
 ) -> None:
     run_id = str(uuid4())
@@ -378,7 +383,10 @@ async def test_backtest_runner_streams_strategy_rows_as_each_strategy_finishes(
     )
     await _insert_run(pg_pool, run_id=run_id, strategy_versions=strategy_keys)
 
+    alpha_completed = asyncio.Event()
+    beta_started = asyncio.Event()
     beta_gate = asyncio.Event()
+    gamma_started = asyncio.Event()
     gamma_gate = asyncio.Event()
     strategies = {
         key: _active_strategy(strategy_id=key[0], strategy_version_id=key[1])
@@ -394,28 +402,32 @@ async def test_backtest_runner_streams_strategy_rows_as_each_strategy_finishes(
                 "alpha": BlockingPipeline(
                     strategy_id="alpha",
                     strategy_version_id="alpha-v1",
+                    completed_event=alpha_completed,
                 ),
                 "beta": BlockingPipeline(
                     strategy_id="beta",
                     strategy_version_id="beta-v1",
                     gate=beta_gate,
+                    started_event=beta_started,
                 ),
                 "gamma": BlockingPipeline(
                     strategy_id="gamma",
                     strategy_version_id="gamma-v1",
                     gate=gamma_gate,
+                    started_event=gamma_started,
                 ),
             }
         ),
     )
 
     task = asyncio.create_task(runner.execute(run_id))
-    await _wait_for_count(pg_pool, run_id, 1)
-    assert await _strategy_run_count(pg_pool, run_id) == 1
+    await asyncio.wait_for(alpha_completed.wait(), timeout=1.0)
+    await asyncio.wait_for(beta_started.wait(), timeout=1.0)
+    assert await _strategy_run_count(pg_pool, run_id) == 0
 
     beta_gate.set()
-    await _wait_for_count(pg_pool, run_id, 2)
-    assert await _strategy_run_count(pg_pool, run_id) == 2
+    await asyncio.wait_for(gamma_started.wait(), timeout=1.0)
+    assert await _strategy_run_count(pg_pool, run_id) == 0
 
     gamma_gate.set()
     assert await task is True
@@ -430,7 +442,7 @@ async def test_backtest_runner_streams_strategy_rows_as_each_strategy_finishes(
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_backtest_runner_preserves_partial_results_on_strategy_failure(
+async def test_backtest_runner_discards_partial_results_on_strategy_failure(
     pg_pool: asyncpg.Pool,
 ) -> None:
     run_id = str(uuid4())
@@ -473,7 +485,7 @@ async def test_backtest_runner_preserves_partial_results_on_strategy_failure(
 
     assert await runner.execute(run_id) is False
     assert await _run_status(pg_pool, run_id) == ("failed", "strategy-two boom")
-    assert await _strategy_run_count(pg_pool, run_id) == 1
+    assert await _strategy_run_count(pg_pool, run_id) == 0
     assert tracking_writable.acquire_calls == tracking_writable.release_calls
     assert tracking_readonly.acquire_calls == tracking_readonly.release_calls
 
@@ -525,7 +537,7 @@ async def test_backtest_runner_marks_time_budget_exceeded(
     ("cancel_point", "expected_rows"),
     [
         ("before_first_strategy", 0),
-        ("between_strategies", 1),
+        ("between_strategies", 0),
         ("after_last_strategy", 2),
     ],
 )

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import Literal, cast
 
 import pytest
 
@@ -25,7 +25,7 @@ def _decision(
     *,
     decision_id: str = "d-cp06",
     market_id: str = "m-cp06",
-    side: str = Side.BUY.value,
+    side: Literal["BUY", "SELL"] = Side.BUY.value,
     price: float = 0.4,
     size: float = 10.0,
 ) -> TradeDecision:

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -143,6 +143,43 @@ async def test_paper_actuator_fills_buy_at_best_ask() -> None:
 
 
 @pytest.mark.asyncio
+async def test_paper_actuator_derives_no_fill_price_from_yes_bid() -> None:
+    actuator = PaperActuator(
+        orderbooks={
+            "m-cp06": {
+                "bids": [{"price": 0.62, "size": 100.0}],
+                "asks": [{"price": 0.64, "size": 100.0}],
+            }
+        }
+    )
+
+    state = await actuator.execute(
+        TradeDecision(
+            decision_id="d-no-cp06",
+            market_id="m-cp06",
+            token_id="t-no",
+            venue="polymarket",
+            side=Side.BUY.value,
+            price=0.38,
+            size=10.0,
+            order_type="limit",
+            max_slippage_bps=100,
+            stop_conditions=["unit-test"],
+            prob_estimate=0.38,
+            expected_edge=0.02,
+            time_in_force="GTC",
+            opportunity_id="op-d-no-cp06",
+            strategy_id="default",
+            strategy_version_id="default-v1",
+            outcome="NO",
+        )
+    )
+
+    assert state.status == OrderStatus.MATCHED.value
+    assert state.fill_price == pytest.approx(0.38)
+
+
+@pytest.mark.asyncio
 async def test_paper_actuator_empty_orderbook_raises_insufficient_liquidity() -> None:
     actuator = PaperActuator(orderbooks={"m-cp06": {"bids": [], "asks": []}})
 

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -167,13 +167,15 @@ async def test_api_routes_expose_mock_runner_state() -> None:
     assert status["mode"] == "backtest"
     assert status["runner_started_at"] == "2026-04-14T00:00:00+00:00"
     assert status["sensors"][0].keys() == {"name", "status", "last_signal_at"}
-    assert status["controller"] == {"decisions_total": 1}
+    assert status["controller"] == {"decisions_total": 1, "diagnostics_total": 0}
     assert status["actuator"] == {"fills_total": 1, "mode": "backtest"}
     assert status["evaluator"] == {"eval_records_total": 1, "brier_overall": 0.09}
     assert signals[0]["market_id"] == "api-market"
     assert decisions[0]["forecaster"] == "model-a"
     assert decisions[0]["prob_estimate"] == 0.7
     assert decisions[0]["expected_edge"] == 0.3
+    assert decisions[0]["action"] == "BUY"
+    assert decisions[0]["limit_price"] == 0.4
     assert decisions[0]["kelly_size"] == 12.5
     assert metrics["brier_overall"] == 0.09
     assert metrics["ops_view"]["brier_overall"] == 0.09

--- a/tests/unit/test_controller_cp02.py
+++ b/tests/unit/test_controller_cp02.py
@@ -70,6 +70,7 @@ async def test_controller_pipeline_on_signal_emits_opportunity_and_linked_decisi
     assert opportunity.selected_factor_values == {
         "fair_value": 0.61,
         "confidence": 0.8,
+        "yes_price": 0.4,
     }
     assert opportunity.rationale == "StaticForecaster:factor-value edge"
     assert opportunity.target_size_usdc == decision.size

--- a/tests/unit/test_controller_order_intent_cp03.py
+++ b/tests/unit/test_controller_order_intent_cp03.py
@@ -212,3 +212,14 @@ async def test_negative_edge_skips_when_no_token_cannot_be_resolved() -> None:
     emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
 
     assert emission is None
+    diagnostic = getattr(pipeline, "last_diagnostic")
+    assert diagnostic is not None
+    assert diagnostic.code == "missing_no_token"
+    assert diagnostic.market_id == "market-buy-no"
+    assert diagnostic.strategy_id == "alpha"
+    assert diagnostic.strategy_version_id == "alpha-v1"
+    assert diagnostic.metadata == {
+        "signal_token_id": "yes-token",
+        "yes_token_id": "yes-token",
+        "outcome": "NO",
+    }

--- a/tests/unit/test_controller_order_intent_cp03.py
+++ b/tests/unit/test_controller_order_intent_cp03.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+import importlib
+from typing import Any
+
+import pytest
+
+from pms.config import ControllerSettings, RiskSettings
+from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.pipeline import ControllerPipeline
+from pms.controller.router import Router
+from pms.controller.sizers.kelly import KellySizer
+from pms.core.models import MarketSignal, Portfolio
+from pms.strategies.projections import (
+    ActiveStrategy,
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    module = importlib.import_module(module_name)
+    return getattr(module, symbol_name)
+
+
+def _step(
+    factor_id: str,
+    *,
+    role: str,
+    weight: float = 1.0,
+    param: str = "",
+    threshold: float | None = None,
+) -> FactorCompositionStep:
+    return FactorCompositionStep(
+        factor_id=factor_id,
+        role=role,
+        param=param,
+        weight=weight,
+        threshold=threshold,
+    )
+
+
+def _active_strategy() -> ActiveStrategy:
+    return ActiveStrategy(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        config=StrategyConfig(
+            strategy_id="alpha",
+            factor_composition=(
+                _step("snapshot_probability", role="runtime_probability"),
+            ),
+            metadata=(("owner", "test"),),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl")),
+        forecaster=ForecasterSpec(forecasters=(("rules", ()),)),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
+def _signal(*, yes_price: float = 0.65) -> MarketSignal:
+    return MarketSignal(
+        market_id="market-buy-no",
+        token_id="yes-token",
+        venue="polymarket",
+        title="Should the controller buy NO?",
+        yes_price=yes_price,
+        volume_24h=1_000.0,
+        resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": 0.64, "size": 10.0}],
+            "asks": [{"price": 0.66, "size": 10.0}],
+        },
+        external_signal={},
+        fetched_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1_000.0,
+        free_usdc=1_000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+class StaticForecaster:
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return (0.30, 0.9, "static")
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        del signal
+        return 0.30
+
+
+class RecordingFactorReader:
+    def __init__(self, snapshot: Any) -> None:
+        self._snapshot = snapshot
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> Any:
+        del market_id, as_of, required, strategy_id, strategy_version_id
+        return self._snapshot
+
+
+class RecordingOutcomeResolver:
+    def __init__(self, tokens: Any) -> None:
+        self._tokens = tokens
+        self.calls: list[tuple[str, str | None]] = []
+
+    async def resolve(self, *, market_id: str, signal_token_id: str | None) -> Any:
+        self.calls.append((market_id, signal_token_id))
+        return self._tokens
+
+
+@pytest.mark.asyncio
+async def test_negative_edge_maps_to_buy_no_with_resolved_no_token() -> None:
+    factor_snapshot_cls = _load_symbol(
+        "pms.controller.factor_snapshot",
+        "FactorSnapshot",
+    )
+    outcome_tokens_cls = _load_symbol(
+        "pms.controller.outcome_tokens",
+        "OutcomeTokens",
+    )
+    resolver = RecordingOutcomeResolver(
+        outcome_tokens_cls(yes_token_id="yes-token", no_token_id="no-token")
+    )
+    pipeline = ControllerPipeline(
+        strategy=_active_strategy(),
+        factor_reader=RecordingFactorReader(
+            factor_snapshot_cls(
+                values={("snapshot_probability", ""): 0.30},
+                missing_factors=(),
+                snapshot_hash="snapshot-30",
+            )
+        ),
+        outcome_token_resolver=resolver,
+        forecasters=(StaticForecaster(),),
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is not None
+    opportunity, decision = emission
+    assert opportunity.side == "no"
+    assert opportunity.token_id == "no-token"
+    assert decision.side == "BUY"
+    assert decision.action == "BUY"
+    assert decision.outcome == "NO"
+    assert decision.token_id == "no-token"
+    assert decision.price == pytest.approx(0.35)
+    assert decision.limit_price == pytest.approx(0.35)
+    assert resolver.calls == [("market-buy-no", "yes-token")]
+
+
+@pytest.mark.asyncio
+async def test_negative_edge_skips_when_no_token_cannot_be_resolved() -> None:
+    factor_snapshot_cls = _load_symbol(
+        "pms.controller.factor_snapshot",
+        "FactorSnapshot",
+    )
+    outcome_tokens_cls = _load_symbol(
+        "pms.controller.outcome_tokens",
+        "OutcomeTokens",
+    )
+    pipeline = ControllerPipeline(
+        strategy=_active_strategy(),
+        factor_reader=RecordingFactorReader(
+            factor_snapshot_cls(
+                values={("snapshot_probability", ""): 0.20},
+                missing_factors=(),
+                snapshot_hash="snapshot-20",
+            )
+        ),
+        outcome_token_resolver=RecordingOutcomeResolver(
+            outcome_tokens_cls(yes_token_id="yes-token", no_token_id=None)
+        ),
+        forecasters=(StaticForecaster(),),
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is None

--- a/tests/unit/test_controller_runtime_selection_contract_cp01.py
+++ b/tests/unit/test_controller_runtime_selection_contract_cp01.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import asdict
 from datetime import UTC, datetime
 import importlib
 from typing import Any
@@ -183,6 +184,13 @@ async def test_controller_pipeline_uses_strategy_factor_composition_not_forecast
     assert decision.prob_estimate == pytest.approx(0.72)
     assert decision.expected_edge == pytest.approx(0.32)
     assert opportunity.expected_edge == pytest.approx(0.32)
+    assert opportunity.selected_factor_values == {
+        "fair_value": pytest.approx(0.58),
+        "yes_price": pytest.approx(0.4),
+        "rules": pytest.approx(0.10),
+        "llm": pytest.approx(0.90),
+        "snapshot_probability": pytest.approx(0.72),
+    }
     assert opportunity.factor_snapshot_hash == "snapshot-72"
     assert opportunity.composition_trace == {
         "selected_probability": pytest.approx(0.72),
@@ -253,3 +261,67 @@ def test_controller_pipeline_factory_passes_strategy_and_factor_reader() -> None
 
     assert pipeline.strategy == strategy
     assert pipeline.factor_reader is factor_reader
+
+
+def test_snapshot_hash_distinguishes_missing_factors_and_strategy_identity() -> None:
+    snapshot_hash = _load_symbol("pms.controller.factor_snapshot", "_snapshot_hash")
+
+    with_missing = snapshot_hash(
+        market_id="market-runtime-contract",
+        as_of=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        required_keys=(("rules", ""), ("llm", "")),
+        values={("rules", ""): 0.55},
+        missing_factors=(("llm", ""),),
+    )
+    without_missing = snapshot_hash(
+        market_id="market-runtime-contract",
+        as_of=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        required_keys=(("rules", ""),),
+        values={("rules", ""): 0.55},
+        missing_factors=(),
+    )
+    other_strategy = snapshot_hash(
+        market_id="market-runtime-contract",
+        as_of=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        strategy_id="beta",
+        strategy_version_id="beta-v2",
+        required_keys=(("rules", ""), ("llm", "")),
+        values={("rules", ""): 0.55},
+        missing_factors=(("llm", ""),),
+    )
+
+    assert with_missing != without_missing
+    assert with_missing != other_strategy
+
+
+def test_trade_decision_asdict_exposes_normalized_order_intent_fields() -> None:
+    decision = asdict(
+        _load_symbol("pms.core.models", "TradeDecision")(
+            decision_id="decision-runtime-contract",
+            market_id="market-runtime-contract",
+            token_id="yes-token",
+            venue="polymarket",
+            side="BUY",
+            price=0.4,
+            size=10.0,
+            order_type="limit",
+            max_slippage_bps=50,
+            stop_conditions=[],
+            prob_estimate=0.72,
+            expected_edge=0.32,
+            time_in_force="GTC",
+            opportunity_id="opportunity-runtime-contract",
+            strategy_id="alpha",
+            strategy_version_id="alpha-v1",
+            model_id="ensemble",
+        )
+    )
+
+    assert decision["side"] == "BUY"
+    assert decision["price"] == pytest.approx(0.4)
+    assert decision["action"] == "BUY"
+    assert decision["limit_price"] == pytest.approx(0.4)

--- a/tests/unit/test_controller_runtime_selection_contract_cp01.py
+++ b/tests/unit/test_controller_runtime_selection_contract_cp01.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+import importlib
+from typing import Any
+
+import pytest
+
+from pms.config import ControllerSettings, RiskSettings
+from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.pipeline import ControllerPipeline
+from pms.controller.router import Router
+from pms.controller.sizers.kelly import KellySizer
+from pms.core.models import MarketSignal, Portfolio
+from pms.strategies.projections import (
+    ActiveStrategy,
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+
+def _load_symbol(module_name: str, symbol_name: str) -> Any:
+    try:
+        module = importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - red phase
+        pytest.fail(f"{module_name} is missing: {exc}")
+    return getattr(module, symbol_name)
+
+
+def _signal(*, yes_price: float = 0.4) -> MarketSignal:
+    return MarketSignal(
+        market_id="market-runtime-contract",
+        token_id="yes-token",
+        venue="polymarket",
+        title="Will the runtime contract close?",
+        yes_price=yes_price,
+        volume_24h=1_000.0,
+        resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": 0.39, "size": 10.0}],
+            "asks": [{"price": 0.41, "size": 10.0}],
+        },
+        external_signal={"fair_value": 0.58},
+        fetched_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1_000.0,
+        free_usdc=1_000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+def _step(
+    factor_id: str,
+    *,
+    role: str,
+    weight: float = 1.0,
+    param: str = "",
+    threshold: float | None = None,
+) -> FactorCompositionStep:
+    return FactorCompositionStep(
+        factor_id=factor_id,
+        role=role,
+        param=param,
+        weight=weight,
+        threshold=threshold,
+    )
+
+
+def _active_strategy(
+    *,
+    strategy_id: str = "alpha",
+    strategy_version_id: str = "alpha-v1",
+    factor_composition: tuple[FactorCompositionStep, ...],
+    forecaster_names: tuple[str, ...],
+) -> ActiveStrategy:
+    return ActiveStrategy(
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        config=StrategyConfig(
+            strategy_id=strategy_id,
+            factor_composition=factor_composition,
+            metadata=(("owner", "test"),),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl")),
+        forecaster=ForecasterSpec(
+            forecasters=tuple((name, ()) for name in forecaster_names)
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=500.0,
+        ),
+    )
+
+
+class StaticForecaster:
+    def __init__(self, probability: float) -> None:
+        self._probability = probability
+
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return (self._probability, 0.9, f"static-{self._probability}")
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        del signal
+        return self._probability
+
+
+class RecordingFactorReader:
+    def __init__(self, snapshot: Any) -> None:
+        self.snapshot_value = snapshot
+        self.calls: list[dict[str, Any]] = []
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> Any:
+        self.calls.append(
+            {
+                "market_id": market_id,
+                "as_of": as_of,
+                "required": tuple(required),
+                "strategy_id": strategy_id,
+                "strategy_version_id": strategy_version_id,
+            }
+        )
+        return self.snapshot_value
+
+
+@pytest.mark.asyncio
+async def test_controller_pipeline_uses_strategy_factor_composition_not_forecaster_mean() -> None:
+    factor_snapshot_cls = _load_symbol(
+        "pms.controller.factor_snapshot",
+        "FactorSnapshot",
+    )
+    strategy = _active_strategy(
+        factor_composition=(
+            _step("snapshot_probability", role="runtime_probability"),
+        ),
+        forecaster_names=("rules", "llm"),
+    )
+    factor_reader = RecordingFactorReader(
+        factor_snapshot_cls(
+            values={( "snapshot_probability", ""): 0.72},
+            missing_factors=(),
+            snapshot_hash="snapshot-72",
+        )
+    )
+    pipeline = ControllerPipeline(
+        strategy=strategy,
+        factor_reader=factor_reader,
+        forecasters=(StaticForecaster(0.10), StaticForecaster(0.90)),
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is not None
+    opportunity, decision = emission
+    assert decision.prob_estimate == pytest.approx(0.72)
+    assert decision.expected_edge == pytest.approx(0.32)
+    assert opportunity.expected_edge == pytest.approx(0.32)
+    assert opportunity.factor_snapshot_hash == "snapshot-72"
+    assert opportunity.composition_trace == {
+        "selected_probability": pytest.approx(0.72),
+        "expected_edge": pytest.approx(0.32),
+        "factor_snapshot_hash": "snapshot-72",
+        "missing_factors": [],
+        "branch_probabilities": {"snapshot_probability": pytest.approx(0.72)},
+    }
+    assert factor_reader.calls == [
+        {
+            "market_id": "market-runtime-contract",
+            "as_of": datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+            "required": strategy.config.factor_composition,
+            "strategy_id": "alpha",
+            "strategy_version_id": "alpha-v1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_controller_pipeline_maps_stats_forecaster_to_statistical_runtime_factor() -> None:
+    strategy = _active_strategy(
+        factor_composition=(
+            _step("statistical", role="runtime_probability"),
+        ),
+        forecaster_names=("stats",),
+    )
+    factor_snapshot_cls = _load_symbol(
+        "pms.controller.factor_snapshot",
+        "FactorSnapshot",
+    )
+    pipeline = ControllerPipeline(
+        strategy=strategy,
+        factor_reader=RecordingFactorReader(
+            factor_snapshot_cls(values={}, missing_factors=(), snapshot_hash=None)
+        ),
+        forecasters=(StaticForecaster(0.81),),
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+    )
+
+    emission = await pipeline.on_signal(_signal(yes_price=0.4), portfolio=_portfolio())
+
+    assert emission is not None
+    _, decision = emission
+    assert decision.prob_estimate == pytest.approx(0.81)
+
+
+def test_controller_pipeline_factory_passes_strategy_and_factor_reader() -> None:
+    factor_snapshot_cls = _load_symbol(
+        "pms.controller.factor_snapshot",
+        "FactorSnapshot",
+    )
+    factory_cls = _load_symbol("pms.controller.factory", "ControllerPipelineFactory")
+    strategy = _active_strategy(
+        factor_composition=(
+            _step("snapshot_probability", role="runtime_probability"),
+        ),
+        forecaster_names=("rules",),
+    )
+    factor_reader = RecordingFactorReader(
+        factor_snapshot_cls(values={}, missing_factors=(), snapshot_hash="snapshot")
+    )
+
+    factory = factory_cls(factor_reader=factor_reader)
+    pipeline = factory.build(strategy)
+
+    assert pipeline.strategy == strategy
+    assert pipeline.factor_reader is factor_reader

--- a/tests/unit/test_evaluation_cp07.py
+++ b/tests/unit/test_evaluation_cp07.py
@@ -159,6 +159,37 @@ def test_scorer_brier_known_values() -> None:
     assert second.brier_score == pytest.approx(0.25)
 
 
+def test_scorer_pnl_for_buy_no_uses_complementary_contract_outcome() -> None:
+    scorer = Scorer()
+    decision = TradeDecision(
+        decision_id="d-buy-no",
+        market_id="m-cp07",
+        token_id="t-no",
+        venue="polymarket",
+        side=Side.BUY.value,
+        price=0.38,
+        size=10.0,
+        order_type="limit",
+        max_slippage_bps=100,
+        stop_conditions=["min_volume:100.00"],
+        prob_estimate=0.62,
+        expected_edge=0.24,
+        time_in_force="GTC",
+        opportunity_id="op-d-buy-no",
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        model_id="model-a",
+        outcome="NO",
+    )
+
+    record = scorer.score(
+        _fill(decision_id="d-buy-no", resolved_outcome=0.0, fill_price=0.38),
+        decision,
+    )
+
+    assert record.pnl == pytest.approx(6.2)
+
+
 def test_scorer_rejects_fill_and_decision_strategy_identity_mismatch() -> None:
     scorer = Scorer()
 

--- a/tests/unit/test_feedback_identity_cp05.py
+++ b/tests/unit/test_feedback_identity_cp05.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+
+from pms.core.models import Feedback
+from pms.storage.feedback_store import _feedback_from_record, insert_feedback_row
+
+
+class RecordingConnection:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.calls.append((query, args))
+        return "INSERT 0 1"
+
+
+def _feedback(
+    *,
+    strategy_id: str = "alpha",
+    strategy_version_id: str = "alpha-v1",
+) -> Feedback:
+    return Feedback(
+        feedback_id="fb-runtime-identity",
+        target="controller",
+        source="evaluator",
+        message="typed identity should round-trip",
+        severity="warning",
+        created_at=datetime(2026, 4, 20, tzinfo=UTC),
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        metadata={"origin": "unit-test"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_insert_feedback_row_uses_feedback_identity_when_kwargs_are_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = RecordingConnection()
+
+    async def passthrough_tags(
+        inner: RecordingConnection,
+        *,
+        strategy_id: str,
+        strategy_version_id: str | None,
+    ) -> tuple[str, str]:
+        del inner
+        assert strategy_id == "alpha"
+        assert strategy_version_id == "alpha-v1"
+        return strategy_id, strategy_version_id
+
+    monkeypatch.setattr(
+        "pms.storage.feedback_store.resolve_strategy_tags",
+        passthrough_tags,
+    )
+
+    await insert_feedback_row(connection, _feedback())
+
+    assert len(connection.calls) == 1
+    _, args = connection.calls[0]
+    assert args[10] == "alpha"
+    assert args[11] == "alpha-v1"
+
+
+def test_feedback_from_record_restores_typed_strategy_identity() -> None:
+    feedback = _feedback_from_record(
+        cast(
+            Any,
+            {
+                "feedback_id": "fb-runtime-identity",
+                "target": "controller",
+                "source": "evaluator",
+                "message": "typed identity should round-trip",
+                "severity": "warning",
+                "created_at": datetime(2026, 4, 20, tzinfo=UTC),
+                "resolved": False,
+                "resolved_at": None,
+                "category": None,
+                "metadata": {"origin": "unit-test"},
+                "strategy_id": "alpha",
+                "strategy_version_id": "alpha-v1",
+            },
+        )
+    )
+
+    assert feedback.strategy_id == "alpha"
+    assert feedback.strategy_version_id == "alpha-v1"

--- a/tests/unit/test_opportunity_store.py
+++ b/tests/unit/test_opportunity_store.py
@@ -29,6 +29,36 @@ class RaisingPool:
         return RaisingAcquire()
 
 
+class RecordingConnection:
+    def __init__(self) -> None:
+        self.query: str | None = None
+        self.args: tuple[object, ...] | None = None
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.query = query
+        self.args = args
+        return "INSERT 0 1"
+
+
+class RecordingAcquire:
+    def __init__(self, connection: RecordingConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> RecordingConnection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class RecordingPool:
+    def __init__(self) -> None:
+        self.connection = RecordingConnection()
+
+    def acquire(self) -> RecordingAcquire:
+        return RecordingAcquire(self.connection)
+
+
 def _opportunity() -> Opportunity:
     return Opportunity(
         opportunity_id="opp-1",
@@ -44,6 +74,11 @@ def _opportunity() -> Opportunity:
         strategy_id="alpha",
         strategy_version_id="alpha-v1",
         created_at=datetime(2026, 4, 19, 15, 0, tzinfo=UTC),
+        factor_snapshot_hash="snapshot-1",
+        composition_trace={
+            "selected_probability": 0.61,
+            "branch_probabilities": {"rules": 0.61},
+        },
     )
 
 
@@ -53,6 +88,21 @@ async def test_opportunity_store_insert_propagates_missing_table_errors() -> Non
 
     with pytest.raises(asyncpg.UndefinedTableError, match="opportunities missing"):
         await store.insert(_opportunity())
+
+
+@pytest.mark.asyncio
+async def test_opportunity_store_insert_serializes_trace_fields() -> None:
+    pool = RecordingPool()
+    store = OpportunityStore(pool=cast(asyncpg.Pool, pool))
+
+    await store.insert(_opportunity())
+
+    assert pool.connection.query is not None
+    assert "factor_snapshot_hash" in pool.connection.query
+    assert "composition_trace" in pool.connection.query
+    assert pool.connection.args is not None
+    assert pool.connection.args[13] == "snapshot-1"
+    assert pool.connection.args[14] == '{"selected_probability": 0.61, "branch_probabilities": {"rules": 0.61}}'
 
 
 def test_opportunity_from_row_skips_boolean_factor_values() -> None:
@@ -70,8 +120,18 @@ def test_opportunity_from_row_skips_boolean_factor_values() -> None:
         "strategy_id": "alpha",
         "strategy_version_id": "alpha-v1",
         "created_at": datetime(2026, 4, 19, 15, 0, tzinfo=UTC),
+        "factor_snapshot_hash": "snapshot-1",
+        "composition_trace": {
+            "selected_probability": 0.61,
+            "branch_probabilities": {"rules": 0.61},
+        },
     }
 
     opportunity = _opportunity_from_row(cast(Any, row))
 
     assert opportunity.selected_factor_values == {"numeric": 0.42, "count": 2.0}
+    assert opportunity.factor_snapshot_hash == "snapshot-1"
+    assert opportunity.composition_trace == {
+        "selected_probability": 0.61,
+        "branch_probabilities": {"rules": 0.61},
+    }

--- a/tests/unit/test_research_execution_simulator_cp06.py
+++ b/tests/unit/test_research_execution_simulator_cp06.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+
+import pytest
+
+from pms.core.enums import OrderStatus
+from pms.core.models import MarketSignal, Portfolio, TradeDecision
+from pms.research.execution import BacktestExecutionSimulator
+from pms.research.specs import ExecutionModel
+
+
+def _signal(
+    *,
+    yes_price: float = 0.4,
+    resolves_at: datetime | None = None,
+) -> MarketSignal:
+    return MarketSignal(
+        market_id="sim-market",
+        token_id="yes-token",
+        venue="polymarket",
+        title="Will the simulator work?",
+        yes_price=yes_price,
+        volume_24h=1_000.0,
+        resolves_at=resolves_at or datetime(2026, 4, 30, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": 0.39, "size": 100.0}],
+            "asks": [{"price": 0.41, "size": 100.0}],
+        },
+        external_signal={},
+        fetched_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1_000.0,
+        free_usdc=1_000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+def _decision(
+    *,
+    action: Literal["BUY", "SELL"] = "BUY",
+    outcome: Literal["YES", "NO"] = "YES",
+    limit_price: float = 0.4,
+    size: float = 10.0,
+) -> TradeDecision:
+    token_id = "no-token" if outcome == "NO" else "yes-token"
+    return TradeDecision(
+        decision_id="decision-sim",
+        market_id="sim-market",
+        token_id=token_id,
+        venue="polymarket",
+        side=action,
+        price=limit_price,
+        size=size,
+        order_type="limit",
+        max_slippage_bps=100,
+        stop_conditions=[],
+        prob_estimate=0.6,
+        expected_edge=0.2,
+        time_in_force="GTC",
+        opportunity_id="opp-sim",
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        action=action,
+        limit_price=limit_price,
+        outcome=outcome,
+        model_id="rules",
+    )
+
+
+@pytest.mark.asyncio
+async def test_simulator_ioc_matches_using_book_price_with_latency_applied() -> None:
+    simulator = BacktestExecutionSimulator()
+
+    order_state = await simulator.execute(
+        signal=_signal(),
+        decision=_decision(limit_price=0.4),
+        portfolio=_portfolio(),
+        execution_model=ExecutionModel(
+            fee_rate=0.0,
+            slippage_bps=0.0,
+            latency_ms=250.0,
+            staleness_ms=1_000.0,
+            fill_policy="immediate_or_cancel",
+        ),
+    )
+
+    assert order_state.status == OrderStatus.MATCHED.value
+    assert order_state.fill_price == pytest.approx(0.41)
+    assert order_state.submitted_at == datetime(2026, 4, 20, 12, 0, tzinfo=UTC) + timedelta(
+        milliseconds=250
+    )
+    assert order_state.last_updated_at == order_state.submitted_at
+
+
+@pytest.mark.asyncio
+async def test_simulator_applies_slippage_bps_to_fill_price() -> None:
+    simulator = BacktestExecutionSimulator()
+
+    order_state = await simulator.execute(
+        signal=_signal(),
+        decision=_decision(limit_price=0.4),
+        portfolio=_portfolio(),
+        execution_model=ExecutionModel(
+            fee_rate=0.0,
+            slippage_bps=100.0,
+            latency_ms=0.0,
+            staleness_ms=1_000.0,
+            fill_policy="immediate_or_cancel",
+        ),
+    )
+
+    assert order_state.status == OrderStatus.MATCHED.value
+    assert order_state.fill_price == pytest.approx(0.41 * 1.01)
+
+
+@pytest.mark.asyncio
+async def test_simulator_rejects_when_latency_exceeds_staleness_budget() -> None:
+    simulator = BacktestExecutionSimulator()
+
+    order_state = await simulator.execute(
+        signal=_signal(),
+        decision=_decision(limit_price=0.4),
+        portfolio=_portfolio(),
+        execution_model=ExecutionModel(
+            fee_rate=0.0,
+            slippage_bps=0.0,
+            latency_ms=250.0,
+            staleness_ms=100.0,
+            fill_policy="immediate_or_cancel",
+        ),
+    )
+
+    assert order_state.status == OrderStatus.CANCELED.value
+    assert order_state.fill_price is None
+    assert order_state.raw_status == "stale_signal"
+
+
+@pytest.mark.asyncio
+async def test_simulator_limit_if_touched_leaves_order_unmatched_when_book_never_touches_limit() -> None:
+    simulator = BacktestExecutionSimulator()
+
+    order_state = await simulator.execute(
+        signal=_signal(),
+        decision=_decision(limit_price=0.4),
+        portfolio=_portfolio(),
+        execution_model=ExecutionModel(
+            fee_rate=0.0,
+            slippage_bps=0.0,
+            latency_ms=0.0,
+            staleness_ms=1_000.0,
+            fill_policy="limit_if_touched",
+        ),
+    )
+
+    assert order_state.status == OrderStatus.UNMATCHED.value
+    assert order_state.fill_price is None
+    assert order_state.raw_status == "limit_not_touched"
+
+
+@pytest.mark.asyncio
+async def test_simulator_cancels_when_latency_pushes_execution_past_resolution() -> None:
+    simulator = BacktestExecutionSimulator()
+
+    order_state = await simulator.execute(
+        signal=_signal(
+            resolves_at=datetime(2026, 4, 20, 12, 0, 0, 100_000, tzinfo=UTC)
+        ),
+        decision=_decision(limit_price=0.4),
+        portfolio=_portfolio(),
+        execution_model=ExecutionModel(
+            fee_rate=0.0,
+            slippage_bps=0.0,
+            latency_ms=250.0,
+            staleness_ms=1_000.0,
+            fill_policy="immediate_or_cancel",
+        ),
+    )
+
+    assert order_state.status == OrderStatus.CANCELED_MARKET_RESOLVED.value
+    assert order_state.fill_price is None
+    assert order_state.raw_status == "market_resolved_before_execution"

--- a/tests/unit/test_research_pnl_cp04.py
+++ b/tests/unit/test_research_pnl_cp04.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.core.models import MarketSignal
+from pms.research.runner import _pnl_delta
+from pms.research.specs import ExecutionModel
+
+
+def _signal(*, resolved_outcome: float) -> MarketSignal:
+    return MarketSignal(
+        market_id="market-pnl-no",
+        token_id="token-no",
+        venue="polymarket",
+        title="Will research pnl respect NO fills?",
+        yes_price=0.62,
+        volume_24h=1_000.0,
+        resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
+        orderbook={"bids": [], "asks": []},
+        external_signal={"resolved_outcome": resolved_outcome},
+        fetched_at=datetime(2026, 4, 20, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def test_pnl_delta_for_buy_no_uses_no_fill_price_directly() -> None:
+    pnl = _pnl_delta(
+        signal=_signal(resolved_outcome=0.0),
+        decision_outcome="NO",
+        decision_size=10.0,
+        fill_price=0.38,
+        execution_model=ExecutionModel.polymarket_paper(),
+    )
+
+    assert float(pnl) == pytest.approx(16.31578947368421)

--- a/tests/unit/test_research_runner_cp04b.py
+++ b/tests/unit/test_research_runner_cp04b.py
@@ -254,8 +254,9 @@ async def test_backtest_runner_updates_portfolio_between_replay_signals() -> Non
     assert pipeline.portfolios[1].free_usdc == pytest.approx(990.0)
     assert pipeline.portfolios[1].locked_usdc == pytest.approx(10.0)
     assert len(pipeline.portfolios[1].open_positions) == 1
+    expected_fill_price = 0.41 * (1.0 + _spec().execution_model.slippage_bps / 10_000.0)
     assert pipeline.portfolios[1].open_positions[0].shares_held == pytest.approx(
-        10.0 / 0.41
+        10.0 / expected_fill_price
     )
 
 
@@ -271,13 +272,20 @@ async def test_backtest_runner_propagates_unexpected_actuator_errors(
         controller_factory=_PipelineFactory(pipeline),
     )
 
-    async def _boom(self: object, decision: object, portfolio: object | None = None) -> object:
-        del self, decision, portfolio
-        raise RuntimeError("actuator exploded")
+    async def _boom(
+        self: object,
+        *,
+        signal: object,
+        decision: object,
+        portfolio: object | None = None,
+        execution_model: object,
+    ) -> object:
+        del self, signal, decision, portfolio, execution_model
+        raise RuntimeError("execution simulator exploded")
 
-    monkeypatch.setattr("pms.research.runner.PaperActuator.execute", _boom)
+    monkeypatch.setattr("pms.research.execution.BacktestExecutionSimulator.execute", _boom)
 
-    with pytest.raises(RuntimeError, match="actuator exploded"):
+    with pytest.raises(RuntimeError, match="execution simulator exploded"):
         await runner._run_strategy(
             strategy=_active_strategy(),
             spec=_spec(),
@@ -442,3 +450,37 @@ async def test_strategy_accumulator_emits_numeric_pnl_when_any_resolution_observ
 
     args = accumulator.as_insert_args(run_id="11111111-1111-1111-1111-111111111111")
     assert args[5] is not None, "pnl_cum must remain numeric when resolutions observed"
+
+
+@pytest.mark.asyncio
+async def test_backtest_runner_execution_model_staleness_budget_can_prevent_fill() -> None:
+    pipeline = _PortfolioRecordingPipeline()
+    runner = BacktestRunner(
+        writable_pool=cast(Any, object()),
+        readonly_pool=cast(Any, object()),
+        replay_engine=_ReplayEngine([_signal(datetime(2026, 4, 20, 0, 0, tzinfo=UTC))]),
+        controller_factory=_PipelineFactory(pipeline),
+    )
+    spec = BacktestSpec(
+        strategy_versions=(("alpha", "alpha-v1"),),
+        dataset=_spec().dataset,
+        execution_model=ExecutionModel(
+            fee_rate=0.0,
+            slippage_bps=0.0,
+            latency_ms=250.0,
+            staleness_ms=100.0,
+            fill_policy="immediate_or_cancel",
+        ),
+        risk_policy=_spec().risk_policy,
+        date_range_start=_spec().date_range_start,
+        date_range_end=_spec().date_range_end,
+    )
+
+    accumulator = await runner._run_strategy(
+        strategy=_active_strategy(),
+        spec=spec,
+        exec_config=BacktestExecutionConfig(),
+    )
+
+    assert accumulator.decision_count == 1
+    assert accumulator.fill_count == 0

--- a/tests/unit/test_research_specs_cp01a.py
+++ b/tests/unit/test_research_specs_cp01a.py
@@ -294,12 +294,9 @@ def _build_real_execution_model(
     )
 
 
-def test_backtest_spec_config_hash_ignores_unapplied_execution_fields() -> None:
-    """latency_ms and staleness_ms are declared on ExecutionModel but neither
-    the replay engine nor the runner applies them yet. Hashing them would
-    make cache-dedup treat otherwise-identical-behavior profiles as distinct
-    runs, producing misleading "rerun" decisions. Exclude them from the
-    hash until the runner actually consumes them."""
+def test_backtest_spec_config_hash_changes_for_latency_and_staleness_once_runner_applies_them() -> None:
+    """Now that the backtest execution simulator consumes latency_ms and
+    staleness_ms, they must distinguish spec hashes."""
     baseline = _build_spec(execution_model=_build_real_execution_model())
     variant_latency = _build_spec(
         execution_model=_build_real_execution_model(latency_ms=250.0),
@@ -308,12 +305,12 @@ def test_backtest_spec_config_hash_ignores_unapplied_execution_fields() -> None:
         execution_model=_build_real_execution_model(staleness_ms=120_000.0),
     )
 
-    assert variant_latency.config_hash == baseline.config_hash
-    assert variant_staleness.config_hash == baseline.config_hash
+    assert variant_latency.config_hash != baseline.config_hash
+    assert variant_staleness.config_hash != baseline.config_hash
 
 
 def test_backtest_spec_config_hash_still_changes_for_applied_execution_fields() -> None:
-    """fee_rate, slippage_bps, and fill_policy ARE consumed today — they
+    """fee_rate, slippage_bps, and fill_policy are also consumed — they
     must continue to distinguish spec hashes."""
     baseline = _build_spec(execution_model=_build_real_execution_model())
     variant_fee = _build_spec(

--- a/tests/unit/test_runner_cp02.py
+++ b/tests/unit/test_runner_cp02.py
@@ -10,8 +10,10 @@ from typing import Any, cast
 import pytest
 
 from pms.actuator.executor import ActuatorExecutor
-from pms.config import PMSSettings, RiskSettings
+from pms.config import ControllerSettings, PMSSettings, RiskSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.factor_snapshot import FactorSnapshot
+from pms.controller.outcome_tokens import OutcomeTokens
 from pms.controller.pipeline import ControllerPipeline
 from pms.controller.router import Router
 from pms.controller.sizers.kelly import KellySizer
@@ -42,6 +44,45 @@ class IdleSensor:
         while True:
             await asyncio.sleep(60.0)
             yield _signal()
+
+
+class StaticLowForecaster:
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return (0.30, 0.9, "runner skip diagnostic")
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        del signal
+        return 0.30
+
+
+class RecordingFactorReader:
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: object,
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> FactorSnapshot:
+        del market_id, as_of, required, strategy_id, strategy_version_id
+        return FactorSnapshot(
+            values={("snapshot_probability", ""): 0.30},
+            missing_factors=(),
+            snapshot_hash="snapshot-runner-skip",
+        )
+
+
+class NoNoTokenResolver:
+    async def resolve(
+        self,
+        *,
+        market_id: str,
+        signal_token_id: str | None,
+    ) -> OutcomeTokens:
+        del market_id, signal_token_id
+        return OutcomeTokens(yes_token_id="runner-token", no_token_id=None)
 
 
 def _signal() -> MarketSignal:
@@ -76,6 +117,15 @@ async def _wait_for_opportunities(runner: Runner, count: int) -> None:
     while len(runner.state.opportunities) < count:
         if asyncio.get_running_loop().time() >= deadline:
             msg = f"timed out waiting for {count} opportunities"
+            raise AssertionError(msg)
+        await asyncio.sleep(0.01)
+
+
+async def _wait_for_diagnostics(runner: Runner, count: int) -> None:
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while len(runner.state.controller_diagnostics) < count:
+        if asyncio.get_running_loop().time() >= deadline:
+            msg = f"timed out waiting for {count} controller diagnostics"
             raise AssertionError(msg)
         await asyncio.sleep(0.01)
 
@@ -144,3 +194,73 @@ async def test_runner_forwards_opportunity_id_to_actuator() -> None:
     assert runner.state.opportunities[0].opportunity_id == opportunity.opportunity_id
     assert captured_decisions[0].opportunity_id == opportunity.opportunity_id
     assert captured_decisions[0].stop_conditions
+
+
+@pytest.mark.asyncio
+async def test_runner_records_structured_controller_diagnostics_for_skipped_bearish_signal() -> None:
+    from pms.strategies.projections import (
+        ActiveStrategy,
+        EvalSpec,
+        FactorCompositionStep,
+        ForecasterSpec,
+        MarketSelectionSpec,
+        RiskParams,
+        StrategyConfig,
+    )
+
+    strategy = ActiveStrategy(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        config=StrategyConfig(
+            strategy_id="alpha",
+            factor_composition=(
+                FactorCompositionStep(
+                    factor_id="snapshot_probability",
+                    role="runtime_probability",
+                    param="",
+                    weight=1.0,
+                    threshold=None,
+                ),
+            ),
+            metadata=(),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=100.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier",)),
+        forecaster=ForecasterSpec(forecasters=(("rules", ()),)),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=100.0,
+        ),
+    )
+    runner = Runner(
+        config=_settings(),
+        historical_data_path=FIXTURE_PATH,
+        sensors=[IdleSensor()],
+        controller=ControllerPipeline(
+            strategy=strategy,
+            factor_reader=RecordingFactorReader(),
+            outcome_token_resolver=NoNoTokenResolver(),
+            forecasters=[StaticLowForecaster()],
+            calibrator=NetcalCalibrator(),
+            sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+            router=Router(ControllerSettings(min_volume=100.0)),
+        ),
+        opportunity_store=cast(Any, InMemoryOpportunityStore()),
+    )
+
+    try:
+        await runner.start()
+        await runner.sensor_stream.queue.put(_signal())
+        await _wait_for_diagnostics(runner, 1)
+    finally:
+        await runner.stop()
+
+    assert runner.state.opportunities == []
+    assert runner.state.decisions == []
+    assert runner.state.controller_diagnostics[0].code == "missing_no_token"
+    assert runner.state.controller_diagnostics[0].metadata["signal_token_id"] == "runner-token"


### PR DESCRIPTION
## What changed

This PR closes the runtime selection contract so live, paper, and backtest all execute the same strategy-driven controller path.

- added controller-side factor snapshot reading and composition application
- passed full `ActiveStrategy` policy into `ControllerPipeline`
- added outcome token resolution and switched bearish runtime intent from `SELL YES` to `BUY NO`
- added `Opportunity.factor_snapshot_hash` and `Opportunity.composition_trace` with store/schema persistence
- added typed `strategy_id` / `strategy_version_id` to `Feedback`
- updated paper execution, evaluation scoring, and research PnL handling for outcome-aware NO fills
- wired the default live runner and backtest runner to the Postgres factor snapshot reader and token resolver

## Why

S6 had the right research/backtest shape, but the runtime controller was still averaging forecasters directly and expressing bearish views with `SELL` on the YES token. That left a gap between strategy config, live decision semantics, and research attribution.

This change makes the controller consume strategy factor composition as the source of truth, normalizes runtime order intent to prediction-market semantics, and preserves enough decision trace to compare live and backtest behavior without guessing.

## Impact

- controller decisions now come from composed factor values instead of ensemble mean when a strategy composition is present
- bearish views now require a resolvable NO token and emit `BUY NO`
- opportunities persist composition trace metadata for later reporting and debugging
- feedback rows carry typed strategy identity directly

## Validation

- `uv run pytest -q`
- `uv run mypy src/ tests/ --strict`

Both passed locally:

- `368 passed, 85 skipped`
- `Success: no issues found in 202 source files`
