### PR TITLE
[codex] Harden paper end-to-end runtime flow

### DIFF
--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -49,6 +49,7 @@ class RiskSettings(BaseModel):
 class SensorSettings(BaseModel):
     poll_interval_s: float = 5.0
     max_reconnect_interval_s: float = 60.0
+    max_subscription_asset_ids: int | None = Field(default=100, ge=1)
 
 
 class DashboardSettings(BaseModel):

--- a/src/pms/market_selection/selector.py
+++ b/src/pms/market_selection/selector.py
@@ -89,4 +89,5 @@ def _asset_ids_from_eligible_markets(
         token.token_id
         for _, tokens in eligible_markets
         for token in tokens
+        if token.outcome == "YES"
     )

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -71,6 +71,7 @@ from pms.storage.fill_store import FillStore
 from pms.storage.market_data_store import PostgresMarketDataStore
 from pms.storage.market_subscription_store import PostgresMarketSubscriptionStore
 from pms.storage.opportunity_store import OpportunityStore
+from pms.storage.order_store import OrderStore
 from pms.storage.strategy_registry import PostgresStrategyRegistry
 from pms.strategies.aggregate import Strategy
 from pms.strategies.defaults import DEFAULT_STRATEGY_COMPOSITION
@@ -93,6 +94,7 @@ RUNNER_STATE_LIMIT = 1000
 RESELECTION_INTERVAL_S = 300.0
 DECISION_PENDING_TTL = timedelta(minutes=15)
 DECISION_SWEEP_INTERVAL_S = 5.0
+DEFAULT_OPERATIONAL_MARKET_SELECTION_HORIZON_DAYS = 90
 RAW_FACTOR_COMPOSITION_ROLES = frozenset(
     {
         "weighted",
@@ -174,6 +176,7 @@ class Runner:
     eval_store: EvalStore = field(default_factory=EvalStore)
     feedback_store: FeedbackStore = field(default_factory=FeedbackStore)
     decision_store: DecisionStore = field(default_factory=DecisionStore)
+    order_store: OrderStore = field(default_factory=OrderStore)
     fill_store: FillStore = field(default_factory=FillStore)
     opportunity_store: OpportunityStore = field(default_factory=OpportunityStore)
     portfolio: Portfolio = field(default_factory=lambda: Portfolio(
@@ -351,7 +354,11 @@ class Runner:
 
         self._stop_event.clear()
         self._controller_pipeline_error = None
-        self.state.runner_started_at = datetime.now(tz=UTC)
+        self.state = RunnerState(
+            mode=self.config.mode,
+            runner_started_at=datetime.now(tz=UTC),
+        )
+        self._paper_orderbooks.clear()
 
         try:
             self._assert_no_legacy_jsonl_paths()
@@ -574,7 +581,7 @@ class Runner:
         )
         self._subscription_controller = SensorSubscriptionController(subscription_sink)
         self._register_strategy_change_callbacks()
-        discovery_sensor.on_poll_complete = self._request_reselection
+        discovery_sensor.on_poll_complete = self._handle_discovery_poll_complete
         self._reselection_task = asyncio.create_task(self._periodic_reselection_loop())
 
     def _register_strategy_change_callbacks(self) -> None:
@@ -630,7 +637,13 @@ class Runner:
         strategy = await registry.get_by_id("default")
         if strategy is None:
             return
-        if strategy.config.factor_composition == DEFAULT_V2_FACTOR_COMPOSITION:
+        migrated_market_selection = _operational_default_market_selection(
+            strategy.market_selection
+        )
+        if (
+            strategy.config.factor_composition == DEFAULT_V2_FACTOR_COMPOSITION
+            and strategy.market_selection == migrated_market_selection
+        ):
             return
 
         migrated_strategy = Strategy(
@@ -641,7 +654,7 @@ class Runner:
             risk=strategy.risk,
             eval_spec=strategy.eval_spec,
             forecaster=strategy.forecaster,
-            market_selection=strategy.market_selection,
+            market_selection=migrated_market_selection,
         )
         version = await registry.create_version(migrated_strategy)
         await registry.set_active("default", version.strategy_version_id)
@@ -668,6 +681,8 @@ class Runner:
             self.feedback_store.bind_pool(self._pg_pool)
         if isinstance(self.decision_store, DecisionStore):
             self.decision_store.bind_pool(self._pg_pool)
+        if isinstance(self.order_store, OrderStore):
+            self.order_store.bind_pool(self._pg_pool)
         if isinstance(self.fill_store, FillStore):
             self.fill_store.bind_pool(self._pg_pool)
         if isinstance(self.opportunity_store, OpportunityStore):
@@ -683,6 +698,8 @@ class Runner:
             self.feedback_store.pool = None
         if isinstance(self.decision_store, DecisionStore):
             self.decision_store.pool = None
+        if isinstance(self.order_store, OrderStore):
+            self.order_store.pool = None
         if isinstance(self.fill_store, FillStore):
             self.fill_store.pool = None
         if isinstance(self.opportunity_store, OpportunityStore):
@@ -844,6 +861,10 @@ class Runner:
                     dedup_acquired=work_item.dedup_acquired,
                 )
                 _append_bounded(self.state.orders, order_state)
+                try:
+                    await self.order_store.insert(order_state)
+                except Exception as error:  # noqa: BLE001
+                    logger.warning("order persistence failed: %s", error)
                 fill = _fill_from_order(order_state, decision, signal)
                 if fill is not None:
                     _append_bounded(self.state.fills, fill)
@@ -1074,7 +1095,9 @@ class Runner:
             return
         async with self._reselection_lock:
             result = await selector.select()
-            await subscription_controller.update(list(result.asset_ids))
+            await subscription_controller.update(
+                _cap_subscription_asset_ids(list(result.asset_ids), self.config)
+            )
 
     async def _periodic_reselection_loop(self) -> None:
         while True:
@@ -1105,6 +1128,13 @@ class Runner:
 
     async def _request_reselection(self) -> None:
         self._reselection_requested.set()
+
+    async def _handle_discovery_poll_complete(self) -> None:
+        try:
+            await self._sync_controller_runtimes()
+        except Exception as error:  # noqa: BLE001
+            logger.warning("discovery-driven controller sync failed: %s", error)
+        await self._request_reselection()
 
     async def _await_cancelled_task(
         self,
@@ -1147,6 +1177,8 @@ class Runner:
             }
             current_strategy_ids = set(self._controller_runtimes)
             desired_strategy_ids = set(desired_by_strategy)
+            if not current_strategy_ids and not desired_strategy_ids:
+                return
 
             for strategy_id in sorted(current_strategy_ids - desired_strategy_ids):
                 await self._release_controller_runtime_locked(strategy_id)
@@ -1265,7 +1297,9 @@ class Runner:
             }
         )
         async with self._reselection_lock:
