### PR TITLE
docs(claude): refresh stale pytest/mypy baseline numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,13 @@ uv run pytest -q                         # full suite — see baseline below
 uv run mypy src/ tests/ --strict         # strict on every committed module
 ```
 
-**Baseline (as of 2026-04-18, feat/pms-active-perception-v1):** `pytest`
-246 passing, 54 skipped. The 54 skips are PostgreSQL-backed integration
+**Baseline (as of 2026-04-21, main @ 96f2a14):** `pytest`
+337 passing, 85 skipped. The 85 skips are PostgreSQL-backed integration
 checks gated on `PMS_RUN_INTEGRATION=1` and, where needed,
-`PMS_TEST_DATABASE_URL`. mypy strict must be clean. If the baseline
-fails on a fresh clone, fix the config — not the test — and commit
-with a `fix(tests):` or `fix(build):` prefix before starting feature
-work (see promoted rule: *Fresh-clone baseline verification*).
+`PMS_TEST_DATABASE_URL`. mypy strict must be clean (196 source files).
+If the baseline fails on a fresh clone, fix the config — not the test —
+and commit with a `fix(tests):` or `fix(build):` prefix before starting
+feature work (see promoted rule: *Fresh-clone baseline verification*).
 
 Integration tests:
 ```bash


### PR DESCRIPTION
## Summary

- Update CLAUDE.md baseline from `246 passed / 54 skipped` → `337 passed / 85 skipped`
- Add explicit mypy surface count (`196 source files`)
- Refresh the "as of" anchor from `2026-04-18, feat/pms-active-perception-v1` to `2026-04-21, main @ 96f2a14`

## Why

The baseline line was captured before PR #16 (`feat/pms-research-backtest-v1`) and the S6 schema-alignment fix (41b8fb3) merged. New contributors running `uv run pytest -q` on a fresh clone of `main` would see numbers that don't match the documented baseline and waste time hunting for "missing" tests. This is exactly the *Fresh-clone baseline verification* promoted rule — the rule still holds, the numbers just needed to catch up.

## Verification

Measured on `fix/claudemd-stale-baseline` (branched from `origin/main` at `96f2a14`):

```
$ uv run pytest -q
337 passed, 85 skipped in 6.32s

$ uv run mypy src/ tests/ --strict
Success: no issues found in 196 source files

$ uv run lint-imports
Contracts: 6 kept, 0 broken.
```

Doc-only change; no behaviour touched.

## Test plan

- [x] `uv run pytest -q` passes with the documented counts on `origin/main`
- [x] `uv run mypy src/ tests/ --strict` clean on 196 files
- [x] `uv run lint-imports` — 6 contracts kept, 0 broken
- [ ] Reviewer sanity-checks the numbers on their own fresh clone