-            await subscription_controller.update(merged_asset_ids)
+            await subscription_controller.update(
+                _cap_subscription_asset_ids(merged_asset_ids, self.config)
+            )
 
     async def _maybe_inject_controller_release_cancel(
         self,
@@ -1319,6 +1353,8 @@ class Runner:
             )
         ):
             active_strategies = await self._strategy_registry.list_active_strategies()
+            if not active_strategies:
+                return []
             scopes: dict[str, frozenset[str]] = {}
             if (
                 self._market_selector is not None
@@ -1418,7 +1454,9 @@ def _default_active_strategy(settings: PMSSettings) -> ActiveStrategy:
     )
     market_selection = MarketSelectionSpec(
         venue="polymarket",
-        resolution_time_max_horizon_days=7,
+        resolution_time_max_horizon_days=(
+            DEFAULT_OPERATIONAL_MARKET_SELECTION_HORIZON_DAYS
+        ),
         volume_min_usdc=500.0,
     )
     strategy_version_id = compute_strategy_version_id(
@@ -1437,6 +1475,34 @@ def _default_active_strategy(settings: PMSSettings) -> ActiveStrategy:
         forecaster=forecaster,
         market_selection=market_selection,
     )
+
+
+def _operational_default_market_selection(
+    market_selection: MarketSelectionSpec,
+) -> MarketSelectionSpec:
+    if market_selection.resolution_time_max_horizon_days != 7:
+        return market_selection
+    return replace(
+        market_selection,
+        resolution_time_max_horizon_days=(
+            DEFAULT_OPERATIONAL_MARKET_SELECTION_HORIZON_DAYS
+        ),
+    )
+
+
+def _cap_subscription_asset_ids(
+    asset_ids: list[str],
+    settings: PMSSettings,
+) -> list[str]:
+    limit = settings.sensor.max_subscription_asset_ids
+    if limit is None or len(asset_ids) <= limit:
+        return asset_ids
+    logger.warning(
+        "subscription asset set capped at %d of %d selected assets",
+        limit,
+        len(asset_ids),
+    )
+    return asset_ids[:limit]
 
 
 def _fill_from_order(

--- a/src/pms/sensor/adapters/market_data.py
+++ b/src/pms/sensor/adapters/market_data.py
@@ -59,6 +59,7 @@ class MarketDataSensor:
     _HEARTBEAT_INTERVAL_S = 10.0
     _PONG_TIMEOUT_S = 15.0
     _WATCHDOG_TIMEOUT_S = 120.0
+    _CLOSE_TIMEOUT_S = 1.0
 
     def __init__(
         self,
@@ -69,6 +70,7 @@ class MarketDataSensor:
         self.store = store
         self.ws_url = ws_url
         self._asset_ids: list[str] = list(asset_ids) if asset_ids else []
+        self._subscribed_asset_ids: frozenset[str] = frozenset()
         self._books: dict[str, _BookState] = {}
         self._websocket: Any = None
         self._send_lock = asyncio.Lock()
@@ -127,7 +129,7 @@ class MarketDataSensor:
                     "reconnect" if self._connected_once else "subscribe"
                 )
                 try:
-                    async with connect(self.ws_url) as websocket:
+                    async with self._connect() as websocket:
                         self._reset_book_state()
                         self._websocket = websocket
                         self._connection_book_source = connection_book_source
@@ -138,6 +140,7 @@ class MarketDataSensor:
                         self._heartbeat_task = heartbeat_task
                         try:
                             await self._send_subscription()
+                            self._subscribed_asset_ids = frozenset(self._asset_ids)
                             self._connected_once = True
                             backoff = self._INITIAL_BACKOFF_S
                             async for raw_message in websocket:
@@ -150,6 +153,7 @@ class MarketDataSensor:
                             self._heartbeat_task = None
                             self._websocket = None
                             self._connection_book_source = None
+                            self._subscribed_asset_ids = frozenset()
                             self._pending_reconnect_assets = set()
                             self._reset_book_state()
                 except asyncio.CancelledError:
@@ -169,11 +173,13 @@ class MarketDataSensor:
             await self._watchdog.stop()
             self._websocket = None
             self._connection_book_source = None
+            self._subscribed_asset_ids = frozenset()
             self._pending_reconnect_assets = set()
             self._reset_book_state()
 
     async def update_subscription(self, asset_ids: list[str]) -> None:
-        self._asset_ids = list(asset_ids)
+        next_asset_ids = list(dict.fromkeys(asset_ids))
+        self._asset_ids = next_asset_ids
         if self._websocket is None:
             return
 
@@ -183,7 +189,11 @@ class MarketDataSensor:
             await self._sleep(self._POOL_RETRY_BACKOFF_S)
             await self._probe_pool_latency()
 
-        await self._send_subscription()
+        await self._send_subscription_update(
+            previous_asset_ids=self._subscribed_asset_ids,
+            next_asset_ids=next_asset_ids,
+        )
+        self._subscribed_asset_ids = frozenset(next_asset_ids)
 
     async def aclose(self) -> None:
         heartbeat_task = self._heartbeat_task
@@ -195,6 +205,7 @@ class MarketDataSensor:
 
         websocket = self._websocket
         self._websocket = None
+        self._subscribed_asset_ids = frozenset()
         if websocket is not None:
             await websocket.close()
         await self._watchdog.stop()
@@ -386,6 +397,52 @@ class MarketDataSensor:
         async with self._send_lock:
             await websocket.send(json.dumps(_subscription_payload(self._asset_ids)))
 
+    def _connect(self) -> Any:
+        try:
+            return connect(self.ws_url, close_timeout=self._CLOSE_TIMEOUT_S)
+        except TypeError as exc:
+            if "close_timeout" not in str(exc):
+                raise
+            return connect(self.ws_url)
+
+    async def _send_subscription_update(
+        self,
+        *,
+        previous_asset_ids: frozenset[str],
+        next_asset_ids: list[str],
+    ) -> None:
+        websocket = self._websocket
+        if websocket is None:
+            return
+        next_asset_set = frozenset(next_asset_ids)
+        removed_asset_ids = sorted(previous_asset_ids - next_asset_set)
+        added_asset_ids = [
+            asset_id
+            for asset_id in next_asset_ids
+            if asset_id not in previous_asset_ids
+        ]
+        async with self._send_lock:
+            if removed_asset_ids:
+                await websocket.send(
+                    json.dumps(
+                        _subscription_update_payload(
+                            removed_asset_ids,
+                            operation="unsubscribe",
+                        )
+                    )
+                )
+                for asset_id in removed_asset_ids:
+                    self._books.pop(asset_id, None)
+            if added_asset_ids:
+                await websocket.send(
+                    json.dumps(
+                        _subscription_update_payload(
+                            added_asset_ids,
+                            operation="subscribe",
+                        )
+                    )
+                )
+
     async def _probe_pool_latency(self) -> float:
         started = time.perf_counter()
         async with self.store.pool.acquire():
@@ -459,6 +516,17 @@ def _subscription_payload(asset_ids: list[str]) -> dict[str, Any]:
         "type": "market",
         "initial_dump": True,
         "level": 2,
+    }
+
+
+def _subscription_update_payload(
+    asset_ids: list[str],
+    *,
+    operation: str,
+) -> dict[str, Any]:
+    return {
+        "assets_ids": asset_ids,
+        "operation": operation,
     }
 
 

--- a/src/pms/storage/fill_store.py
+++ b/src/pms/storage/fill_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import Decimal
 import json
 from typing import Any, cast
 
@@ -107,26 +108,60 @@ class FillStore:
             await _ensure_fill_payloads_table(connection)
             rows = await connection.fetch(
                 """
+                WITH aggregated_positions AS (
+                    SELECT
+                        fills.market_id,
+                        fill_payloads.payload->>'token_id' AS token_id,
+                        fill_payloads.payload->>'venue' AS venue,
+                        fill_payloads.payload->>'side' AS side,
+                        SUM(fills.fill_quantity) AS shares_held,
+                        CASE
+                            WHEN SUM(fills.fill_quantity) = 0 THEN 0.0
+                            ELSE SUM(fills.fill_notional_usdc) / SUM(fills.fill_quantity)
+                        END AS avg_entry_price,
+                        SUM(fills.fill_notional_usdc) AS locked_usdc,
+                        MAX(fills.ts) AS last_fill_at
+                    FROM fills
+                    INNER JOIN fill_payloads
+                        ON fill_payloads.fill_id = fills.fill_id
+                    GROUP BY
+                        fills.market_id,
+                        fill_payloads.payload->>'token_id',
+                        fill_payloads.payload->>'venue',
+                        fill_payloads.payload->>'side'
+                )
                 SELECT
-                    fills.market_id,
-                    fill_payloads.payload->>'token_id' AS token_id,
-                    fill_payloads.payload->>'venue' AS venue,
-                    fill_payloads.payload->>'side' AS side,
-                    SUM(fills.fill_quantity) AS shares_held,
+                    aggregated_positions.market_id,
+                    aggregated_positions.token_id,
+                    aggregated_positions.venue,
+                    aggregated_positions.side,
+                    aggregated_positions.shares_held,
+                    aggregated_positions.avg_entry_price,
+                    aggregated_positions.locked_usdc,
                     CASE
-                        WHEN SUM(fills.fill_quantity) = 0 THEN 0.0
-                        ELSE SUM(fills.fill_notional_usdc) / SUM(fills.fill_quantity)
-                    END AS avg_entry_price,
-                    SUM(fills.fill_notional_usdc) AS locked_usdc
-                FROM fills
-                INNER JOIN fill_payloads
-                    ON fill_payloads.fill_id = fills.fill_id
-                GROUP BY
-                    fills.market_id,
-                    fill_payloads.payload->>'token_id',
-                    fill_payloads.payload->>'venue',
-                    fill_payloads.payload->>'side'
-                ORDER BY MAX(fills.ts) DESC, fills.market_id ASC
+                        WHEN tokens.outcome = 'YES' THEN COALESCE(
+                            markets.yes_price,
+                            CASE
+                                WHEN markets.no_price IS NULL THEN NULL
+                                ELSE 1 - markets.no_price
+                            END
+                        )
+                        WHEN tokens.outcome = 'NO' THEN COALESCE(
+                            markets.no_price,
+                            CASE
+                                WHEN markets.yes_price IS NULL THEN NULL
+                                ELSE 1 - markets.yes_price
+                            END
+                        )
+                        ELSE markets.yes_price
+                    END AS current_price
+                FROM aggregated_positions
+                LEFT JOIN tokens
+                    ON tokens.token_id = aggregated_positions.token_id
+                LEFT JOIN markets
+                    ON markets.condition_id = aggregated_positions.market_id
+                ORDER BY aggregated_positions.last_fill_at DESC,
+                    aggregated_positions.market_id ASC
                 """
             )
         return [_position_from_row(row) for row in rows]
@@ -252,9 +287,36 @@ def _position_from_row(row: asyncpg.Record) -> Position:
         side=cast(str, row["side"]),
         shares_held=float(cast(float, row["shares_held"])),
         avg_entry_price=float(cast(float, row["avg_entry_price"])),
-        unrealized_pnl=0.0,
+        unrealized_pnl=_unrealized_pnl_from_row(row),
         locked_usdc=float(cast(float, row["locked_usdc"])),
     )
+
+
+def _unrealized_pnl_from_row(row: asyncpg.Record) -> float:
+    current_price = _decimal_or_none(_optional_row_value(row, "current_price"))
+    if current_price is None:
+        return 0.0
+
+    shares_held = Decimal(str(row["shares_held"]))
+    avg_entry_price = Decimal(str(row["avg_entry_price"]))
+    if str(row["side"]).upper() == "SELL":
+        pnl = (avg_entry_price - current_price) * shares_held
+    else:
+        pnl = (current_price - avg_entry_price) * shares_held
+    return float(pnl)
+
+
+def _optional_row_value(row: asyncpg.Record, key: str) -> object | None:
+    try:
+        return cast(object, row[key])
+    except KeyError:
+        return None
+
+
+def _decimal_or_none(value: object | None) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(str(value))
 
 
 def _trade_from_row(row: asyncpg.Record) -> StoredTradeRow:

--- a/tests/integration/test_default_v2_migration.py
+++ b/tests/integration/test_default_v2_migration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import json
 import os
 
 import asyncpg
@@ -160,7 +161,10 @@ async def _expected_default_v2_version_id(pg_pool: asyncpg.Pool) -> str:
         risk=strategy.risk,
         eval_spec=strategy.eval_spec,
         forecaster=strategy.forecaster,
-        market_selection=strategy.market_selection,
+        market_selection=replace(
+            strategy.market_selection,
+            resolution_time_max_horizon_days=90,
+        ),
     )
     return compute_strategy_version_id(*migrated.snapshot())
 
@@ -185,6 +189,14 @@ async def test_default_v2_migration_is_idempotent_and_respects_disable_flag(
         )
         first_strategy_factor_count = await connection.fetchval(
             "SELECT COUNT(*) FROM strategy_factors WHERE strategy_id = 'default'"
+        )
+        first_config_json = await connection.fetchval(
+            """
+            SELECT config_json
+            FROM strategy_versions
+            WHERE strategy_version_id = $1
+            """,
+            first_active_version_id,
         )
 
     await _boot_runner(pg_pool, auto_migrate_default_v2=True)
@@ -216,6 +228,9 @@ async def test_default_v2_migration_is_idempotent_and_respects_disable_flag(
     assert first_active_version_id == expected_version_id
     assert first_version_count == 2
     assert first_strategy_factor_count >= 3
+    assert json.loads(first_config_json)["market_selection"][
+        "resolution_time_max_horizon_days"
+    ] == 90
     assert second_active_version_id == expected_version_id
     assert second_version_count == first_version_count
     assert second_strategy_factor_count == first_strategy_factor_count

--- a/tests/integration/test_market_selector.py
+++ b/tests/integration/test_market_selector.py
@@ -224,11 +224,8 @@ async def test_market_selector_returns_merged_asset_ids_from_active_strategies(
     result = await selector.select()
 
     assert result.asset_ids == [
-        "pm-far-secondary-no",
         "pm-far-secondary-yes",
-        "pm-fast-no",
         "pm-fast-yes",
-        "pm-near-secondary-no",
         "pm-near-secondary-yes",
     ]
     assert result.conflicts == []

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -210,3 +210,48 @@ async def test_paper_runner_fills_against_signal_orderbook_depth(
     assert runner.state.orders[0].raw_status == "matched"
     assert runner.state.orders[0].fill_price == pytest.approx(0.41)
     assert len(runner.state.fills) == 1
+
+
+@pytest.mark.asyncio
+async def test_runner_start_resets_in_memory_session_state(
+    tmp_path: Path,
+) -> None:
+    runner = Runner(
+        config=_settings(RunMode.PAPER),
+        sensors=[
+            OneShotSensor(
+                _signal(
+                    market_id="paper-state-reset",
+                    orderbook={
+                        "bids": [{"price": 0.39, "size": 250.0}],
+                        "asks": [{"price": 0.41, "size": 250.0}],
+                    },
+                    external_signal={"metaculus_prob": 0.9, "resolved_outcome": 1.0},
+                )
+            )
+        ],
+        eval_store=cast(EvalStore, InMemoryEvalStore()),
+        feedback_store=cast(FeedbackStore, InMemoryFeedbackStore()),
+    )
+
+    await runner.start()
+    await asyncio.wait_for(runner.wait_until_idle(), timeout=5.0)
+    await asyncio.wait_for(runner.stop(), timeout=5.0)
+
+    assert runner.state.signals
+    assert runner.state.decisions
+    assert runner.state.orders
+
+    runner.sensors = [HoldingSensor()]
+    await runner.start()
+    try:
+        assert runner.state.mode == RunMode.PAPER
+        assert runner.state.runner_started_at is not None
+        assert runner.state.signals == []
+        assert runner.state.opportunities == []
+        assert runner.state.decisions == []
+        assert runner.state.orders == []
+        assert runner.state.fills == []
+        assert runner.state.controller_diagnostics == []
+    finally:
+        await asyncio.wait_for(runner.stop(), timeout=5.0)

--- a/tests/integration/test_positions_trades_route.py
+++ b/tests/integration/test_positions_trades_route.py
@@ -118,6 +118,9 @@ async def _seed_market_data(pg_pool: asyncpg.Pool) -> None:
             created_at=now - timedelta(days=1),
             last_seen_at=now,
             volume_24h=1200.0,
+            yes_price=0.46,
+            no_price=0.54,
+            price_updated_at=now,
         )
     )
     await store.write_token(
@@ -208,7 +211,7 @@ async def test_positions_and_trades_routes_reflect_persisted_paper_fill(
                 "side": "BUY",
                 "shares_held": 50.0,
                 "avg_entry_price": 0.41,
-                "unrealized_pnl": 0.0,
+                "unrealized_pnl": 2.5,
                 "locked_usdc": 20.5,
             }
         ]

--- a/tests/unit/test_market_data_sensor.py
+++ b/tests/unit/test_market_data_sensor.py
@@ -254,6 +254,51 @@ async def test_market_data_sensor_replays_fixture_losslessly_and_persists_piecew
 
 
 @pytest.mark.asyncio
+async def test_market_data_sensor_bounds_websocket_close_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store_mock()
+    captured_kwargs: dict[str, Any] = {}
+    fake_websocket = HeartbeatWebSocket(
+        [
+            json.dumps(
+                {
+                    "event_type": "book",
+                    "market": "m-close-timeout",
+                    "asset_id": "asset-close-timeout",
+                    "timestamp": "1757908892351",
+                    "hash": "book-close-timeout",
+                    "bids": [{"price": "0.40", "size": "5"}],
+                    "asks": [{"price": "0.60", "size": "5"}],
+                    "last_trade_price": "0.50",
+                }
+            )
+        ],
+        ping_outcomes=[0.0],
+    )
+
+    def fake_connect(url: str, **kwargs: Any) -> FakeConnect:
+        del url
+        captured_kwargs.update(kwargs)
+        return FakeConnect(fake_websocket)
+
+    monkeypatch.setattr("pms.sensor.adapters.market_data.connect", fake_connect)
+    sensor = MarketDataSensor(
+        store=store,
+        ws_url="ws://market-data.example.test",
+        asset_ids=["asset-close-timeout"],
+    )
+    iterator = cast(Any, sensor.__aiter__())
+
+    signal = await asyncio.wait_for(anext(iterator), timeout=0.5)
+    await asyncio.wait_for(iterator.aclose(), timeout=0.5)
+    await sensor.aclose()
+
+    assert signal.market_id == "m-close-timeout"
+    assert captured_kwargs["close_timeout"] == 1.0
+
+
+@pytest.mark.asyncio
 async def test_market_data_sensor_persists_last_trade_price_and_emits_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -345,11 +390,32 @@ async def test_market_data_sensor_update_subscription_warns_and_retries_on_slow_
     assert fake_websocket.sent_messages == [
         {
             "assets_ids": ["asset-a", "asset-b"],
-            "type": "market",
-            "initial_dump": True,
-            "level": 2,
+            "operation": "subscribe",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_market_data_sensor_dynamic_update_sends_subscribe_and_unsubscribe_deltas(
+) -> None:
+    sensor = MarketDataSensor(store=_store_mock(), asset_ids=["asset-a", "asset-b"])
+    fake_websocket = FakeWebSocket([])
+    sensor._websocket = cast(Any, fake_websocket)
+    sensor._subscribed_asset_ids = frozenset({"asset-a", "asset-b"})
+
+    await sensor.update_subscription(["asset-b", "asset-c"])
+
+    assert fake_websocket.sent_messages == [
+        {
+            "assets_ids": ["asset-a"],
+            "operation": "unsubscribe",
+        },
+        {
+            "assets_ids": ["asset-c"],
+            "operation": "subscribe",
+        },
+    ]
+    assert sensor._subscribed_asset_ids == frozenset({"asset-b", "asset-c"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_market_selector.py
+++ b/tests/unit/test_market_selector.py
@@ -206,12 +206,12 @@ async def test_market_selector_builds_strategy_sets_before_merging(
         strategy_market_set_cls(
             strategy_id="alpha",
             strategy_version_id="alpha-v1",
-            asset_ids=frozenset({"pm-yes", "pm-no"}),
+            asset_ids=frozenset({"pm-yes"}),
         ),
         strategy_market_set_cls(
             strategy_id="beta",
             strategy_version_id="beta-v2",
-            asset_ids=frozenset({"pm-b-yes", "pm-b-no"}),
+            asset_ids=frozenset({"pm-b-yes"}),
         ),
     ]
     assert result.asset_ids == ["pm-b-no", "pm-b-yes", "pm-no", "pm-yes"]
@@ -287,12 +287,12 @@ async def test_market_selector_select_per_strategy_returns_pre_merge_strategy_se
         strategy_market_set_cls(
             strategy_id="alpha",
             strategy_version_id="alpha-v1",
-            asset_ids=frozenset({"pm-yes", "pm-no"}),
+            asset_ids=frozenset({"pm-yes"}),
         ),
         strategy_market_set_cls(
             strategy_id="beta",
             strategy_version_id="beta-v2",
-            asset_ids=frozenset({"pm-yes", "pm-no"}),
+            asset_ids=frozenset({"pm-yes"}),
         ),
     ]
 

--- a/tests/unit/test_order_fill_store_cp10.py
+++ b/tests/unit/test_order_fill_store_cp10.py
@@ -186,6 +186,7 @@ async def test_fill_store_read_positions_maps_aggregated_rows() -> None:
             "side": "yes",
             "shares_held": 400.0,
             "avg_entry_price": 0.25,
+            "current_price": 0.31,
             "locked_usdc": 100.0,
         }
     ]
@@ -201,11 +202,46 @@ async def test_fill_store_read_positions_maps_aggregated_rows() -> None:
             side="yes",
             shares_held=400.0,
             avg_entry_price=0.25,
-            unrealized_pnl=0.0,
+            unrealized_pnl=24.0,
             locked_usdc=100.0,
         )
     ]
     assert "GROUP BY" in connection.fetch_calls[0][0]
+    assert "LEFT JOIN tokens" in connection.fetch_calls[0][0]
+    assert "LEFT JOIN markets" in connection.fetch_calls[0][0]
+
+
+@pytest.mark.asyncio
+async def test_fill_store_read_positions_maps_missing_market_price_to_zero_pnl() -> None:
+    connection = _RecordingConnection()
+    connection.fetch_rows = [
+        {
+            "market_id": "market-unit-cp10-2",
+            "token_id": "token-unit-cp10-2",
+            "venue": "polymarket",
+            "side": "BUY",
+            "shares_held": 50.0,
+            "avg_entry_price": 0.42,
+            "current_price": None,
+            "locked_usdc": 21.0,
+        }
+    ]
+    store = FillStore(cast(asyncpg.Pool, _RecordingPool(connection)))
+
+    positions = await store.read_positions()
+
+    assert positions == [
+        Position(
+            market_id="market-unit-cp10-2",
+            token_id="token-unit-cp10-2",
+            venue="polymarket",
+            side="BUY",
+            shares_held=50.0,
+            avg_entry_price=0.42,
+            unrealized_pnl=0.0,
+            locked_usdc=21.0,
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_active_perception.py
+++ b/tests/unit/test_runner_active_perception.py
@@ -11,11 +11,12 @@ from typing import Any, cast
 
 import pytest
 
-from pms.config import DatabaseSettings, PMSSettings, RiskSettings
+from pms.config import DatabaseSettings, PMSSettings, RiskSettings, SensorSettings
 from pms.core.enums import RunMode
 from pms.core.models import MarketSignal
 from pms.market_selection.merge import StrategyMarketSet
-from pms.runner import Runner
+from pms.runner import Runner, _default_active_strategy
+from tests.support.default_strategy_seed import build_default_v1_strategy
 
 
 FIXTURE_PATH = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
@@ -161,6 +162,60 @@ def _settings(mode: RunMode) -> PMSSettings:
             max_total_exposure=10_000.0,
         ),
     )
+
+
+class _DefaultV2Connection:
+    async def fetchval(self, query: str) -> str:
+        del query
+        return "default-v1"
+
+
+class _DefaultV2AcquireContext:
+    async def __aenter__(self) -> _DefaultV2Connection:
+        return _DefaultV2Connection()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
+    ) -> bool:
+        del exc_type, exc, tb
+        return False
+
+
+class _DefaultV2Pool:
+    def acquire(self) -> _DefaultV2AcquireContext:
+        return _DefaultV2AcquireContext()
+
+
+@dataclass
+class _RecordingDefaultV2Registry:
+    created_strategy: Any | None = None
+    active_version: str | None = None
+    populated_version: str | None = None
+
+    async def get_by_id(self, strategy_id: str) -> Any:
+        assert strategy_id == "default"
+        return build_default_v1_strategy()
+
+    async def create_version(self, strategy: Any) -> Any:
+        self.created_strategy = strategy
+        return SimpleNamespace(strategy_version_id="default-v2-test")
+
+    async def set_active(self, strategy_id: str, strategy_version_id: str) -> None:
+        assert strategy_id == "default"
+        self.active_version = strategy_version_id
+
+    async def populate_strategy_factors(
+        self,
+        strategy_id: str,
+        strategy_version_id: str,
+        factor_ids: object,
+    ) -> None:
+        del factor_ids
+        assert strategy_id == "default"
+        self.populated_version = strategy_version_id
 
 
 def _runner(mode: RunMode, **kwargs: Any) -> Runner:
@@ -322,6 +377,41 @@ async def test_runner_active_perception_boot_order_and_first_poll_subscription_u
     await runner.stop()
 
 
+def test_default_active_strategy_uses_operational_market_selection_horizon() -> None:
+    strategy = _default_active_strategy(_settings(RunMode.PAPER))
+
+    assert strategy.market_selection.resolution_time_max_horizon_days == 90
+
+
+@pytest.mark.asyncio
+async def test_default_v2_migration_widens_legacy_bootstrap_horizon() -> None:
+    runner = Runner(
+        config=PMSSettings(
+            mode=RunMode.PAPER,
+            auto_migrate_default_v2=True,
+            database=DatabaseSettings(
+                dsn="postgresql://localhost/pms_test_runner",
+                pool_min_size=2,
+                pool_max_size=10,
+            ),
+        ),
+        historical_data_path=FIXTURE_PATH,
+    )
+    registry = _RecordingDefaultV2Registry()
+    runner._pg_pool = cast(Any, _DefaultV2Pool())  # noqa: SLF001
+    runner._strategy_registry = cast(Any, registry)  # noqa: SLF001
+
+    await runner._ensure_default_v2_version()  # noqa: SLF001
+
+    assert registry.created_strategy is not None
+    assert (
+        registry.created_strategy.market_selection.resolution_time_max_horizon_days
+        == 90
+    )
+    assert registry.active_version == "default-v2-test"
+    assert registry.populated_version == "default-v2-test"
+
+
 @pytest.mark.asyncio
 async def test_runner_active_perception_backtest_skips_wiring(
     monkeypatch: pytest.MonkeyPatch,
@@ -405,6 +495,119 @@ async def test_runner_active_perception_reselection_is_serialized(
 
 
 @pytest.mark.asyncio
+async def test_discovery_poll_refreshes_controller_runtime_scopes() -> None:
+    events: list[list[str]] = []
+
+    class IdleController:
+        async def decide(
+            self,
+            signal: MarketSignal,
+            portfolio: object | None = None,
+        ) -> None:
+            del signal, portfolio
+            return None
+
+    class ActiveRegistry:
+        async def list_active_strategies(self) -> list[Any]:
+            return [
+                SimpleNamespace(
+                    strategy_id="alpha",
+                    strategy_version_id="alpha-v1",
+                )
+            ]
+
+    @dataclass
+    class ScopeSelector:
+        async def select(self) -> Any:
+            return type("MergeResult", (), {"asset_ids": ("fresh-token",)})()
+
+        async def select_per_strategy(self) -> list[StrategyMarketSet]:
+            return [
+                StrategyMarketSet(
+                    strategy_id="alpha",
+                    strategy_version_id="alpha-v1",
+                    asset_ids=frozenset({"fresh-token"}),
+                )
+            ]
+
+    @dataclass
+    class RecordingSubscriptionController:
+        async def update(self, asset_ids: list[str]) -> bool:
+            events.append(list(asset_ids))
+            return True
+
+    class ControllerFactory:
+        def build_many(self, active_strategies: list[Any]) -> dict[str, IdleController]:
+            return {
+                strategy.strategy_id: IdleController()
+                for strategy in active_strategies
+            }
+
+    runner = _runner(RunMode.LIVE)
+    runner._strategy_registry = cast(Any, ActiveRegistry())  # noqa: SLF001
+    runner._market_selector = cast(Any, ScopeSelector())  # noqa: SLF001
+    runner._subscription_controller = cast(Any, RecordingSubscriptionController())  # noqa: SLF001
+    runner._controller_factory = cast(Any, ControllerFactory())  # noqa: SLF001
+
+    try:
+        await runner._handle_discovery_poll_complete()  # noqa: SLF001
+
+        assert runner._controller_runtimes["alpha"].asset_ids == frozenset(  # noqa: SLF001
+            {"fresh-token"}
+        )
+        assert events == [["fresh-token"]]
+        assert runner._reselection_requested.is_set()  # noqa: SLF001
+    finally:
+        runner._stop_event.set()  # noqa: SLF001
+        tasks = tuple(runner._controller_pipeline_tasks.values())  # noqa: SLF001
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_reselection_caps_subscription_asset_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    _, discovery, market_data, selector, subscription_controller = _install_live_doubles(
+        monkeypatch,
+        events=events,
+        returned_asset_ids=["asset-a", "asset-b", "asset-c"],
+    )
+
+    runner = Runner(
+        config=PMSSettings(
+            mode=RunMode.LIVE,
+            auto_migrate_default_v2=False,
+            database=DatabaseSettings(
+                dsn="postgresql://localhost/pms_test_runner",
+                pool_min_size=2,
+                pool_max_size=10,
+            ),
+            sensor=SensorSettings(max_subscription_asset_ids=2),
+        ),
+        historical_data_path=FIXTURE_PATH,
+    )
+    await runner.start()
+
+    task = asyncio.create_task(runner._reselect())  # noqa: SLF001
+    await asyncio.wait_for(selector.call_started.wait(), timeout=2.0)
+    selector.call_release.set()
+    await asyncio.wait_for(subscription_controller.call_started.wait(), timeout=2.0)
+    subscription_controller.call_release.set()
+    await asyncio.wait_for(market_data.update_started.wait(), timeout=2.0)
+    market_data.update_release.set()
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert subscription_controller.updates[-1] == ["asset-a", "asset-b"]
+    assert market_data.asset_ids == ["asset-a", "asset-b"]
+
+    discovery.poll_released.set()
+    await runner.stop()
+
+
+@pytest.mark.asyncio
 async def test_refresh_subscription_updates_wait_for_reselection_lock() -> None:
     events: list[list[str]] = []
 
@@ -463,6 +666,42 @@ async def test_refresh_subscription_updates_wait_for_reselection_lock() -> None:
 
     assert subscription_controller.max_active_calls == 1
     assert events == [["strategy-token"], ["refresh-token"]]
+
+
+@pytest.mark.asyncio
+async def test_refresh_subscription_caps_asset_ids() -> None:
+    events: list[list[str]] = []
+
+    @dataclass
+    class RecordingSubscriptionController:
+        async def update(self, asset_ids: list[str]) -> bool:
+            events.append(list(asset_ids))
+            return True
+
+    runner = Runner(
+        config=PMSSettings(
+            mode=RunMode.LIVE,
+            auto_migrate_default_v2=False,
+            database=DatabaseSettings(
+                dsn="postgresql://localhost/pms_test_runner",
+                pool_min_size=2,
+                pool_max_size=10,
+            ),
+            sensor=SensorSettings(max_subscription_asset_ids=2),
+        ),
+        historical_data_path=FIXTURE_PATH,
+    )
+    runner._subscription_controller = cast(Any, RecordingSubscriptionController())  # noqa: SLF001
+    runner._controller_runtimes = {  # noqa: SLF001
+        "alpha": cast(
+            Any,
+            SimpleNamespace(asset_ids=frozenset({"asset-c", "asset-a", "asset-b"})),
+        )
+    }
+
+    await runner._refresh_subscription_assets_locked()  # noqa: SLF001
+
+    assert events == [["asset-a", "asset-b"]]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_fill_persistence_cp06.py
+++ b/tests/unit/test_runner_fill_persistence_cp06.py
@@ -137,6 +137,29 @@ class _EvaluatorSpoolDouble:
         self.calls.append((fill.market_id, decision.decision_id))
 
 
+class _RecordingOrderStore:
+    def __init__(self, runner: Runner) -> None:
+        self.runner = runner
+        self.calls: list[str] = []
+
+    async def insert(self, order: OrderState) -> None:
+        assert self.runner.state.orders[-1] == order
+        self.calls.append(order.market_id)
+
+
+class _FlakyOrderStore(_RecordingOrderStore):
+    def __init__(self, runner: Runner) -> None:
+        super().__init__(runner)
+        self.fail_first = True
+
+    async def insert(self, order: OrderState) -> None:
+        assert self.runner.state.orders[-1] == order
+        self.calls.append(order.market_id)
+        if self.fail_first:
+            self.fail_first = False
+            raise RuntimeError("order store down")
+
+
 class _RecordingFillStore:
     def __init__(self, runner: Runner) -> None:
         self.runner = runner
@@ -173,6 +196,7 @@ async def test_actuator_loop_persists_fill_after_appending_runner_state() -> Non
     runner = _runner()
     runner.actuator_executor = cast(Any, _ExecutorDouble())
     runner._evaluator_spool = cast(Any, _EvaluatorSpoolDouble())  # noqa: SLF001
+    runner.order_store = cast(Any, _RecordingOrderStore(runner))
     runner.fill_store = cast(Any, _RecordingFillStore(runner))
     _mark_controller_done(runner)
 
@@ -183,12 +207,66 @@ async def test_actuator_loop_persists_fill_after_appending_runner_state() -> Non
 
     await _run_actuator_loop(runner)
 
+    assert [order.market_id for order in runner.state.orders] == ["market-cp06-a"]
+    assert cast(_RecordingOrderStore, runner.order_store).calls == ["market-cp06-a"]
     assert [fill.market_id for fill in runner.state.fills] == ["market-cp06-a"]
     assert cast(_RecordingFillStore, runner.fill_store).calls == ["market-cp06-a"]
     assert runner.portfolio.locked_usdc == pytest.approx(20.5)
     assert cast(_EvaluatorSpoolDouble, runner._evaluator_spool).calls == [
         ("market-cp06-a", "decision-market-cp06-a")
     ]
+
+
+@pytest.mark.asyncio
+async def test_actuator_loop_logs_order_store_failures_and_continues(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runner = _runner()
+    runner.actuator_executor = cast(Any, _ExecutorDouble())
+    runner._evaluator_spool = cast(Any, _EvaluatorSpoolDouble())  # noqa: SLF001
+    runner.order_store = cast(Any, _FlakyOrderStore(runner))
+    runner.fill_store = cast(Any, _RecordingFillStore(runner))
+    _mark_controller_done(runner)
+
+    await runner._decision_queue.put(  # noqa: SLF001
+        ActuatorWorkItem(
+            _decision(market_id="market-cp06-a"),
+            _signal(market_id="market-cp06-a"),
+        )
+    )
+    await runner._decision_queue.put(  # noqa: SLF001
+        ActuatorWorkItem(
+            _decision(market_id="market-cp06-b"),
+            _signal(market_id="market-cp06-b"),
+        )
+    )
+
+    caplog.set_level(logging.WARNING, logger="pms.runner")
+
+    await _run_actuator_loop(runner)
+
+    assert [order.market_id for order in runner.state.orders] == [
+        "market-cp06-a",
+        "market-cp06-b",
+    ]
+    assert cast(_FlakyOrderStore, runner.order_store).calls == [
+        "market-cp06-a",
+        "market-cp06-b",
+    ]
+    assert [fill.market_id for fill in runner.state.fills] == [
+        "market-cp06-a",
+        "market-cp06-b",
+    ]
+    assert cast(_RecordingFillStore, runner.fill_store).calls == [
+        "market-cp06-a",
+        "market-cp06-b",
+    ]
+    assert runner.portfolio.locked_usdc == pytest.approx(41.0)
+    assert cast(_EvaluatorSpoolDouble, runner._evaluator_spool).calls == [
+        ("market-cp06-a", "decision-market-cp06-a"),
+        ("market-cp06-b", "decision-market-cp06-b"),
+    ]
+    assert "order persistence failed" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_pool_lifecycle.py
+++ b/tests/unit/test_runner_pool_lifecycle.py
@@ -330,6 +330,7 @@ async def test_runner_close_pg_pool_unbinds_eval_and_feedback_stores(
     from pms.storage.eval_store import EvalStore
     from pms.storage.feedback_store import FeedbackStore
     from pms.storage.fill_store import FillStore
+    from pms.storage.order_store import OrderStore
 
     fake_pool = FakePool()
     runner = _runner(
@@ -338,11 +339,13 @@ async def test_runner_close_pg_pool_unbinds_eval_and_feedback_stores(
         eval_store=EvalStore(),
         feedback_store=FeedbackStore(),
         decision_store=DecisionStore(),
+        order_store=OrderStore(),
         fill_store=FillStore(),
     )
     eval_store = runner.eval_store
     feedback_store = runner.feedback_store
     decision_store = runner.decision_store
+    order_store = runner.order_store
     fill_store = runner.fill_store
 
     runner.bind_pg_pool(cast(Any, fake_pool))
@@ -350,6 +353,7 @@ async def test_runner_close_pg_pool_unbinds_eval_and_feedback_stores(
     assert eval_store.pool is fake_pool
     assert feedback_store.pool is fake_pool
     assert decision_store.pool is fake_pool
+    assert order_store.pool is fake_pool
     assert fill_store.pool is fake_pool
 
     await runner.close_pg_pool()
@@ -357,6 +361,7 @@ async def test_runner_close_pg_pool_unbinds_eval_and_feedback_stores(
     assert getattr(eval_store, "pool", None) is None
     assert getattr(feedback_store, "pool", None) is None
     assert getattr(decision_store, "pool", None) is None
+    assert getattr(order_store, "pool", None) is None
     assert getattr(fill_store, "pool", None) is None
 
 


### PR DESCRIPTION
## Summary

This PR fixes the current PAPER-mode end-to-end blockers found by running the system as a first-time user/trading bot on a fresh PostgreSQL database.

## What Changed

- Refresh controller runtime scopes after discovery completes so a fresh database no longer stalls at signals-only.
- Cap active market-data subscriptions and update the websocket with subscribe/unsubscribe operations instead of forcing an oversized static subscription.
- Persist actuator order states through `OrderStore` and bind/unbind it with the rest of the runner-owned PostgreSQL stores.
- Compute mark-to-market unrealized P&L for `/positions` from current market prices.
- Expand the operational default market-selection horizon and keep strategy selection to YES token IDs.

## Runtime Evidence

Fresh PAPER smoke on a migrated temporary database produced:

- 500 markets / 1000 tokens
- 83 decisions
- 83 persisted orders
- 48 fills
- 33 open positions
- 999.7349 USDC locked
- -43.4620 USDC unrealized P&L

`eval_records` remained 0 because the live markets were unresolved; realized evaluation still requires `resolved_outcome`.

## Validation

- `uv sync`
- `uv run pytest -q` -> 659 passed, 155 skipped
- `uv run mypy src/ tests/ --strict` -> clean

## Remaining Gap

Real-money execution is still intentionally gated: `live_trading_enabled` must be explicit, and `PolymarketActuator.execute()` still raises `NotImplementedError`. A separate issue tracks the live executor/operator-gate work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limit for subscription asset IDs
  * Order persistence now enabled in storage
  * Extended market selection horizon from 7 to 90 days

* **Improvements**
  * Position tracking now calculates unrealized PnL using current market prices
  * Market data subscriptions optimized with incremental updates instead of full refreshes
  * Market selection filtering enhanced to exclude non-YES market tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->