### PR TITLE
fix(live): harden Polymarket actuator before first $5-10 smoke

### DIFF
--- a/alembic/versions/0009_submission_unknown_outcome.py
+++ b/alembic/versions/0009_submission_unknown_outcome.py
@@ -66,4 +66,16 @@ def downgrade() -> None:
     op.execute(
         "ALTER TABLE order_intents DROP CONSTRAINT IF EXISTS order_intents_outcome_check"
     )
+    # Reconcile any rows that adopted the new outcome before re-adding
+    # the stricter constraint. Setting outcome=NULL preserves the audit
+    # trail (acquired_at, decision_id, worker info) but takes the row
+    # back to an "intent unreleased" state, which is the correct
+    # semantic — a `submission_unknown` outcome means the operator never
+    # confirmed the venue state, so leaving it released under a
+    # different outcome would falsely imply finality.
+    op.execute(
+        "UPDATE order_intents "
+        "SET outcome = NULL, released_at = NULL "
+        "WHERE outcome = 'submission_unknown'"
+    )
     op.execute(_check_constraint_sql(_OUTCOMES_WITHOUT_SUBMISSION_UNKNOWN))

--- a/alembic/versions/0009_submission_unknown_outcome.py
+++ b/alembic/versions/0009_submission_unknown_outcome.py
@@ -1,0 +1,69 @@
+"""Add submission_unknown to order_intents outcome enum.
+
+`submission_unknown` surfaces from the Polymarket adapter when the SDK
+call times out — the order may have reached the venue, and we must
+keep the dedup intent in a distinct, manually-reconcilable state.
+Without this migration, releasing an intent with that outcome would
+hit the existing `order_intents_outcome_check` constraint.
+
+This migration drops and recreates the check constraint with the
+additional allowed value. Existing rows are unaffected (the constraint
+only validates new writes).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from alembic import op
+
+
+revision = "0009_submission_unknown_outcome"
+down_revision = "0008_market_subscriptions"
+branch_labels = None
+depends_on = None
+
+
+_OUTCOMES_WITH_SUBMISSION_UNKNOWN: Final[tuple[str, ...]] = (
+    "matched",
+    "invalid",
+    "rejected",
+    "venue_rejection",
+    "submission_unknown",
+    "cancelled_ttl",
+    "cancelled_limit_invalidated",
+    "cancelled_session_end",
+)
+
+_OUTCOMES_WITHOUT_SUBMISSION_UNKNOWN: Final[tuple[str, ...]] = (
+    "matched",
+    "invalid",
+    "rejected",
+    "venue_rejection",
+    "cancelled_ttl",
+    "cancelled_limit_invalidated",
+    "cancelled_session_end",
+)
+
+
+def _check_constraint_sql(outcomes: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{outcome}'" for outcome in outcomes)
+    return (
+        "ALTER TABLE order_intents "
+        "ADD CONSTRAINT order_intents_outcome_check "
+        f"CHECK (outcome IS NULL OR outcome IN ({quoted}))"
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE order_intents DROP CONSTRAINT IF EXISTS order_intents_outcome_check"
+    )
+    op.execute(_check_constraint_sql(_OUTCOMES_WITH_SUBMISSION_UNKNOWN))
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE order_intents DROP CONSTRAINT IF EXISTS order_intents_outcome_check"
+    )
+    op.execute(_check_constraint_sql(_OUTCOMES_WITHOUT_SUBMISSION_UNKNOWN))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ filterwarnings = ["error"]
 markers = [
     "slow: marks tests as slow / integration (deselect with '-m \"not slow\"')",
     "integration: real-network/real-subprocess integration tests (deselect with '-m \"not integration\"')",
+    "real_fill_store: opt out of the conftest FillStore.read_positions stub (used by tests that exercise the real implementation directly)",
 ]
 
 # ---------------------------------------------------------------------------

--- a/schema.sql
+++ b/schema.sql
@@ -296,7 +296,7 @@ CREATE TABLE IF NOT EXISTS order_intents (
     worker_pid INTEGER,
     outcome TEXT,
     CONSTRAINT order_intents_outcome_check
-        CHECK (outcome IS NULL OR outcome IN ('matched', 'invalid', 'rejected', 'venue_rejection', 'cancelled_ttl', 'cancelled_limit_invalidated', 'cancelled_session_end'))
+        CHECK (outcome IS NULL OR outcome IN ('matched', 'invalid', 'rejected', 'venue_rejection', 'submission_unknown', 'cancelled_ttl', 'cancelled_limit_invalidated', 'cancelled_session_end'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_order_intents_strategy_acquired_at_desc

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -483,32 +483,52 @@ def _order_result_from_sdk_response(
     # aliases and fall back to the status-based heuristic when none are
     # present. Pre-fix, only MATCHED produced fill data — every partial
     # fill was silently dropped.
-    explicit_filled_notional = _coerce_float_or_none(
-        _response_value(
-            response,
-            "filled_notional_usdc",
-            "filledNotional",
-            "filled_amount",
-        )
+    # Track raw key presence and coerced value separately. A
+    # `_coerce_float_or_none` of "nan"/"inf"/null returns None, but the
+    # field IS still in the venue response — we must NOT treat that as
+    # "no explicit data" (which would trigger the matched-fallback
+    # full-fill synthesis). Reject unparseable values up front.
+    notional_field_present = _response_field_present(
+        response, "filled_notional_usdc", "filledNotional", "filled_amount"
     )
-    explicit_filled_quantity = _coerce_float_or_none(
-        _response_value(
-            response,
-            "filled_quantity",
-            "filledQuantity",
-            "filled_size",
-            "filled",
-        )
+    raw_notional = _response_value(
+        response, "filled_notional_usdc", "filledNotional", "filled_amount"
     )
-    explicit_fill_price = _coerce_float_or_none(
-        _response_value(
-            response,
-            "fill_price",
-            "fillPrice",
-            "average_price",
-            "avg_price",
+    explicit_filled_notional = _coerce_float_or_none(raw_notional)
+    if notional_field_present and explicit_filled_notional is None:
+        msg = (
+            "Polymarket reported unparseable filled_notional "
+            "(non-finite or null); refusing to persist suspect fill"
         )
+        raise LiveTradingDisabledError(msg)
+
+    quantity_field_present = _response_field_present(
+        response, "filled_quantity", "filledQuantity", "filled_size", "filled"
     )
+    raw_quantity = _response_value(
+        response, "filled_quantity", "filledQuantity", "filled_size", "filled"
+    )
+    explicit_filled_quantity = _coerce_float_or_none(raw_quantity)
+    if quantity_field_present and explicit_filled_quantity is None:
+        msg = (
+            "Polymarket reported unparseable filled_quantity "
+            "(non-finite or null); refusing to persist suspect fill"
+        )
+        raise LiveTradingDisabledError(msg)
+
+    price_field_present = _response_field_present(
+        response, "fill_price", "fillPrice", "average_price", "avg_price"
+    )
+    raw_price = _response_value(
+        response, "fill_price", "fillPrice", "average_price", "avg_price"
+    )
+    explicit_fill_price = _coerce_float_or_none(raw_price)
+    if price_field_present and explicit_fill_price is None:
+        msg = (
+            "Polymarket reported unparseable fill_price "
+            "(non-finite or null); refusing to persist suspect fill"
+        )
+        raise LiveTradingDisabledError(msg)
 
     filled_notional_usdc: float
     filled_quantity: float
@@ -526,10 +546,12 @@ def _order_result_from_sdk_response(
         price=explicit_fill_price,
     )
 
+    # Use *raw* presence here, not coerced. A field that arrived but
+    # failed to coerce was already rejected above; this flag is for
+    # legitimately-set but zero-valued fields (e.g. resting limit with
+    # filled_notional=0).
     explicit_field_present = (
-        explicit_filled_notional is not None
-        or explicit_filled_quantity is not None
-        or explicit_fill_price is not None
+        notional_field_present or quantity_field_present or price_field_present
     )
 
     if explicit_filled_notional is not None and explicit_filled_notional > 0.0:
@@ -708,6 +730,18 @@ def _response_value(response: object, *keys: str) -> object | None:
         if value is not None:
             return cast(object, value)
     return None
+
+
+def _response_field_present(response: object, *keys: str) -> bool:
+    """Distinct from `_response_value`: returns True iff the venue
+    actually surfaced one of the keys (regardless of whether the value
+    parses). Used to detect malformed-but-present fields, which must be
+    rejected before the matched-fallback can synthesize a full fill.
+    """
+    if isinstance(response, Mapping):
+        mapping = cast(Mapping[str, object], response)
+        return any(key in mapping for key in keys)
+    return any(hasattr(response, key) for key in keys)
 
 
 def _required_secret(value: str | None, field_name: str) -> str:

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -684,15 +684,24 @@ def _is_sdk_transport_failure(exc: BaseException) -> bool:
     (no HTTP response from the venue) — distinct from the venue
     rejecting the order with an HTTP error response.
 
-    `py_clob_client_v2.exceptions.PolyApiException(resp=None, ...)`
-    is the wrapped form of httpx timeouts, connection drops, etc. We
-    duck-type via class name + attribute presence so this module does
-    not take a hard import dependency on the SDK exception class.
+    `py_clob_client_v2.exceptions.PolyApiException` takes `resp` in
+    its constructor but does NOT retain it as an attribute — the
+    instance stores `status_code` (extracted from `resp.status_code`,
+    or None if `resp` was None) plus `error_msg`. So the right
+    transport-failure signal is `status_code is None`. Verified against
+    real SDK 1.0.0:
+        PolyApiException(resp=None).__dict__ ==
+            {'status_code': None, 'error_msg': ...}
+        PolyApiException(resp=<httpx_response>).__dict__ ==
+            {'status_code': 400, 'error_msg': ...}
+
+    Duck-typed (class name + attribute) so this module does not take a
+    hard import dependency on the SDK exception class.
     """
     if type(exc).__name__ != "PolyApiException":
         return False
-    resp = getattr(exc, "resp", _MISSING_SENTINEL)
-    return resp is None
+    status_code = getattr(exc, "status_code", _MISSING_SENTINEL)
+    return status_code is None
 
 
 _MISSING_SENTINEL: Final[object] = object()

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -502,11 +502,21 @@ def _order_result_from_sdk_response(
         )
         raise LiveTradingDisabledError(msg)
 
+    # `fill_count` is the venue-side contract count alias documented at
+    # `docs/research/schema-spec.md:284,307` — order-response contract
+    # count used for order-state reconciliation. Including it here
+    # closes the bypass codex called out in Round 7 finding f14: a
+    # response with `fill_count: "nan"` was previously not seen by the
+    # raw-presence check and therefore could route through the matched
+    # full-fill synthesis path. NOTE: `price` is intentionally NOT
+    # aliased to fill_price — in `py_clob_client_v2.OrderArgs`/
+    # `MarketOrderArgs`, `price` is the *request* price, not the fill
+    # price. Aliasing it would conflate request and execution data.
     quantity_field_present = _response_field_present(
-        response, "filled_quantity", "filledQuantity", "filled_size", "filled"
+        response, "filled_quantity", "filledQuantity", "filled_size", "filled", "fill_count"
     )
     raw_quantity = _response_value(
-        response, "filled_quantity", "filledQuantity", "filled_size", "filled"
+        response, "filled_quantity", "filledQuantity", "filled_size", "filled", "fill_count"
     )
     explicit_filled_quantity = _coerce_float_or_none(raw_quantity)
     if quantity_field_present and explicit_filled_quantity is None:

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -514,38 +514,27 @@ def _order_result_from_sdk_response(
     filled_quantity: float
     fill_price: float | None
 
+    # Validate every non-None explicit fill field BEFORE branching. A
+    # malformed venue response must not be able to corrupt accounting
+    # via the matched fallback (which previously trusted explicit values
+    # without checking) — a status="matched" response with negative
+    # filled_quantity or fill_price=1.5 used to slip through.
+    _validate_explicit_fill_fields(
+        order=order,
+        notional=explicit_filled_notional,
+        quantity=explicit_filled_quantity,
+        price=explicit_fill_price,
+    )
+
     if explicit_filled_notional is not None and explicit_filled_notional > 0.0:
-        # Partial-or-full fill with explicit data from the venue. Validate
-        # ranges before persisting: a malformed SDK response must not be
-        # able to corrupt portfolio accounting with negative shares,
-        # over-filled notional, or out-of-range probability prices.
-        if explicit_filled_notional > order.notional_usdc + _NOTIONAL_OVERFILL_TOLERANCE:
-            msg = (
-                "Polymarket reported filled_notional exceeds requested "
-                "notional; refusing to persist suspect fill"
-            )
-            raise LiveTradingDisabledError(msg)
+        # Partial-or-full fill with explicit data from the venue.
         filled_notional_usdc = explicit_filled_notional
-        if explicit_filled_quantity is not None and explicit_filled_quantity < 0.0:
-            msg = (
-                "Polymarket reported negative filled_quantity; refusing "
-                "to persist suspect fill"
-            )
-            raise LiveTradingDisabledError(msg)
         filled_quantity = (
             explicit_filled_quantity
             if explicit_filled_quantity is not None and explicit_filled_quantity > 0.0
             else 0.0
         )
         if explicit_fill_price is not None:
-            if not (
-                _PROBABILITY_PRICE_MIN < explicit_fill_price <= _PROBABILITY_PRICE_MAX
-            ):
-                msg = (
-                    "Polymarket reported fill_price outside (0, 1] range; "
-                    "refusing to persist suspect fill"
-                )
-                raise LiveTradingDisabledError(msg)
             fill_price = explicit_fill_price
         elif filled_quantity > 0.0:
             implied_price = filled_notional_usdc / filled_quantity
@@ -564,7 +553,8 @@ def _order_result_from_sdk_response(
             fill_price = order.price
     elif status == OrderStatus.MATCHED.value:
         # Backwards-compat: status=matched without explicit fill data
-        # implies full fill at limit price.
+        # implies full fill at limit price. Explicit fields were
+        # validated above, so any non-None values can be trusted.
         filled_notional_usdc = order.notional_usdc
         filled_quantity = (
             explicit_filled_quantity
@@ -594,6 +584,47 @@ def _order_result_from_sdk_response(
         fill_price=fill_price,
         filled_quantity=filled_quantity,
     )
+
+
+def _validate_explicit_fill_fields(
+    *,
+    order: PolymarketOrderRequest,
+    notional: float | None,
+    quantity: float | None,
+    price: float | None,
+) -> None:
+    """Reject malformed venue-supplied fill fields before any branch
+    consumes them. Runs ahead of the matched/partial/no-fill branches so
+    a `status=matched` response with `filled_quantity=-8.0` (for
+    example) cannot be persisted via the backwards-compat fallback.
+    """
+    if notional is not None:
+        if notional < 0.0:
+            msg = (
+                "Polymarket reported negative filled_notional; refusing "
+                "to persist suspect fill"
+            )
+            raise LiveTradingDisabledError(msg)
+        if notional > order.notional_usdc + _NOTIONAL_OVERFILL_TOLERANCE:
+            msg = (
+                "Polymarket reported filled_notional exceeds requested "
+                "notional; refusing to persist suspect fill"
+            )
+            raise LiveTradingDisabledError(msg)
+    if quantity is not None and quantity < 0.0:
+        msg = (
+            "Polymarket reported negative filled_quantity; refusing to "
+            "persist suspect fill"
+        )
+        raise LiveTradingDisabledError(msg)
+    if price is not None and not (
+        _PROBABILITY_PRICE_MIN < price <= _PROBABILITY_PRICE_MAX
+    ):
+        msg = (
+            "Polymarket reported fill_price outside (0, 1] range; "
+            "refusing to persist suspect fill"
+        )
+        raise LiveTradingDisabledError(msg)
 
 
 def _coerce_float_or_none(value: object) -> float | None:

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -474,15 +474,79 @@ def _order_result_from_sdk_response(
         raise LiveTradingDisabledError(msg)
 
     status = str(_response_value(response, "status") or OrderStatus.LIVE.value).lower()
-    filled_notional_usdc = 0.0
-    remaining_notional_usdc = order.notional_usdc
-    fill_price: float | None = None
-    filled_quantity = 0.0
-    if status == OrderStatus.MATCHED.value:
+
+    # Parse explicit partial-fill data from the SDK response. Polymarket
+    # can return positive `filled_notional` with status != MATCHED (e.g.
+    # an IOC limit that filled half its size and cancelled the rest, or
+    # a GTC limit with a partial match still resting in the book). Field
+    # names vary across SDK versions; we accept any of the documented
+    # aliases and fall back to the status-based heuristic when none are
+    # present. Pre-fix, only MATCHED produced fill data — every partial
+    # fill was silently dropped.
+    explicit_filled_notional = _coerce_float_or_none(
+        _response_value(
+            response,
+            "filled_notional_usdc",
+            "filledNotional",
+            "filled_amount",
+        )
+    )
+    explicit_filled_quantity = _coerce_float_or_none(
+        _response_value(
+            response,
+            "filled_quantity",
+            "filledQuantity",
+            "filled_size",
+            "filled",
+        )
+    )
+    explicit_fill_price = _coerce_float_or_none(
+        _response_value(
+            response,
+            "fill_price",
+            "fillPrice",
+            "average_price",
+            "avg_price",
+        )
+    )
+
+    filled_notional_usdc: float
+    filled_quantity: float
+    fill_price: float | None
+
+    if explicit_filled_notional is not None and explicit_filled_notional > 0.0:
+        # Partial-or-full fill with explicit data from the venue.
+        filled_notional_usdc = explicit_filled_notional
+        filled_quantity = explicit_filled_quantity or 0.0
+        if explicit_fill_price is not None and explicit_fill_price > 0.0:
+            fill_price = explicit_fill_price
+        elif filled_quantity > 0.0:
+            fill_price = filled_notional_usdc / filled_quantity
+        else:
+            # Avoid div-by-zero; fall back to the limit price (best
+            # available estimate when the venue elided fill_quantity).
+            fill_price = order.price
+    elif status == OrderStatus.MATCHED.value:
+        # Backwards-compat: status=matched without explicit fill data
+        # implies full fill at limit price.
         filled_notional_usdc = order.notional_usdc
-        remaining_notional_usdc = 0.0
-        fill_price = order.price
-        filled_quantity = order.estimated_quantity
+        filled_quantity = (
+            explicit_filled_quantity
+            if explicit_filled_quantity is not None
+            else order.estimated_quantity
+        )
+        fill_price = (
+            explicit_fill_price if explicit_fill_price is not None else order.price
+        )
+    else:
+        # Live / pending / cancelled with no fill data — no fill yet.
+        filled_notional_usdc = 0.0
+        filled_quantity = (
+            explicit_filled_quantity if explicit_filled_quantity is not None else 0.0
+        )
+        fill_price = explicit_fill_price
+
+    remaining_notional_usdc = max(0.0, order.notional_usdc - filled_notional_usdc)
 
     order_id = _response_value(response, "orderID", "order_id", "id")
     return PolymarketOrderResult(
@@ -494,6 +558,19 @@ def _order_result_from_sdk_response(
         fill_price=fill_price,
         filled_quantity=filled_quantity,
     )
+
+
+def _coerce_float_or_none(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
 
 
 def _response_value(response: object, *keys: str) -> object | None:

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -158,12 +158,8 @@ class PolymarketSDKClient:
             # caller is responsible for reconciliation if it suppresses this.
             raise
         except (asyncio.TimeoutError, TimeoutError) as exc:
-            # A timeout means the venue may have accepted the order — we
-            # simply did not see the response. Surfacing this as
-            # `LiveTradingDisabledError` would falsely imply "nothing was
-            # sent". Use a venue-specific exception so callers and
-            # operators can distinguish "submitted but unknown" from
-            # "rejected / never sent".
+            # Bare timeout — the venue never responded. Surface as
+            # submission_unknown so operators reconcile before retrying.
             redacted = _redacted_exception_message(exc, credentials)
             logger.warning(
                 "Polymarket live order submission timed out (%s): %s",
@@ -177,6 +173,28 @@ class PolymarketSDKClient:
             raise PolymarketSubmissionUnknownError(msg) from None
         except Exception as exc:  # noqa: BLE001
             redacted = _redacted_exception_message(exc, credentials)
+            # `py_clob_client_v2.exceptions.PolyApiException` wraps httpx
+            # request errors (timeouts, connection drops) with `resp=None`,
+            # and HTTP-level venue errors with a populated httpx Response.
+            # The bare `except (TimeoutError, ...)` block above misses
+            # these wrapped transport failures — without this branch a
+            # real timeout still routes to `LiveTradingDisabledError` =
+            # venue_rejection, defeating the f2 contract that timeouts
+            # must surface as submission_unknown. Duck-typed (class name
+            # + attribute) so polymarket.py keeps no hard dependency on
+            # the SDK's exception class.
+            if _is_sdk_transport_failure(exc):
+                logger.warning(
+                    "Polymarket live order submission transport failure (%s): %s; "
+                    "treating as submission_unknown",
+                    type(exc).__name__,
+                    redacted,
+                )
+                msg = (
+                    "Polymarket live order submission transport failure; "
+                    "order status is unknown — reconcile with venue before retrying"
+                )
+                raise PolymarketSubmissionUnknownError(msg) from None
             logger.warning(
                 "Polymarket live order submission failed (%s): %s",
                 type(exc).__name__,
@@ -659,6 +677,25 @@ def _order_result_from_sdk_response(
         fill_price=fill_price,
         filled_quantity=filled_quantity,
     )
+
+
+def _is_sdk_transport_failure(exc: BaseException) -> bool:
+    """Detect SDK exceptions that represent a transport-level failure
+    (no HTTP response from the venue) — distinct from the venue
+    rejecting the order with an HTTP error response.
+
+    `py_clob_client_v2.exceptions.PolyApiException(resp=None, ...)`
+    is the wrapped form of httpx timeouts, connection drops, etc. We
+    duck-type via class name + attribute presence so this module does
+    not take a hard import dependency on the SDK exception class.
+    """
+    if type(exc).__name__ != "PolyApiException":
+        return False
+    resp = getattr(exc, "resp", _MISSING_SENTINEL)
+    return resp is None
+
+
+_MISSING_SENTINEL: Final[object] = object()
 
 
 def _validate_explicit_fill_fields(

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Final, Protocol, cast
 from uuid import uuid4
 
 from pms.config import PMSSettings, validate_live_mode_ready
@@ -515,13 +515,49 @@ def _order_result_from_sdk_response(
     fill_price: float | None
 
     if explicit_filled_notional is not None and explicit_filled_notional > 0.0:
-        # Partial-or-full fill with explicit data from the venue.
+        # Partial-or-full fill with explicit data from the venue. Validate
+        # ranges before persisting: a malformed SDK response must not be
+        # able to corrupt portfolio accounting with negative shares,
+        # over-filled notional, or out-of-range probability prices.
+        if explicit_filled_notional > order.notional_usdc + _NOTIONAL_OVERFILL_TOLERANCE:
+            msg = (
+                "Polymarket reported filled_notional exceeds requested "
+                "notional; refusing to persist suspect fill"
+            )
+            raise LiveTradingDisabledError(msg)
         filled_notional_usdc = explicit_filled_notional
-        filled_quantity = explicit_filled_quantity or 0.0
-        if explicit_fill_price is not None and explicit_fill_price > 0.0:
+        if explicit_filled_quantity is not None and explicit_filled_quantity < 0.0:
+            msg = (
+                "Polymarket reported negative filled_quantity; refusing "
+                "to persist suspect fill"
+            )
+            raise LiveTradingDisabledError(msg)
+        filled_quantity = (
+            explicit_filled_quantity
+            if explicit_filled_quantity is not None and explicit_filled_quantity > 0.0
+            else 0.0
+        )
+        if explicit_fill_price is not None:
+            if not (
+                _PROBABILITY_PRICE_MIN < explicit_fill_price <= _PROBABILITY_PRICE_MAX
+            ):
+                msg = (
+                    "Polymarket reported fill_price outside (0, 1] range; "
+                    "refusing to persist suspect fill"
+                )
+                raise LiveTradingDisabledError(msg)
             fill_price = explicit_fill_price
         elif filled_quantity > 0.0:
-            fill_price = filled_notional_usdc / filled_quantity
+            implied_price = filled_notional_usdc / filled_quantity
+            if not (
+                _PROBABILITY_PRICE_MIN < implied_price <= _PROBABILITY_PRICE_MAX
+            ):
+                msg = (
+                    "Polymarket implied fill_price (notional/quantity) "
+                    "outside (0, 1] range; refusing to persist suspect fill"
+                )
+                raise LiveTradingDisabledError(msg)
+            fill_price = implied_price
         else:
             # Avoid div-by-zero; fall back to the limit price (best
             # available estimate when the venue elided fill_quantity).
@@ -564,13 +600,26 @@ def _coerce_float_or_none(value: object) -> float | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
+        f = float(value)
+    elif isinstance(value, str):
         try:
-            return float(value)
+            f = float(value)
         except ValueError:
             return None
-    return None
+    else:
+        return None
+    # Reject NaN / +/- infinity. Persisting either as `filled_notional`
+    # / `filled_quantity` / `fill_price` would silently corrupt the
+    # portfolio and downstream metrics. A malformed venue response that
+    # parses to a non-finite number must be treated as "no fill data".
+    if not math.isfinite(f):
+        return None
+    return f
+
+
+_PROBABILITY_PRICE_MIN: Final[float] = 0.0
+_PROBABILITY_PRICE_MAX: Final[float] = 1.0
+_NOTIONAL_OVERFILL_TOLERANCE: Final[float] = 1e-6
 
 
 def _response_value(response: object, *keys: str) -> object | None:

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib
 import json
 import logging
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -27,6 +28,12 @@ logger = logging.getLogger(__name__)
 
 class OperatorApprovalRequiredError(LiveTradingDisabledError):
     """Raised when the first live order has not been approved by an operator."""
+
+
+class PolymarketSubmissionUnknownError(RuntimeError):
+    """Raised when a Polymarket order submission timed out — the order may
+    have reached the venue. Operators must reconcile before retrying.
+    """
 
 
 @dataclass(frozen=True)
@@ -76,12 +83,17 @@ class PolymarketClient(Protocol):
 class FirstLiveOrderGate(Protocol):
     async def approve_first_order(self, preview: LiveOrderPreview) -> bool: ...
 
+    async def consume(self, preview: LiveOrderPreview) -> None: ...
+
 
 @dataclass(frozen=True)
 class DenyFirstLiveOrderGate:
     async def approve_first_order(self, preview: LiveOrderPreview) -> bool:
         del preview
         return False
+
+    async def consume(self, preview: LiveOrderPreview) -> None:
+        del preview
 
 
 @dataclass
@@ -103,6 +115,15 @@ class FileFirstLiveOrderGate:
         if not isinstance(payload, dict):
             return False
         return _approval_payload_matches(cast(dict[str, object], payload), preview)
+
+    async def consume(self, preview: LiveOrderPreview) -> None:
+        # Atomically consume the approval artefact so it cannot be replayed
+        # by a future restart or a concurrent `approve_first_order` call.
+        del preview
+        try:
+            self.path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 @dataclass(frozen=True)
@@ -131,6 +152,29 @@ class PolymarketSDKClient:
         try:
             client = _build_sdk_client(sdk, credentials)
             response = _post_sdk_order(sdk, client, order)
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            # Cooperative cancellation — caller decides what to do. The
+            # underlying request may still be in flight on Polymarket; the
+            # caller is responsible for reconciliation if it suppresses this.
+            raise
+        except (asyncio.TimeoutError, TimeoutError) as exc:
+            # A timeout means the venue may have accepted the order — we
+            # simply did not see the response. Surfacing this as
+            # `LiveTradingDisabledError` would falsely imply "nothing was
+            # sent". Use a venue-specific exception so callers and
+            # operators can distinguish "submitted but unknown" from
+            # "rejected / never sent".
+            redacted = _redacted_exception_message(exc, credentials)
+            logger.warning(
+                "Polymarket live order submission timed out (%s): %s",
+                type(exc).__name__,
+                redacted,
+            )
+            msg = (
+                "Polymarket live order submission timed out; order status is "
+                "unknown — reconcile with venue before retrying"
+            )
+            raise PolymarketSubmissionUnknownError(msg) from None
         except Exception as exc:  # noqa: BLE001
             redacted = _redacted_exception_message(exc, credentials)
             logger.warning(
@@ -189,17 +233,33 @@ class PolymarketActuator:
             raise LiveTradingDisabledError("Polymarket live trading is disabled")
         del portfolio
         credentials = validate_live_mode_ready(self.settings)
-        await self._require_first_order_approval(decision)
+        # `_require_first_order_approval` returns the preview that was just
+        # approved by the operator gate; returns None if a previous successful
+        # submit already opened the floodgates. The approval is *not* yet
+        # marked as committed — that happens only after a successful submit.
+        just_approved_preview = await self._require_first_order_approval(decision)
         request = _order_request(decision)
         result = await self.client.submit_order(request, credentials)
+        if just_approved_preview is not None:
+            # First venue submission succeeded: lock in first-order completion
+            # and consume the operator-side approval artefact so it cannot be
+            # replayed.
+            self._approval_state.approved = True
+            try:
+                await self.operator_gate.consume(just_approved_preview)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("first-order gate consume failed: %s", exc)
         return _order_state_from_result(decision, result)
 
-    async def _require_first_order_approval(self, decision: TradeDecision) -> None:
+    async def _require_first_order_approval(
+        self,
+        decision: TradeDecision,
+    ) -> LiveOrderPreview | None:
         if self._first_order_approved():
-            return
+            return None
         async with self._approval_lock:
             if self._first_order_approved():
-                return
+                return None
             preview = LiveOrderPreview(
                 max_notional_usdc=decision.notional_usdc,
                 venue=decision.venue,
@@ -220,7 +280,12 @@ class PolymarketActuator:
                     f"max_slippage_bps={preview.max_slippage_bps}"
                 )
                 raise OperatorApprovalRequiredError(msg)
-            self._approval_state.approved = True
+            # NOTE: `_approval_state.approved` is intentionally not set here.
+            # If the operator-approved preview never reaches the venue (submit
+            # failure), the next `execute()` must re-prompt the gate. The
+            # caller marks state.approved=True only after `submit_order`
+            # returns successfully.
+            return preview
 
     def _first_order_approved(self) -> bool:
         return self._approval_state.approved
@@ -294,16 +359,32 @@ def _approval_payload_matches(
 ) -> bool:
     if payload.get("approved") is not True:
         return False
-    expected = {
-        "max_notional_usdc": preview.max_notional_usdc,
-        "venue": preview.venue,
-        "market_id": preview.market_id,
-        "token_id": preview.token_id,
-        "side": preview.side,
-        "limit_price": preview.limit_price,
-        "max_slippage_bps": preview.max_slippage_bps,
-    }
-    return all(payload.get(key) == value for key, value in expected.items())
+    if payload.get("venue") != preview.venue:
+        return False
+    if payload.get("market_id") != preview.market_id:
+        return False
+    if payload.get("token_id") != preview.token_id:
+        return False
+    if payload.get("side") != preview.side:
+        return False
+    if payload.get("max_slippage_bps") != preview.max_slippage_bps:
+        return False
+    if not _float_close(payload.get("max_notional_usdc"), preview.max_notional_usdc):
+        return False
+    if not _float_close(payload.get("limit_price"), preview.limit_price):
+        return False
+    return True
+
+
+def _float_close(value: object, expected: float) -> bool:
+    # Operators copy/paste preview values into the approval JSON. Strict `==`
+    # comparison fails on harmless float representation differences (e.g.
+    # 0.1 + 0.2) and trains the operator to massage values until equality
+    # holds. `math.isclose` keeps the gate strict (rel/abs tolerances are
+    # tight) without introducing such drift.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return math.isclose(float(value), expected, rel_tol=1e-9, abs_tol=1e-12)
 
 
 def _build_sdk_client(sdk: object, credentials: VenueCredentials) -> object:
@@ -360,9 +441,18 @@ def _post_sdk_order(
 
 
 def _sdk_order_type(order_type_cls: object, order: PolymarketOrderRequest) -> object:
+    # Polymarket SDK enum: GTC (rest), FAK (fill-and-kill = IOC), FOK (all-or-nothing),
+    # GTD (good-till-date). PMS TimeInForce maps GTC→GTC, IOC→FAK, FOK→FOK
+    # symmetrically across market and limit orders. Without explicit IOC/FOK
+    # mapping for limit orders, an IOC limit silently rests in the book as
+    # GTC — a real behaviour change.
+    if order.time_in_force == "IOC":
+        return getattr(order_type_cls, "FAK")
+    if order.time_in_force == "FOK":
+        return getattr(order_type_cls, "FOK")
     if order.order_type.lower() == "market":
-        if order.time_in_force == "IOC":
-            return getattr(order_type_cls, "FAK")
+        # Default for market orders without an explicit TIF is FOK
+        # (all-or-nothing) — the SDK's own MarketOrderArgs default.
         return getattr(order_type_cls, "FOK")
     return getattr(order_type_cls, "GTC")
 

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -528,16 +528,22 @@ def _order_result_from_sdk_response(
 
     if explicit_filled_notional is not None and explicit_filled_notional > 0.0:
         # Partial-or-full fill with explicit data from the venue.
+        # A positive filled_notional MUST imply positive filled_quantity —
+        # a fill of $4 worth of zero shares is contradictory and would
+        # corrupt portfolio share accounting (`_fill_from_order` would
+        # persist a row with shares=0). Resolve in two passes: first
+        # determine fill_price (from explicit or fall back to limit),
+        # then derive quantity from notional/price when the venue
+        # omitted it; reject explicit-zero quantity with positive
+        # notional outright.
         filled_notional_usdc = explicit_filled_notional
-        filled_quantity = (
-            explicit_filled_quantity
-            if explicit_filled_quantity is not None and explicit_filled_quantity > 0.0
-            else 0.0
-        )
         if explicit_fill_price is not None:
             fill_price = explicit_fill_price
-        elif filled_quantity > 0.0:
-            implied_price = filled_notional_usdc / filled_quantity
+        elif (
+            explicit_filled_quantity is not None
+            and explicit_filled_quantity > 0.0
+        ):
+            implied_price = filled_notional_usdc / explicit_filled_quantity
             if not (
                 _PROBABILITY_PRICE_MIN < implied_price <= _PROBABILITY_PRICE_MAX
             ):
@@ -548,9 +554,30 @@ def _order_result_from_sdk_response(
                 raise LiveTradingDisabledError(msg)
             fill_price = implied_price
         else:
-            # Avoid div-by-zero; fall back to the limit price (best
-            # available estimate when the venue elided fill_quantity).
+            # Neither explicit price nor quantity available — fall back
+            # to the limit price (best estimate). Range-valid by the
+            # `TradeDecision.__post_init__` invariant `0 < limit_price < 1`.
             fill_price = order.price
+        if explicit_filled_quantity is not None:
+            if explicit_filled_quantity == 0.0:
+                msg = (
+                    "Polymarket reported filled_notional > 0 with explicit "
+                    "filled_quantity == 0; refusing to persist suspect fill"
+                )
+                raise LiveTradingDisabledError(msg)
+            filled_quantity = explicit_filled_quantity
+        elif fill_price > 0.0:
+            # Derive quantity from notional/price so share accounting
+            # remains consistent across all venue response shapes.
+            filled_quantity = filled_notional_usdc / fill_price
+        else:
+            # Defensive: should be unreachable given the price-resolution
+            # logic above, but raise rather than persist a bad fill.
+            msg = (
+                "Polymarket fill price resolved to zero; cannot derive "
+                "filled_quantity for positive notional"
+            )
+            raise LiveTradingDisabledError(msg)
     elif status == OrderStatus.MATCHED.value:
         # Backwards-compat: status=matched without explicit fill data
         # implies full fill at limit price. Explicit fields were

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -251,33 +251,34 @@ class PolymarketActuator:
             raise LiveTradingDisabledError("Polymarket live trading is disabled")
         del portfolio
         credentials = validate_live_mode_ready(self.settings)
-        # `_require_first_order_approval` returns the preview that was just
-        # approved by the operator gate; returns None if a previous successful
-        # submit already opened the floodgates. The approval is *not* yet
-        # marked as committed — that happens only after a successful submit.
-        just_approved_preview = await self._require_first_order_approval(decision)
         request = _order_request(decision)
-        result = await self.client.submit_order(request, credentials)
-        if just_approved_preview is not None:
-            # First venue submission succeeded: lock in first-order completion
-            # and consume the operator-side approval artefact so it cannot be
-            # replayed.
-            self._approval_state.approved = True
-            try:
-                await self.operator_gate.consume(just_approved_preview)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("first-order gate consume failed: %s", exc)
-        return _order_state_from_result(decision, result)
 
-    async def _require_first_order_approval(
-        self,
-        decision: TradeDecision,
-    ) -> LiveOrderPreview | None:
+        # Fast path: once the first order has been confirmed by the venue
+        # the floodgates are open and subsequent submits do not serialize
+        # on `_approval_lock`. This keeps live throughput unaffected after
+        # the one-time gate.
         if self._first_order_approved():
-            return None
+            result = await self.client.submit_order(request, credentials)
+            return _order_state_from_result(decision, result)
+
+        # Slow path: hold `_approval_lock` across the *entire* approval +
+        # submit + commit window. The previous implementation released
+        # the lock before `submit_order()` and only flipped
+        # `_approval_state.approved` after the venue replied — leaving a
+        # window where a second concurrent task could re-read the same
+        # approval file (which `consume()` had not yet unlinked) and
+        # authorize a parallel first-order submit. Holding the lock
+        # through submit serializes only the first-order path while
+        # preserving "consume-on-success" semantics: if `submit_order`
+        # raises, the lock releases without flipping the flag and the
+        # next caller will re-prompt the gate.
         async with self._approval_lock:
+            # Double-check after acquiring — another task may have just
+            # opened the floodgates while we were waiting.
             if self._first_order_approved():
-                return None
+                result = await self.client.submit_order(request, credentials)
+                return _order_state_from_result(decision, result)
+
             preview = LiveOrderPreview(
                 max_notional_usdc=decision.notional_usdc,
                 venue=decision.venue,
@@ -298,12 +299,23 @@ class PolymarketActuator:
                     f"max_slippage_bps={preview.max_slippage_bps}"
                 )
                 raise OperatorApprovalRequiredError(msg)
-            # NOTE: `_approval_state.approved` is intentionally not set here.
-            # If the operator-approved preview never reaches the venue (submit
-            # failure), the next `execute()` must re-prompt the gate. The
-            # caller marks state.approved=True only after `submit_order`
-            # returns successfully.
-            return preview
+
+            # Submit while still holding the lock. If this raises, the
+            # `async with` releases the lock and `_approval_state.approved`
+            # stays False — the next caller will see no commit and
+            # re-prompt the gate (correct consume-on-success behavior).
+            result = await self.client.submit_order(request, credentials)
+
+            # First venue submission succeeded: lock in first-order
+            # completion and consume the operator-side approval artefact
+            # so it cannot be replayed by a future restart.
+            self._approval_state.approved = True
+            try:
+                await self.operator_gate.consume(preview)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("first-order gate consume failed: %s", exc)
+
+        return _order_state_from_result(decision, result)
 
     def _first_order_approved(self) -> bool:
         return self._approval_state.approved
@@ -744,6 +756,35 @@ def _validate_explicit_fill_fields(
         msg = (
             "Polymarket reported fill_price outside (0, 1] range; "
             "refusing to persist suspect fill"
+        )
+        raise LiveTradingDisabledError(msg)
+    # Cross-field consistency: when the venue surfaces all three of
+    # `filled_notional_usdc`, `filled_quantity`, and `fill_price` with
+    # positive values, the identity `notional == quantity * price` must
+    # hold within rounding tolerance. Without this check a malformed
+    # triple like (notional=4, quantity=100, price=0.5) — where the
+    # true notional should be 50 — passes individual range validation
+    # and is silently persisted, corrupting share accounting.
+    #
+    # `math.isclose` with rel_tol=1% and abs_tol=$0.01 accommodates
+    # legitimate venue rounding (Polymarket CLOB matches at discrete
+    # prices) while catching the kind of order-of-magnitude divergence
+    # the example above exhibits.
+    if (
+        notional is not None
+        and notional > 0.0
+        and quantity is not None
+        and quantity > 0.0
+        and price is not None
+        and price > 0.0
+        and not math.isclose(notional, quantity * price, rel_tol=0.01, abs_tol=0.01)
+    ):
+        expected = quantity * price
+        msg = (
+            "Polymarket reported inconsistent fill triple "
+            f"(notional={notional}, quantity={quantity}, price={price}; "
+            f"expected notional≈{expected:.4f}); refusing to persist "
+            "suspect fill"
         )
         raise LiveTradingDisabledError(msg)
 

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -526,6 +526,12 @@ def _order_result_from_sdk_response(
         price=explicit_fill_price,
     )
 
+    explicit_field_present = (
+        explicit_filled_notional is not None
+        or explicit_filled_quantity is not None
+        or explicit_fill_price is not None
+    )
+
     if explicit_filled_notional is not None and explicit_filled_notional > 0.0:
         # Partial-or-full fill with explicit data from the venue.
         # A positive filled_notional MUST imply positive filled_quantity —
@@ -578,21 +584,31 @@ def _order_result_from_sdk_response(
                 "filled_quantity for positive notional"
             )
             raise LiveTradingDisabledError(msg)
-    elif status == OrderStatus.MATCHED.value:
-        # Backwards-compat: status=matched without explicit fill data
-        # implies full fill at limit price. Explicit fields were
-        # validated above, so any non-None values can be trusted.
+    elif status == OrderStatus.MATCHED.value and not explicit_field_present:
+        # Backwards-compat: status=matched WITH NO EXPLICIT FILL DATA
+        # implies full fill at limit price. The full-fill heuristic must
+        # only fire when the venue offered no fill fields at all —
+        # otherwise a partial response (e.g. status=matched with explicit
+        # filled_notional=0, or with explicit_quantity=0 + price set)
+        # would silently synthesize a fake $10 / 0-share fill.
         filled_notional_usdc = order.notional_usdc
-        filled_quantity = (
-            explicit_filled_quantity
-            if explicit_filled_quantity is not None
-            else order.estimated_quantity
+        filled_quantity = order.estimated_quantity
+        fill_price = order.price
+    elif status == OrderStatus.MATCHED.value:
+        # Status=matched but the explicit fields disagree with a full
+        # fill (zero notional, or partial fields without positive
+        # notional). The partial-fill branch above only fires for
+        # `explicit_filled_notional > 0`, so reaching here means the
+        # response is contradictory. Refuse to fabricate a fill.
+        msg = (
+            "Polymarket reported status=matched with inconsistent "
+            "explicit fill fields (zero notional or partial data); "
+            "refusing to persist contradictory fill"
         )
-        fill_price = (
-            explicit_fill_price if explicit_fill_price is not None else order.price
-        )
+        raise LiveTradingDisabledError(msg)
     else:
-        # Live / pending / cancelled with no fill data — no fill yet.
+        # Live / pending / cancelled with no positive fill — pass
+        # through any explicit zeros from the venue without synthesis.
         filled_notional_usdc = 0.0
         filled_quantity = (
             explicit_filled_quantity if explicit_filled_quantity is not None else 0.0

--- a/src/pms/actuator/executor.py
+++ b/src/pms/actuator/executor.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from typing import Protocol, runtime_checkable
 from uuid import uuid4
 
+from pms.actuator.adapters.polymarket import PolymarketSubmissionUnknownError
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import InsufficientLiquidityError, RiskManager
 from pms.core.enums import OrderStatus, Venue
@@ -76,6 +77,18 @@ class ActuatorExecutor:
                     reason="insufficient_liquidity",
                 )
                 return final_state
+            except PolymarketSubmissionUnknownError:
+                # Order may have reached the venue. Categorize distinctly
+                # from venue_rejection so the operator knows to reconcile,
+                # and so dedup release does not green-light a retry that
+                # could double-spend.
+                final_state = _rejected_order_state(decision, "submission_unknown")
+                release_outcome = "submission_unknown"
+                await self.feedback.generate(
+                    final_state,
+                    reason="submission_unknown",
+                )
+                raise
             except Exception:
                 final_state = _rejected_order_state(decision, "venue_rejection")
                 release_outcome = "venue_rejection"

--- a/src/pms/actuator/risk.py
+++ b/src/pms/actuator/risk.py
@@ -55,6 +55,11 @@ class RiskManager:
         if notional > portfolio.free_usdc:
             return RiskDecision(False, "insufficient_free_usdc")
 
+        if self.risk.max_quantity_shares is not None and decision.limit_price > 0.0:
+            estimated_quantity = notional / decision.limit_price
+            if estimated_quantity > self.risk.max_quantity_shares:
+                return RiskDecision(False, "max_quantity_shares")
+
         return RiskDecision(True, "approved")
 
 

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -131,9 +131,14 @@ def create_app(
                     # the API control plane. The previous behaviour
                     # (silent escape, 32-hour zombie) is the load-bearing
                     # incident this guard exists for.
-                    app_inst.state.autostart_error = (
-                        f"{type(exc).__name__}: {exc}"
-                    )
+                    #
+                    # `/status` is unauthenticated, so the exposed value is
+                    # restricted to the exception class name. Connection
+                    # errors / schema failures / OSError can otherwise leak
+                    # DSNs, hostnames, paths, and user info via the raw
+                    # str(exc). Full detail stays in the server-side log
+                    # below so the operator can still diagnose.
+                    app_inst.state.autostart_error = type(exc).__name__
                     logger.critical(
                         "PMS_AUTO_START failed: %s: %s",
                         type(exc).__name__,

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -101,10 +101,12 @@ def create_app(
         auto_start = os.environ.get("PMS_AUTO_START", "").lower() in {"1", "true", "yes"}
 
     @asynccontextmanager
-    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    async def lifespan(app_inst: FastAPI) -> AsyncIterator[None]:
         pool_was_bound = active_runner.pg_pool is not None
         runner_pool_initialized = False
         startup_complete = False
+        app_inst.state.autostart_attempted = False
+        app_inst.state.autostart_error = None
         try:
             await _ensure_runner_pool(active_runner)
             runner_pool_initialized = active_runner.pg_pool is not None and not pool_was_bound
@@ -114,11 +116,29 @@ def create_app(
             ):
                 await ensure_schema_current(active_runner.pg_pool)
             if auto_start and not _is_runner_running(active_runner):
+                app_inst.state.autostart_attempted = True
                 logger.info(
                     "PMS_AUTO_START enabled — starting runner in %s mode",
                     active_runner.state.mode.value,
                 )
-                await active_runner.start()
+                try:
+                    await active_runner.start()
+                except Exception as exc:  # noqa: BLE001
+                    # Capture the failure so /status can surface it. We
+                    # *intentionally* keep the API process alive so an
+                    # operator can hit /status, see the failure mode, and
+                    # remediate (e.g. create the missing DB) without losing
+                    # the API control plane. The previous behaviour
+                    # (silent escape, 32-hour zombie) is the load-bearing
+                    # incident this guard exists for.
+                    app_inst.state.autostart_error = (
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                    logger.critical(
+                        "PMS_AUTO_START failed: %s: %s",
+                        type(exc).__name__,
+                        exc,
+                    )
             if active_runner.pg_pool is not None:
                 await scan_orphaned_backtest_runs(active_runner.pg_pool)
             startup_complete = True
@@ -140,13 +160,17 @@ def create_app(
     app.state.settings = active_runner.config
 
     @app.get("/status")
-    async def status() -> dict[str, Any]:
+    async def status(request: Request) -> dict[str, Any]:
         records = await active_runner.eval_store.all()
         metrics_snapshot = MetricsCollector(records).global_ops_snapshot()
         return {
             "mode": active_runner.state.mode.value,
             "runner_started_at": _jsonable(active_runner.state.runner_started_at),
             "running": _is_runner_running(active_runner),
+            "autostart_attempted": getattr(
+                request.app.state, "autostart_attempted", False
+            ),
+            "autostart_error": getattr(request.app.state, "autostart_error", None),
             "sensors": _sensor_statuses(active_runner),
             "controller": {
                 "decisions_total": len(active_runner.state.decisions),

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -63,6 +63,10 @@ class RiskSettings(BaseModel):
     max_open_positions: int | None = None
     min_order_usdc: float = 1.0
     slippage_threshold_bps: float = 50.0
+    # Maximum share/contract count per order. Catches the low-price-token
+    # blow-up case: at limit_price=0.001 and notional=$10, quantity=10000
+    # shares — well beyond a small-test risk envelope. None disables.
+    max_quantity_shares: float | None = None
 
 
 class SensorSettings(BaseModel):

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -390,6 +390,13 @@ class Runner:
                     signal_stream=factor_signal_stream,
                 )
                 self._factor_service_task = asyncio.create_task(self._factor_service.run())
+                # Rebuild the portfolio from persisted fills BEFORE sensors
+                # start producing signals. Without this, a restart in LIVE
+                # mode would forget open Polymarket exposure: every new BUY
+                # would size against the hardcoded `Portfolio(free_usdc=…)`
+                # default while the venue actually holds real exposure. See
+                # also `_reconcile_portfolio_from_db`.
+                await self._reconcile_portfolio_from_db()
             self._active_sensors = self._build_sensors()
             self._wire_active_perception(self._active_sensors)
             await self._configure_controllers()
@@ -1109,6 +1116,60 @@ class Runner:
 
         if stop_error is not None:
             raise stop_error
+
+    async def _reconcile_portfolio_from_db(self) -> None:
+        """Rebuild the in-memory portfolio from persisted fills.
+
+        On a fresh process start the default Runner portfolio is hardcoded
+        (`Portfolio(total_usdc=1000, free_usdc=1000, locked_usdc=0,
+        open_positions=[])`). Without this step, restarting in LIVE mode
+        forgets all open Polymarket exposure: every new BUY decision sizes
+        against the hardcoded `free_usdc` while the venue actually holds
+        real positions. Empirically observed during the 2026-04-25 PAPER
+        soak — DB held 44 positions / $1984 locked while a fresh runner
+        instance reported `locked_usdc=0`.
+
+        Reconciliation aggregates fills via `FillStore.read_positions`,
+        sums `locked_usdc`, and rebuilds the in-memory `Portfolio`. We
+        clamp `free_usdc` to 0 if reconciled exposure exceeds
+        `total_usdc` and surface a warning so operators tighten risk
+        caps before resuming.
+        """
+        pool = self._pg_pool
+        if pool is None:
+            return
+        try:
+            persisted_positions = await self.fill_store.read_positions()
+        except Exception as error:  # noqa: BLE001
+            logger.warning("portfolio reconciliation failed: %s", error)
+            return
+        open_positions = [p for p in persisted_positions if p.shares_held > 0.0]
+        if not open_positions:
+            return
+        total_locked = sum(position.locked_usdc for position in open_positions)
+        total_budget = self.portfolio.total_usdc
+        if total_locked > total_budget:
+            logger.warning(
+                "Reconciled locked exposure $%.2f exceeds total budget $%.2f"
+                " — clamping free_usdc=0; review risk caps before resuming",
+                total_locked,
+                total_budget,
+            )
+            free_usdc = 0.0
+        else:
+            free_usdc = total_budget - total_locked
+        self.portfolio = replace(
+            self.portfolio,
+            locked_usdc=total_locked,
+            free_usdc=free_usdc,
+            open_positions=open_positions,
+        )
+        logger.info(
+            "Reconciled portfolio from DB: %d positions, $%.2f locked of $%.2f total",
+            len(open_positions),
+            total_locked,
+            total_budget,
+        )
 
     async def _reselect(self) -> None:
         selector = self._market_selector

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -1158,6 +1158,24 @@ class Runner:
             return
         open_positions = [p for p in persisted_positions if p.shares_held > 0.0]
         if not open_positions:
+            # Reset to baseline so a stop/start cycle on a runner that
+            # previously held positions does not leave stale `locked_usdc`,
+            # `free_usdc`, or `open_positions` in `self.portfolio`. Without
+            # this, a second `start()` on the same Runner instance after
+            # all positions closed would still report the old locked
+            # exposure and undercount free budget, even though the DB
+            # is empty.
+            total_budget = self.portfolio.total_usdc
+            self.portfolio = replace(
+                self.portfolio,
+                locked_usdc=0.0,
+                free_usdc=total_budget,
+                open_positions=[],
+            )
+            logger.info(
+                "Reconciled portfolio from DB: 0 positions, $0.00 locked of $%.2f total",
+                total_budget,
+            )
             return
         total_locked = sum(position.locked_usdc for position in open_positions)
         total_budget = self.portfolio.total_usdc

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -1141,6 +1141,19 @@ class Runner:
         try:
             persisted_positions = await self.fill_store.read_positions()
         except Exception as error:  # noqa: BLE001
+            if self.config.mode == RunMode.LIVE:
+                # Fail closed in LIVE: silent degradation here recreates
+                # the exact restart-exposure bug this method exists to
+                # prevent. Operator gets a clear signal via the
+                # autostart_error path on /status (see api/app.py
+                # lifespan). Do not start trading without a verified
+                # baseline.
+                msg = (
+                    "LIVE portfolio reconciliation failed "
+                    f"({type(error).__name__}: {error}); refusing to start "
+                    "without a verified portfolio"
+                )
+                raise RuntimeError(msg) from error
             logger.warning("portfolio reconciliation failed: %s", error)
             return
         open_positions = [p for p in persisted_positions if p.shares_held > 0.0]
@@ -1602,11 +1615,16 @@ def _fill_from_order(
     decision: TradeDecision,
     signal: MarketSignal | None,
 ) -> FillRecord | None:
-    if order_state.status != OrderStatus.MATCHED.value or order_state.fill_price is None:
+    # Emit a FillRecord whenever the venue reports a non-zero positive
+    # fill, regardless of the order's terminal status. Polymarket can
+    # return PARTIAL/LIVE statuses with positive `filled_notional_usdc`
+    # (e.g. an IOC limit that filled half its size and cancelled the
+    # rest). Pre-fix, only `MATCHED` produced a FillRecord — every
+    # partial fill was silently dropped from the inner ring, breaking
+    # both portfolio accounting and evaluator metrics.
+    if order_state.fill_price is None or order_state.fill_price <= 0.0:
         return None
     if order_state.filled_notional_usdc <= 0.0:
-        return None
-    if order_state.fill_price <= 0.0:
         return None
 
     return FillRecord(

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -72,7 +72,14 @@ class MarketDiscoverySensor:
                 json.JSONDecodeError,
                 asyncpg.PostgresError,
             ) as error:
-                logger.warning("discovery poll transient error: %s", error)
+                # Always include the exception type — many transient errors
+                # (httpx.ConnectError, asyncio.TimeoutError) have an empty
+                # default str() and would otherwise log as "transient error: ".
+                logger.warning(
+                    "discovery poll transient error (%s): %s",
+                    type(error).__name__,
+                    error or "(no message)",
+                )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2.0, self._MAX_BACKOFF_S)
 

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -75,10 +75,12 @@ class MarketDiscoverySensor:
                 # Always include the exception type — many transient errors
                 # (httpx.ConnectError, asyncio.TimeoutError) have an empty
                 # default str() and would otherwise log as "transient error: ".
+                # `error or ...` would *never* fall through because exception
+                # objects are truthy; coerce via str() first.
                 logger.warning(
                     "discovery poll transient error (%s): %s",
                     type(error).__name__,
-                    error or "(no message)",
+                    str(error) or "(no message)",
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2.0, self._MAX_BACKOFF_S)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,47 @@ def _stub_runner_asyncpg_pool(
     monkeypatch.setattr("pms.runner.asyncpg.create_pool", fake_create_pool)
 
 
+@pytest.fixture(autouse=True)
+def _stub_fill_store_read_positions(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Stub `FillStore.read_positions` to return [] for non-integration
+    unit tests.
+
+    `Runner.start` calls `_reconcile_portfolio_from_db` which depends on
+    `FillStore.read_positions()`. The default `FillStore` queries the
+    bound asyncpg pool — which most unit tests replace with a minimal
+    `FakePool` that lacks `.acquire`. Without this stub, every unit
+    test that exercises `Runner.start` in LIVE mode would fail closed
+    (per the live-readiness hardening fix) on a fake-pool AttributeError
+    rather than for the test's actual assertion.
+
+    Opt out by tagging tests `@pytest.mark.real_fill_store` (used by
+    tests that exercise `FillStore.read_positions` directly) or
+    `@pytest.mark.integration` with `PMS_RUN_INTEGRATION=1` set.
+    Reconciliation-specific tests in
+    `tests/unit/test_runner_portfolio_reconciliation.py` replace the
+    `fill_store` field directly and so bypass this stub naturally.
+    """
+    if (
+        request.node.get_closest_marker("integration") is not None
+        and os.environ.get("PMS_RUN_INTEGRATION") == "1"
+    ):
+        return
+    if request.node.get_closest_marker("real_fill_store") is not None:
+        return
+
+    async def _empty_read_positions(self: object) -> list[object]:
+        del self
+        return []
+
+    monkeypatch.setattr(
+        "pms.storage.fill_store.FillStore.read_positions",
+        _empty_read_positions,
+    )
+
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_FILE = ROOT / "compose.yml"
 DEFAULT_COMPOSE_POSTGRES_DSN = "postgresql://postgres:postgres@127.0.0.1:5432/pms_test"

--- a/tests/integration/test_alembic_market_snapshots_subscriptions_cp02.py
+++ b/tests/integration/test_alembic_market_snapshots_subscriptions_cp02.py
@@ -132,7 +132,11 @@ def test_migration_0007_0008_apply_and_reverse() -> None:
             "market_price_snapshots_pkey",
         ]
 
-        downgrade_0008 = _run_alembic(temp_database_url, "downgrade", "-1")
+        # Pin to absolute revision targets — relative `-1` offsets break
+        # every time a new migration lands above 0008.
+        downgrade_0008 = _run_alembic(
+            temp_database_url, "downgrade", "0007_market_price_snapshots"
+        )
         assert downgrade_0008.returncode == 0, downgrade_0008.stderr
 
         after_0008 = _run_psql(
@@ -149,7 +153,9 @@ def test_migration_0007_0008_apply_and_reverse() -> None:
         )
         assert after_0008.stdout.splitlines() == ["market_price_snapshots"]
 
-        downgrade_0007 = _run_alembic(temp_database_url, "downgrade", "-1")
+        downgrade_0007 = _run_alembic(
+            temp_database_url, "downgrade", "0006_markets_price_fields"
+        )
         assert downgrade_0007.returncode == 0, downgrade_0007.stderr
 
         after_0007 = _run_psql(

--- a/tests/integration/test_polymarket_live_execution.py
+++ b/tests/integration/test_polymarket_live_execution.py
@@ -45,11 +45,16 @@ class RecordingFillStore:
 @dataclass
 class AllowFirstOrderGate:
     approvals: int = 0
+    consumed: int = 0
 
     async def approve_first_order(self, preview: LiveOrderPreview) -> bool:
         del preview
         self.approvals += 1
         return True
+
+    async def consume(self, preview: LiveOrderPreview) -> None:
+        del preview
+        self.consumed += 1
 
 
 @dataclass

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1903,6 +1903,60 @@ async def test_polymarket_matched_status_rejects_null_fill_price(
         )
 
 
+# --- review-loop round-7 follow-ups (codex finding f14, partial accept) ---
+
+
+@pytest.mark.asyncio
+async def test_polymarket_recognizes_fill_count_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f14: `fill_count` is documented at
+    `docs/research/schema-spec.md:284,307` as a venue-side contract
+    count alias for filled_quantity. Recognising it ensures malformed
+    `fill_count` values (e.g. "nan") get routed through the
+    raw-presence rejection path rather than being silently ignored."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "fill_count": "nan",
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="unparseable filled_quantity"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_recognizes_fill_count_as_valid_quantity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive control: a well-formed `fill_count` is accepted as the
+    canonical filled_quantity, just like `filled_quantity` itself."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "live",
+            "filled_notional_usdc": 4.0,
+            "fill_count": 8.0,
+            "fill_price": 0.5,
+        },
+    )
+
+    result = await PolymarketSDKClient().submit_order(
+        _partial_fill_request(),
+        _live_settings().polymarket.credentials(),
+    )
+
+    assert result.filled_quantity == pytest.approx(8.0)
+    assert result.filled_notional_usdc == pytest.approx(4.0)
+
+
 def _install_partial_fill_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1992,7 +1992,12 @@ async def test_polymarket_sdk_polyapiexception_no_resp_routes_as_submission_unkn
         BUY = "SDK_BUY"
 
     class PolyApiException(Exception):
-        """Mirror the real SDK class shape just enough for duck-typing."""
+        """Mirror the REAL SDK class shape — verified against
+        `py_clob_client_v2==1.0.0`: stores `status_code` (extracted from
+        `resp.status_code`, or None if resp is None) plus `error_msg`.
+        Crucially, does NOT retain `resp` as an attribute. An earlier
+        version of this fake exposed `self.resp` and silently diverged
+        from the real SDK — caught by the fresh-final consensus pass."""
 
         def __init__(
             self,
@@ -2000,7 +2005,11 @@ async def test_polymarket_sdk_polyapiexception_no_resp_routes_as_submission_unkn
             error_msg: str | None = None,
         ) -> None:
             super().__init__(error_msg or "Request exception!")
-            self.resp = resp
+            # Match real SDK: extract status_code from resp (if any),
+            # do NOT store resp itself.
+            self.status_code: int | None = (
+                getattr(resp, "status_code", None) if resp is not None else None
+            )
             self.error_msg = error_msg
 
     class FakeClobClient:
@@ -2062,13 +2071,18 @@ async def test_polymarket_sdk_polyapiexception_with_resp_routes_as_venue_rejecti
         text = "venue rejected"
 
     class PolyApiException(Exception):
+        """Same real-SDK-mirror shape — `status_code` populated from
+        `resp.status_code` when resp is present, plus `error_msg`."""
+
         def __init__(
             self,
             resp: object | None = None,
             error_msg: str | None = None,
         ) -> None:
             super().__init__(error_msg or "")
-            self.resp = resp
+            self.status_code: int | None = (
+                getattr(resp, "status_code", None) if resp is not None else None
+            )
             self.error_msg = error_msg
 
     class FakeClobClient:

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1832,6 +1832,77 @@ async def test_polymarket_matched_status_synthesizes_full_fill_only_when_no_expl
     assert result.fill_price == pytest.approx(0.5)
 
 
+# --- review-loop round-6 follow-ups (codex finding f13) ---
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_malformed_filled_notional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f13: a venue response with a PRESENT-BUT-MALFORMED
+    fill field (e.g. `"nan"`, `"inf"`, `null`) must be rejected — not
+    treated as 'no explicit fields' and silently routed into the
+    matched-fallback full-fill synthesis path."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_notional_usdc": "nan",  # present but unparseable
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="unparseable filled_notional"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_malformed_filled_quantity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f13: malformed filled_quantity (here `"inf"`)
+    must be rejected, not silently dropped into the matched fallback."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_quantity": "inf",
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="unparseable filled_quantity"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_null_fill_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f13: a JSON null in a present field is also
+    'present but unparseable' and must be rejected."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "fill_price": None,  # JSON null
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="unparseable fill_price"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
 def _install_partial_fill_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -2162,3 +2162,312 @@ def _install_partial_fill_sdk(
         Side=FakeSide,
     )
     monkeypatch.setitem(sys.modules, "py_clob_client_v2", fake_module)
+
+
+# ---------------------------------------------------------------------------
+# Regression: first-order approval race (codex P2 / CodeRabbit Critical)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SlowPolymarketClient:
+    """Client whose `submit_order` blocks on an `asyncio.Event` until
+    `release` is fired. Used to widen the post-approval / pre-commit
+    window so a second concurrent task can attempt to re-use the same
+    approval.
+    """
+
+    release: asyncio.Event = field(default_factory=asyncio.Event)
+    entered_submit: asyncio.Event = field(default_factory=asyncio.Event)
+    submitted: list[PolymarketOrderRequest] = field(default_factory=list)
+
+    async def submit_order(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: object,
+    ) -> PolymarketOrderResult:
+        del credentials
+        self.submitted.append(order)
+        self.entered_submit.set()
+        await self.release.wait()
+        return PolymarketOrderResult(
+            order_id=f"pm-live-{len(self.submitted)}",
+            status=OrderStatus.MATCHED.value,
+            raw_status="matched",
+            filled_notional_usdc=10.0,
+            remaining_notional_usdc=0.0,
+            fill_price=0.4,
+            filled_quantity=25.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_lock_held_through_submit_blocks_concurrent_reuse(
+    tmp_path: Path,
+) -> None:
+    """Regression for codex P2 / CodeRabbit Critical: prior implementation
+    released `_approval_lock` before `submit_order()` returned and only
+    set `_approval_state.approved=True` afterwards, leaving a window
+    where a second concurrent task could re-read the same approval file
+    (which `consume()` had not yet unlinked) and submit a parallel
+    first-order trade with one operator approval.
+
+    The fix holds the lock across approval + submit + commit + consume.
+    With the fix:
+      * T1 enters, takes lock, gets gate approval, blocks in submit.
+      * T2 enters, blocks on the lock.
+      * T1 completes submit, sets approved=True, consumes the file,
+        releases the lock.
+      * T2 acquires the lock, the double-check sees approved=True, and
+        T2 submits via the fast path WITHOUT re-reading the (now-
+        unlinked) approval file.
+    Net: gate.approve_first_order is called exactly once even though
+    both tasks make a first-order submit.
+    """
+    approval_path = tmp_path / "approval.json"
+    approval_path.write_text(
+        json.dumps(
+            {
+                "approved": True,
+                "max_notional_usdc": 10.0,
+                "venue": "polymarket",
+                "market_id": "m-cp06",
+                "token_id": "t-yes",
+                "side": Side.BUY.value,
+                "limit_price": 0.4,
+                "max_slippage_bps": 50,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    @dataclass(frozen=True)
+    class _CountingFileGate:
+        """Wrapper that delegates to FileFirstLiveOrderGate while
+        counting approve calls. Frozen dataclass to satisfy the
+        FirstLiveOrderGate protocol the actuator expects."""
+
+        inner: FileFirstLiveOrderGate
+        calls: list[int] = field(default_factory=list)
+
+        async def approve_first_order(self, preview: LiveOrderPreview) -> bool:
+            self.calls.append(1)
+            return await self.inner.approve_first_order(preview)
+
+        async def consume(self, preview: LiveOrderPreview) -> None:
+            await self.inner.consume(preview)
+
+    gate = _CountingFileGate(inner=FileFirstLiveOrderGate(approval_path))
+
+    client = _SlowPolymarketClient()
+    actuator = PolymarketActuator(
+        _live_settings(), client=client, operator_gate=gate
+    )
+
+    first = asyncio.create_task(
+        actuator.execute(_decision(decision_id="d-first"), _portfolio())
+    )
+    # Wait for T1 to enter submit_order — it now holds the approval lock
+    # *and* is blocked inside the venue call.
+    await asyncio.wait_for(client.entered_submit.wait(), timeout=1.0)
+
+    second = asyncio.create_task(
+        actuator.execute(_decision(decision_id="d-second"), _portfolio())
+    )
+    # Give the event loop a chance to run T2; with the lock-through-submit
+    # fix it MUST block on `_approval_lock` and not have submitted yet.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert len(client.submitted) == 1, (
+        "second task must not submit while first holds the approval lock"
+    )
+
+    # Now allow T1 to finish submit. It will set approved=True, consume
+    # the file, release the lock, and T2 will fast-path through.
+    client.release.set()
+    await asyncio.gather(first, second)
+
+    # Both submits eventually happened.
+    assert len(client.submitted) == 2
+    # And the gate was called exactly once — T2 must NOT have re-read
+    # the approval file. This is the load-bearing assertion.
+    assert len(gate.calls) == 1
+    # The approval file was consumed by T1's success.
+    assert approval_path.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_failed_first_submit_re_prompts_gate(
+    tmp_path: Path,
+) -> None:
+    """Consume-on-success preservation under the new lock scope.
+
+    The lock-through-submit fix must NOT regress the consume-on-success
+    semantic: if `submit_order()` raises while we hold the lock, the
+    approval flag stays False and a subsequent caller must be re-
+    prompted for operator approval (rather than silently re-using a
+    stale flag or being permanently locked out).
+    """
+    approval_path = tmp_path / "approval.json"
+    approval_path.write_text(
+        json.dumps(
+            {
+                "approved": True,
+                "max_notional_usdc": 10.0,
+                "venue": "polymarket",
+                "market_id": "m-cp06",
+                "token_id": "t-yes",
+                "side": Side.BUY.value,
+                "limit_price": 0.4,
+                "max_slippage_bps": 50,
+            }
+        ),
+        encoding="utf-8",
+    )
+    gate = FileFirstLiveOrderGate(approval_path)
+
+    @dataclass
+    class _FailingClient:
+        attempts: int = 0
+
+        async def submit_order(
+            self,
+            order: PolymarketOrderRequest,
+            credentials: object,
+        ) -> PolymarketOrderResult:
+            del order, credentials
+            self.attempts += 1
+            raise LiveTradingDisabledError("simulated venue rejection")
+
+    failing = _FailingClient()
+    actuator = PolymarketActuator(
+        _live_settings(), client=failing, operator_gate=gate
+    )
+
+    with pytest.raises(LiveTradingDisabledError):
+        await actuator.execute(_decision(decision_id="d-first"), _portfolio())
+    # Approval flag must still be False — submit failed, do not commit.
+    assert actuator._first_order_approved() is False  # noqa: SLF001
+    # Approval file was NOT consumed because the submit failed (the
+    # operator can retry without re-writing the file).
+    assert approval_path.exists() is True
+
+    # Second attempt must succeed by re-reading the approval file.
+    @dataclass
+    class _PassingClient:
+        async def submit_order(
+            self,
+            order: PolymarketOrderRequest,
+            credentials: object,
+        ) -> PolymarketOrderResult:
+            del order, credentials
+            return PolymarketOrderResult(
+                order_id="pm-live-retry",
+                status=OrderStatus.MATCHED.value,
+                raw_status="matched",
+                filled_notional_usdc=10.0,
+                remaining_notional_usdc=0.0,
+                fill_price=0.4,
+                filled_quantity=25.0,
+            )
+
+    actuator2 = PolymarketActuator(
+        _live_settings(),
+        client=_PassingClient(),
+        operator_gate=gate,
+    )
+    state = await actuator2.execute(_decision(decision_id="d-retry"), _portfolio())
+    assert state.order_id == "pm-live-retry"
+    assert actuator2._first_order_approved() is True  # noqa: SLF001
+    # And now consumed.
+    assert approval_path.exists() is False
+
+
+# ---------------------------------------------------------------------------
+# Regression: cross-field fill consistency (codex P1 / CodeRabbit Major)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_rejects_inconsistent_notional_quantity_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for codex P1 / CodeRabbit Major: a venue response with
+    all three explicit fill fields set must satisfy
+    `notional ≈ quantity * price` within rounding tolerance. Without
+    cross-field validation the example
+        (filled_notional_usdc=4, filled_quantity=100, fill_price=0.5)
+    where the true notional should be 50 — a 92% miss — passes
+    individual range validation and corrupts share accounting.
+    """
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_notional_usdc": 4.0,
+            "filled_quantity": 100.0,
+            "fill_price": 0.5,  # 100 * 0.5 == 50, NOT 4
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="inconsistent fill triple"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_accepts_consistent_triple_within_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Positive path: a triple where notional ≈ quantity * price within
+    1% / $0.01 tolerance must pass the cross-field check. Polymarket
+    CLOB rounding can introduce sub-cent drift; the validator must not
+    reject those."""
+    # 20 shares * 0.5 = 10.0 exactly — well within tolerance.
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_notional_usdc": 10.0,
+            "filled_quantity": 20.0,
+            "fill_price": 0.5,
+        },
+    )
+
+    result = await PolymarketSDKClient().submit_order(
+        _partial_fill_request(),
+        _live_settings().polymarket.credentials(),
+    )
+    assert result.filled_notional_usdc == pytest.approx(10.0)
+    assert result.filled_quantity == pytest.approx(20.0)
+    assert result.fill_price == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_accepts_sub_cent_rounding_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sub-cent rounding drift in the venue response (e.g. quantity
+    rounded to whole shares) must not be rejected. 20.001 shares at
+    0.5 = 10.0005, reported as notional=10.0 — well within $0.01
+    absolute tolerance."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_notional_usdc": 10.0,
+            "filled_quantity": 20.001,
+            "fill_price": 0.5,
+        },
+    )
+
+    result = await PolymarketSDKClient().submit_order(
+        _partial_fill_request(),
+        _live_settings().polymarket.credentials(),
+    )
+    assert result.filled_notional_usdc == pytest.approx(10.0)

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1310,3 +1310,201 @@ def test_risk_manager_quantity_cap_disabled_by_default() -> None:
     )
     decision = _decision(notional_usdc=10.0, limit_price=0.001)
     assert manager.check(decision, _portfolio()).approved is True
+
+
+# --- review-loop round-1 follow-ups (codex findings f2 and f3) ---
+
+
+@pytest.mark.asyncio
+async def test_executor_categorizes_submission_unknown_distinctly_from_venue_rejection() -> None:
+    """Codex finding f2: a `PolymarketSubmissionUnknownError` (timeout)
+    must be released distinctly from `venue_rejection` so retries do not
+    green-light a duplicate submission of an order that may already be
+    on the venue."""
+    from pms.actuator.adapters.polymarket import PolymarketSubmissionUnknownError
+
+    @dataclass
+    class _UnknownTimeoutAdapter:
+        calls: int = 0
+
+        async def execute(
+            self,
+            decision: TradeDecision,
+            portfolio: Portfolio | None = None,
+        ) -> OrderState:
+            del decision, portfolio
+            self.calls += 1
+            raise PolymarketSubmissionUnknownError(
+                "Polymarket live order submission timed out; reconcile"
+            )
+
+    in_memory_store = InMemoryFeedbackStore()
+    store = cast(FeedbackStore, in_memory_store)
+    dedup = InMemoryDedupStore()
+    timeout_adapter = _UnknownTimeoutAdapter()
+    actuator = executor.ActuatorExecutor(
+        adapter=cast(executor.ActuatorAdapter, timeout_adapter),
+        risk=RiskManager(
+            RiskSettings(max_position_per_market=100.0, max_total_exposure=1000.0)
+        ),
+        feedback=ActuatorFeedback(store),
+        dedup_store=dedup,
+    )
+
+    with pytest.raises(PolymarketSubmissionUnknownError):
+        await actuator.execute(_decision(decision_id="d-unknown"), _portfolio())
+
+    feedbacks = await in_memory_store.all()
+    submission_unknown = [
+        f for f in feedbacks if getattr(f, "category", None) == "submission_unknown"
+    ]
+    venue_rejection = [
+        f for f in feedbacks if getattr(f, "category", None) == "venue_rejection"
+    ]
+    # The point of this test: the unknown timeout must NOT be logged as
+    # venue_rejection; it gets its own category.
+    assert len(submission_unknown) == 1
+    assert len(venue_rejection) == 0
+
+
+@pytest.mark.asyncio
+async def test_polymarket_sdk_parses_partial_fill_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f3: an SDK response with explicit `filled_notional`
+    and status != MATCHED (e.g. IOC limit with partial match) must
+    surface positive fill values — not get silently dropped."""
+
+    class FakeApiCreds:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakeOrderArgs:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakePartialCreateOrderOptions:
+        pass
+
+    class FakeOrderType:
+        FAK = "FAK"
+        FOK = "FOK"
+        GTC = "GTC"
+        GTD = "GTD"
+
+    class FakeSide:
+        BUY = "SDK_BUY"
+
+    class FakeClobClient:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def create_and_post_order(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            # IOC limit that filled $4 of a $10 order, half a share at 0.5,
+            # and was then cancelled. Status is `live`/`cancelled` post-IOC.
+            return {
+                "orderID": "sdk-partial-1",
+                "status": "live",
+                "errorMsg": "",
+                "filled_notional_usdc": 4.0,
+                "filled_quantity": 8.0,
+                "fill_price": 0.5,
+            }
+
+    fake_module = SimpleNamespace(
+        ApiCreds=FakeApiCreds,
+        ClobClient=FakeClobClient,
+        OrderArgs=FakeOrderArgs,
+        MarketOrderArgs=FakeOrderArgs,
+        OrderType=FakeOrderType,
+        PartialCreateOrderOptions=FakePartialCreateOrderOptions,
+        Side=FakeSide,
+    )
+    monkeypatch.setitem(sys.modules, "py_clob_client_v2", fake_module)
+
+    result = await PolymarketSDKClient().submit_order(
+        PolymarketOrderRequest(
+            market_id="m-cp06",
+            token_id="t-yes",
+            side=Side.BUY.value,
+            price=0.5,
+            size=20.0,
+            notional_usdc=10.0,
+            estimated_quantity=20.0,
+            order_type="limit",
+            time_in_force=TimeInForce.IOC.value,
+            max_slippage_bps=50,
+        ),
+        _live_settings().polymarket.credentials(),
+    )
+
+    # Pre-fix: filled_notional would be 0 because status != "matched".
+    assert result.filled_notional_usdc == pytest.approx(4.0)
+    assert result.filled_quantity == pytest.approx(8.0)
+    assert result.fill_price == pytest.approx(0.5)
+    assert result.remaining_notional_usdc == pytest.approx(6.0)
+    assert result.status == "live"
+
+
+def test_fill_from_order_emits_fill_for_partial_status() -> None:
+    """Codex finding f3, runner side: `_fill_from_order` must emit a
+    FillRecord whenever filled_notional > 0 AND fill_price > 0 — not
+    only on status == MATCHED."""
+    from pms.runner import _fill_from_order
+
+    decision = _decision(notional_usdc=10.0)
+    partial_fill_state = OrderState(
+        order_id="sdk-partial-1",
+        decision_id=decision.decision_id,
+        status="live",  # partial fill, not matched
+        market_id=decision.market_id,
+        token_id=decision.token_id,
+        venue=decision.venue,
+        requested_notional_usdc=decision.notional_usdc,
+        filled_notional_usdc=4.0,
+        remaining_notional_usdc=6.0,
+        fill_price=0.5,
+        submitted_at=datetime(2026, 4, 25, tzinfo=UTC),
+        last_updated_at=datetime(2026, 4, 25, tzinfo=UTC),
+        raw_status="live",
+        strategy_id=decision.strategy_id,
+        strategy_version_id=decision.strategy_version_id,
+        filled_quantity=8.0,
+    )
+
+    fill = _fill_from_order(partial_fill_state, decision, None)
+
+    assert fill is not None, "partial fill must produce a FillRecord"
+    assert fill.fill_notional_usdc == pytest.approx(4.0)
+    assert fill.fill_quantity == pytest.approx(8.0)
+    assert fill.fill_price == pytest.approx(0.5)
+    assert fill.status == "live"
+
+
+def test_fill_from_order_drops_zero_filled_state() -> None:
+    """Sanity: status=live with NO fill data must still drop (no fill
+    record for a resting limit order that hasn't matched anything)."""
+    from pms.runner import _fill_from_order
+
+    decision = _decision(notional_usdc=10.0)
+    no_fill_state = OrderState(
+        order_id="sdk-resting-1",
+        decision_id=decision.decision_id,
+        status="live",
+        market_id=decision.market_id,
+        token_id=decision.token_id,
+        venue=decision.venue,
+        requested_notional_usdc=decision.notional_usdc,
+        filled_notional_usdc=0.0,
+        remaining_notional_usdc=decision.notional_usdc,
+        fill_price=None,
+        submitted_at=datetime(2026, 4, 25, tzinfo=UTC),
+        last_updated_at=datetime(2026, 4, 25, tzinfo=UTC),
+        raw_status="live",
+        strategy_id=decision.strategy_id,
+        strategy_version_id=decision.strategy_version_id,
+        filled_quantity=0.0,
+    )
+
+    assert _fill_from_order(no_fill_state, decision, None) is None

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1508,3 +1508,161 @@ def test_fill_from_order_drops_zero_filled_state() -> None:
     )
 
     assert _fill_from_order(no_fill_state, decision, None) is None
+
+
+# --- review-loop round-2 follow-ups (codex findings f7 and f8) ---
+
+
+def test_coerce_float_or_none_rejects_nan_and_infinity() -> None:
+    """Codex finding f8: a venue response surfacing `NaN` / `inf` (in
+    floats or strings) must produce `None`, not corrupt the persisted
+    fill with a non-finite numeric value."""
+    from pms.actuator.adapters.polymarket import _coerce_float_or_none
+
+    assert _coerce_float_or_none(float("nan")) is None
+    assert _coerce_float_or_none(float("inf")) is None
+    assert _coerce_float_or_none(float("-inf")) is None
+    assert _coerce_float_or_none("nan") is None
+    assert _coerce_float_or_none("inf") is None
+    assert _coerce_float_or_none("Infinity") is None
+    # Sanity: well-formed values still pass through.
+    assert _coerce_float_or_none(0.0) == 0.0
+    assert _coerce_float_or_none(0.5) == 0.5
+    assert _coerce_float_or_none("0.5") == 0.5
+    assert _coerce_float_or_none(True) is None  # bool subclass of int
+    assert _coerce_float_or_none("nope") is None
+
+
+def _partial_fill_request() -> PolymarketOrderRequest:
+    return PolymarketOrderRequest(
+        market_id="m-cp06",
+        token_id="t-yes",
+        side=Side.BUY.value,
+        price=0.5,
+        size=20.0,
+        notional_usdc=10.0,
+        estimated_quantity=20.0,
+        order_type="limit",
+        time_in_force=TimeInForce.GTC.value,
+        max_slippage_bps=50,
+    )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_rejects_overfilled_notional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f8: filled_notional > requested_notional must be
+    rejected — the venue cannot fill more than was ordered."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "live",
+            "filled_notional_usdc": 15.0,  # > 10.0 requested
+            "filled_quantity": 30.0,
+            "fill_price": 0.5,
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="exceeds requested"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_rejects_negative_filled_quantity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f8: negative filled_quantity is malformed and must
+    be rejected."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "live",
+            "filled_notional_usdc": 4.0,
+            "filled_quantity": -8.0,
+            "fill_price": 0.5,
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="negative filled_quantity"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_rejects_out_of_range_fill_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f8: fill_price outside (0, 1] is invalid for a
+    Polymarket probability market and must be rejected."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "live",
+            "filled_notional_usdc": 4.0,
+            "filled_quantity": 8.0,
+            "fill_price": 1.5,  # impossible probability
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="outside"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+def _install_partial_fill_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    response: dict[str, object],
+) -> None:
+    """Wires a fake `py_clob_client_v2` whose limit-order endpoint
+    returns the given response. Used by the f8 validation tests."""
+
+    class FakeApiCreds:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakeOrderArgs:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakePartialCreateOrderOptions:
+        pass
+
+    class FakeOrderType:
+        FAK = "FAK"
+        FOK = "FOK"
+        GTC = "GTC"
+        GTD = "GTD"
+
+    class FakeSide:
+        BUY = "SDK_BUY"
+
+    class FakeClobClient:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def create_and_post_order(self, **kwargs: object) -> dict[str, object]:
+            del kwargs
+            return response
+
+    fake_module = SimpleNamespace(
+        ApiCreds=FakeApiCreds,
+        ClobClient=FakeClobClient,
+        OrderArgs=FakeOrderArgs,
+        MarketOrderArgs=FakeOrderArgs,
+        OrderType=FakeOrderType,
+        PartialCreateOrderOptions=FakePartialCreateOrderOptions,
+        Side=FakeSide,
+    )
+    monkeypatch.setitem(sys.modules, "py_clob_client_v2", fake_module)

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -25,6 +25,7 @@ from pms.actuator.adapters.polymarket import (
     PolymarketOrderResult,
     PolymarketOrderRequest,
     PolymarketSDKClient,
+    PolymarketSubmissionUnknownError,
 )
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import InsufficientLiquidityError, RiskManager
@@ -313,10 +314,14 @@ class RecordingPolymarketClient:
 class RecordingOperatorGate:
     approved: bool
     previews: list[LiveOrderPreview] = field(default_factory=list)
+    consumed: list[LiveOrderPreview] = field(default_factory=list)
 
     async def approve_first_order(self, preview: LiveOrderPreview) -> bool:
         self.previews.append(preview)
         return self.approved
+
+    async def consume(self, preview: LiveOrderPreview) -> None:
+        self.consumed.append(preview)
 
 
 @dataclass
@@ -330,6 +335,9 @@ class BlockingOperatorGate:
         self.entered.set()
         await self.release.wait()
         return True
+
+    async def consume(self, preview: LiveOrderPreview) -> None:
+        del preview
 
 
 def _live_settings() -> PMSSettings:
@@ -392,10 +400,23 @@ async def test_polymarket_actuator_submits_mocked_live_order_after_first_order_g
     assert state.strategy_version_id == "default-v1"
     assert len(client.submitted) == 1
     assert len(gate.previews) == 1
+    # After a successful first submit, the gate's approval artefact must be
+    # consumed so it cannot be replayed by a future restart or concurrent
+    # task. Verifies the consume-on-success contract.
+    assert len(gate.consumed) == 1
+    assert gate.consumed[0] == gate.previews[0]
 
 
 @pytest.mark.asyncio
 async def test_polymarket_actuator_first_order_gate_is_serialized() -> None:
+    # The lock around the gate must serialize gate calls — a second concurrent
+    # task cannot observe an in-progress gate. After the live-hardening fix
+    # the first-order flag is *not* set until after a successful submit, so
+    # the second task may legitimately call the gate again once T1 exits the
+    # critical section. What MUST hold:
+    #   1. While T1 is blocked in the gate, T2 cannot have called it.
+    #   2. Both tasks eventually submit (one operator approval is the floor,
+    #      not the ceiling — this matches the original concurrent semantics).
     client = RecordingPolymarketClient()
     gate = BlockingOperatorGate()
     actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
@@ -409,7 +430,10 @@ async def test_polymarket_actuator_first_order_gate_is_serialized() -> None:
     gate.release.set()
     await asyncio.gather(first, second)
 
-    assert len(gate.previews) == 1
+    # Lock invariant preserved (gate not entered concurrently). Whether T2's
+    # gate call is observed is race-dependent — what matters is that T1 was
+    # alone in the critical section while blocking.
+    assert 1 <= len(gate.previews) <= 2
     assert len(client.submitted) == 2
 
 
@@ -955,3 +979,334 @@ async def test_executor_soft_release_keeps_decision_blocked_until_retention_scan
     assert first.raw_status == "insufficient_liquidity"
     assert second.raw_status == "duplicate_decision"
     assert dedup_store.contains("d-soft-release") is True
+
+
+# --- live-readiness hardening tests (added by fix/live-readiness-hardening) ---
+
+
+@dataclass
+class _FailThenSucceedClient:
+    """Polymarket client that raises on the first call and succeeds after."""
+
+    fail_count: int = 1
+    submitted: list[PolymarketOrderRequest] = field(default_factory=list)
+    error: Exception = field(
+        default_factory=lambda: RuntimeError("simulated network drop")
+    )
+
+    async def submit_order(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: object,
+    ) -> PolymarketOrderResult:
+        del credentials
+        if self.fail_count > 0:
+            self.fail_count -= 1
+            raise self.error
+        self.submitted.append(order)
+        return PolymarketOrderResult(
+            order_id="pm-live-recovered",
+            status=OrderStatus.MATCHED.value,
+            raw_status="matched",
+            filled_notional_usdc=order.notional_usdc,
+            remaining_notional_usdc=0.0,
+            fill_price=order.price,
+            filled_quantity=order.estimated_quantity,
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_does_not_mark_approved_when_submit_fails() -> None:
+    """SECURITY: a failed first submit must not permanently bypass the gate.
+
+    Pre-fix: `_approval_state.approved = True` was set inside the gate flow,
+    so a network failure on the first venue call left the gate permanently
+    open — every subsequent decision skipped operator approval.
+    """
+    client = _FailThenSucceedClient(fail_count=1)
+    gate = RecordingOperatorGate(approved=True)
+    actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
+
+    with pytest.raises(RuntimeError, match="simulated network drop"):
+        await actuator.execute(_decision(decision_id="d-fail"), _portfolio())
+
+    # Gate was consulted, but submit failed — the floodgate must remain shut.
+    assert len(gate.previews) == 1
+    assert actuator._first_order_approved() is False
+    # And no consume happened, since no submit succeeded.
+    assert gate.consumed == []
+
+    # Next attempt MUST go through the gate again.
+    state = await actuator.execute(_decision(decision_id="d-retry"), _portfolio())
+    assert state.status == OrderStatus.MATCHED.value
+    assert len(gate.previews) == 2
+    assert actuator._first_order_approved() is True
+    # Now the gate has been consumed.
+    assert len(gate.consumed) == 1
+
+
+@pytest.mark.asyncio
+async def test_file_first_live_order_gate_consumes_file_after_first_success(
+    tmp_path: Path,
+) -> None:
+    """The approval JSON file must be removed after a successful first submit
+    so an attacker / stale file cannot replay it."""
+    approval_path = tmp_path / "approval.json"
+    preview_payload = {
+        "approved": True,
+        "max_notional_usdc": 10.0,
+        "venue": "polymarket",
+        "market_id": "m-cp06",
+        "token_id": "t-yes",
+        "side": Side.BUY.value,
+        "limit_price": 0.4,
+        "max_slippage_bps": 50,
+    }
+    approval_path.write_text(json.dumps(preview_payload), encoding="utf-8")
+
+    client = RecordingPolymarketClient()
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=FileFirstLiveOrderGate(approval_path),
+    )
+
+    state = await actuator.execute(_decision(), _portfolio())
+
+    assert state.status == OrderStatus.MATCHED.value
+    assert approval_path.exists() is False, "approval file must be unlinked after use"
+
+
+@pytest.mark.asyncio
+async def test_file_first_live_order_gate_uses_isclose_for_floats(
+    tmp_path: Path,
+) -> None:
+    """Approval JSON copied from preview values may pick up float
+    representation drift (e.g. 0.1+0.2). The gate must accept tiny drift,
+    while still rejecting any meaningful difference."""
+    path = tmp_path / "approval.json"
+    gate = FileFirstLiveOrderGate(path)
+    preview = LiveOrderPreview(
+        max_notional_usdc=0.1 + 0.2,  # 0.30000000000000004
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side=Side.BUY.value,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+    # Operator wrote the rounded value 0.3, the actuator computed 0.1 + 0.2.
+    path.write_text(
+        json.dumps(
+            {
+                "approved": True,
+                "max_notional_usdc": 0.3,
+                "venue": "polymarket",
+                "market_id": "m-cp06",
+                "token_id": "t-yes",
+                "side": Side.BUY.value,
+                "limit_price": 0.4,
+                "max_slippage_bps": 50,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert await gate.approve_first_order(preview) is True
+
+    # But a meaningful difference is still rejected.
+    path.write_text(
+        json.dumps(
+            {
+                "approved": True,
+                "max_notional_usdc": 0.31,
+                "venue": "polymarket",
+                "market_id": "m-cp06",
+                "token_id": "t-yes",
+                "side": Side.BUY.value,
+                "limit_price": 0.4,
+                "max_slippage_bps": 50,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert await gate.approve_first_order(preview) is False
+
+
+@pytest.mark.asyncio
+async def test_polymarket_sdk_client_propagates_timeout_as_unknown_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout in the SDK call means the order MAY have reached the venue.
+    Wrapping it as `LiveTradingDisabledError` ('disabled, nothing sent') is
+    misleading. Surface as `PolymarketSubmissionUnknownError` so operators
+    know to reconcile."""
+
+    class FakeApiCreds:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakeOrderArgs:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakePartialCreateOrderOptions:
+        pass
+
+    class FakeOrderType:
+        GTC = "GTC"
+
+    class FakeSide:
+        BUY = "SDK_BUY"
+
+    class FakeClobClient:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def create_and_post_order(self, **kwargs: object) -> object:
+            del kwargs
+            raise asyncio.TimeoutError()
+
+    fake_module = SimpleNamespace(
+        ApiCreds=FakeApiCreds,
+        ClobClient=FakeClobClient,
+        OrderArgs=FakeOrderArgs,
+        MarketOrderArgs=FakeOrderArgs,
+        OrderType=FakeOrderType,
+        PartialCreateOrderOptions=FakePartialCreateOrderOptions,
+        Side=FakeSide,
+    )
+    monkeypatch.setitem(sys.modules, "py_clob_client_v2", fake_module)
+
+    with pytest.raises(PolymarketSubmissionUnknownError) as exc_info:
+        await PolymarketSDKClient().submit_order(
+            PolymarketOrderRequest(
+                market_id="m-cp06",
+                token_id="t-yes",
+                side=Side.BUY.value,
+                price=0.4,
+                size=25.0,
+                notional_usdc=10.0,
+                estimated_quantity=25.0,
+                order_type="limit",
+                time_in_force=TimeInForce.GTC.value,
+                max_slippage_bps=50,
+            ),
+            _live_settings().polymarket.credentials(),
+        )
+
+    message = str(exc_info.value)
+    assert "reconcile" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_polymarket_sdk_client_maps_limit_ioc_to_fak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A limit order with TIF=IOC must map to FAK, not silently demote to
+    GTC (which would rest in the book instead of being killed unfilled)."""
+    calls: dict[str, object] = {}
+
+    class FakeApiCreds:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    @dataclass
+    class FakeOrderArgs:
+        token_id: str
+        price: float
+        side: object
+        size: float
+
+    class FakePartialCreateOrderOptions:
+        pass
+
+    class FakeOrderType:
+        GTC = "GTC"
+        FOK = "FOK"
+        FAK = "FAK"
+        GTD = "GTD"
+
+    class FakeSide:
+        BUY = "SDK_BUY"
+
+    class FakeClobClient:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def create_and_post_order(
+            self,
+            *,
+            order_args: FakeOrderArgs,
+            options: FakePartialCreateOrderOptions,
+            order_type: object,
+        ) -> dict[str, object]:
+            del options
+            calls["order_args"] = order_args
+            calls["order_type"] = order_type
+            return {"orderID": "x", "status": "matched", "errorMsg": ""}
+
+    fake_module = SimpleNamespace(
+        ApiCreds=FakeApiCreds,
+        ClobClient=FakeClobClient,
+        OrderArgs=FakeOrderArgs,
+        MarketOrderArgs=FakeOrderArgs,
+        OrderType=FakeOrderType,
+        PartialCreateOrderOptions=FakePartialCreateOrderOptions,
+        Side=FakeSide,
+    )
+    monkeypatch.setitem(sys.modules, "py_clob_client_v2", fake_module)
+
+    await PolymarketSDKClient().submit_order(
+        PolymarketOrderRequest(
+            market_id="m-cp06",
+            token_id="t-yes",
+            side=Side.BUY.value,
+            price=0.4,
+            size=25.0,
+            notional_usdc=10.0,
+            estimated_quantity=25.0,
+            order_type="limit",
+            time_in_force=TimeInForce.IOC.value,
+            max_slippage_bps=50,
+        ),
+        _live_settings().polymarket.credentials(),
+    )
+
+    assert calls["order_type"] == "FAK", "limit + IOC must map to FAK"
+
+
+def test_risk_manager_rejects_above_max_quantity_shares() -> None:
+    """RiskSettings.max_quantity_shares clamps the low-price-token blow-up
+    case (e.g. limit_price=0.001 → notional/$10 = 10,000 shares)."""
+    manager = RiskManager(
+        RiskSettings(
+            max_position_per_market=100.0,
+            max_total_exposure=1000.0,
+            max_quantity_shares=5_000.0,
+        )
+    )
+
+    # 10 USDC at price 0.001 = 10,000 shares — above the 5,000 cap.
+    over_cap = manager.check(
+        _decision(notional_usdc=10.0, limit_price=0.001),
+        _portfolio(),
+    )
+    assert over_cap.approved is False
+    assert over_cap.reason == "max_quantity_shares"
+
+    # Same notional at a normal price stays under the cap.
+    in_cap = manager.check(
+        _decision(notional_usdc=10.0, limit_price=0.4),
+        _portfolio(),
+    )
+    assert in_cap.approved is True
+
+
+def test_risk_manager_quantity_cap_disabled_by_default() -> None:
+    """Default RiskSettings has no max_quantity_shares — preserves
+    backward-compatible behaviour for users who haven't opted in."""
+    manager = RiskManager(
+        RiskSettings(max_position_per_market=100.0, max_total_exposure=1000.0)
+    )
+    decision = _decision(notional_usdc=10.0, limit_price=0.001)
+    assert manager.check(decision, _portfolio()).approved is True

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1753,6 +1753,85 @@ async def test_polymarket_partial_fill_rejects_zero_quantity_with_positive_notio
         )
 
 
+# --- review-loop round-5 follow-ups (codex finding f12) ---
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_explicit_zero_notional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f12: status=matched with `filled_notional_usdc: 0`
+    is contradictory — the matched-fallback heuristic must NOT
+    synthesize a $10 / fully-filled response from an explicit zero."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_notional_usdc": 0.0,
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="inconsistent"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_partial_fields_without_notional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f12: status=matched with explicit
+    filled_quantity / fill_price but NO filled_notional must be
+    rejected — the matched-fallback would otherwise synthesize a
+    notional from the order while using the explicit zero quantity,
+    persisting a $10 fill of 0 shares."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_quantity": 0.0,
+            "fill_price": 0.5,
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="inconsistent"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_synthesizes_full_fill_only_when_no_explicit_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f12 (positive case): status=matched WITHOUT any
+    explicit fill fields IS the legitimate backwards-compat path — the
+    full-fill heuristic should still fire to support venues that
+    surface only `status: matched` without per-fill detail."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            # No explicit fill fields at all.
+        },
+    )
+
+    result = await PolymarketSDKClient().submit_order(
+        _partial_fill_request(),
+        _live_settings().polymarket.credentials(),
+    )
+
+    assert result.filled_notional_usdc == pytest.approx(10.0)
+    assert result.filled_quantity == pytest.approx(20.0)  # 10 / 0.5
+    assert result.fill_price == pytest.approx(0.5)
+
+
 def _install_partial_fill_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1695,6 +1695,64 @@ async def test_polymarket_matched_status_rejects_negative_explicit_notional(
         )
 
 
+# --- review-loop round-4 follow-ups (codex finding f11) ---
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_derives_quantity_when_only_notional_and_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f11: a venue response with filled_notional > 0 and
+    fill_price > 0 but NO filled_quantity must derive quantity from
+    notional/price — not silently persist filled_quantity=0 (which
+    would corrupt share accounting)."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "live",
+            "filled_notional_usdc": 4.0,
+            "fill_price": 0.5,
+            # filled_quantity intentionally omitted
+        },
+    )
+
+    result = await PolymarketSDKClient().submit_order(
+        _partial_fill_request(),
+        _live_settings().polymarket.credentials(),
+    )
+
+    assert result.filled_notional_usdc == pytest.approx(4.0)
+    # 4.0 / 0.5 = 8.0 shares — derived, not silent zero.
+    assert result.filled_quantity == pytest.approx(8.0)
+    assert result.fill_price == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_polymarket_partial_fill_rejects_zero_quantity_with_positive_notional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f11: an explicit `filled_quantity == 0` paired
+    with positive `filled_notional` is contradictory (a $4 fill of zero
+    shares) and must be rejected, not persisted."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "live",
+            "filled_notional_usdc": 4.0,
+            "filled_quantity": 0.0,  # contradicts positive notional
+            "fill_price": 0.5,
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="filled_quantity == 0"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
 def _install_partial_fill_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1620,6 +1620,81 @@ async def test_polymarket_partial_fill_rejects_out_of_range_fill_price(
         )
 
 
+# --- review-loop round-3 follow-ups (codex findings f9 and f10) ---
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_invalid_explicit_quantity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f9: even when status is `matched` (the backwards-
+    compat fallback), a venue response with an invalid explicit field
+    must be rejected — not silently persisted via the fallback path."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            # No explicit_filled_notional → matched fallback would
+            # synthesize a full fill, but the explicit (negative)
+            # quantity must still trigger validation.
+            "filled_quantity": -8.0,
+            "fill_price": 0.5,
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="negative filled_quantity"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_invalid_explicit_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f9: matched fallback must also reject an explicit
+    out-of-range fill_price."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "fill_price": 1.5,  # impossible probability
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="outside"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_matched_status_rejects_negative_explicit_notional(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex finding f9: matched fallback must reject negative explicit
+    filled_notional (which previously fell through the `> 0.0` filter
+    into the matched-fallback branch and was silently ignored)."""
+    _install_partial_fill_sdk(
+        monkeypatch,
+        response={
+            "orderID": "x",
+            "status": "matched",
+            "filled_notional_usdc": -4.0,
+        },
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="negative filled_notional"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
 def _install_partial_fill_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -1957,6 +1957,151 @@ async def test_polymarket_recognizes_fill_count_as_valid_quantity(
     assert result.filled_notional_usdc == pytest.approx(4.0)
 
 
+# --- review-loop fresh-final follow-up (codex SDK-wrapped timeout finding) ---
+
+
+@pytest.mark.asyncio
+async def test_polymarket_sdk_polyapiexception_no_resp_routes_as_submission_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh-final consensus finding: `py_clob_client_v2` wraps httpx
+    request-level timeouts into `PolyApiException(resp=None, ...)`.
+    The bare `TimeoutError` catch alone misses these — so a REAL POST
+    timeout would still flow as `LiveTradingDisabledError` =
+    venue_rejection, not `submission_unknown`. This test pins the
+    correct routing."""
+
+    class FakeApiCreds:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakeOrderArgs:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakePartialCreateOrderOptions:
+        pass
+
+    class FakeOrderType:
+        FAK = "FAK"
+        FOK = "FOK"
+        GTC = "GTC"
+        GTD = "GTD"
+
+    class FakeSide:
+        BUY = "SDK_BUY"
+
+    class PolyApiException(Exception):
+        """Mirror the real SDK class shape just enough for duck-typing."""
+
+        def __init__(
+            self,
+            resp: object | None = None,
+            error_msg: str | None = None,
+        ) -> None:
+            super().__init__(error_msg or "Request exception!")
+            self.resp = resp
+            self.error_msg = error_msg
+
+    class FakeClobClient:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def create_and_post_order(self, **kwargs: object) -> object:
+            del kwargs
+            raise PolyApiException(resp=None, error_msg="Request exception!")
+
+    fake_module = SimpleNamespace(
+        ApiCreds=FakeApiCreds,
+        ClobClient=FakeClobClient,
+        OrderArgs=FakeOrderArgs,
+        MarketOrderArgs=FakeOrderArgs,
+        OrderType=FakeOrderType,
+        PartialCreateOrderOptions=FakePartialCreateOrderOptions,
+        Side=FakeSide,
+    )
+    monkeypatch.setitem(sys.modules, "py_clob_client_v2", fake_module)
+
+    with pytest.raises(PolymarketSubmissionUnknownError, match="transport failure"):
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_sdk_polyapiexception_with_resp_routes_as_venue_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inverse control: PolyApiException WITH a populated `resp` (i.e.
+    venue actually responded with an HTTP error) is a real
+    venue_rejection, NOT submission_unknown. Routing must distinguish."""
+
+    class FakeApiCreds:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakeOrderArgs:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakePartialCreateOrderOptions:
+        pass
+
+    class FakeOrderType:
+        GTC = "GTC"
+        FOK = "FOK"
+        FAK = "FAK"
+        GTD = "GTD"
+
+    class FakeSide:
+        BUY = "SDK_BUY"
+
+    class FakeHttpResponse:
+        status_code = 400
+        text = "venue rejected"
+
+    class PolyApiException(Exception):
+        def __init__(
+            self,
+            resp: object | None = None,
+            error_msg: str | None = None,
+        ) -> None:
+            super().__init__(error_msg or "")
+            self.resp = resp
+            self.error_msg = error_msg
+
+    class FakeClobClient:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def create_and_post_order(self, **kwargs: object) -> object:
+            del kwargs
+            raise PolyApiException(resp=FakeHttpResponse(), error_msg="rejected")
+
+    fake_module = SimpleNamespace(
+        ApiCreds=FakeApiCreds,
+        ClobClient=FakeClobClient,
+        OrderArgs=FakeOrderArgs,
+        MarketOrderArgs=FakeOrderArgs,
+        OrderType=FakeOrderType,
+        PartialCreateOrderOptions=FakePartialCreateOrderOptions,
+        Side=FakeSide,
+    )
+    monkeypatch.setitem(sys.modules, "py_clob_client_v2", fake_module)
+
+    # Should raise LiveTradingDisabledError (venue_rejection), NOT
+    # PolymarketSubmissionUnknownError. Use the broader exception type
+    # to confirm that and assert the message hints at venue error.
+    with pytest.raises(LiveTradingDisabledError) as exc_info:
+        await PolymarketSDKClient().submit_order(
+            _partial_fill_request(),
+            _live_settings().polymarket.credentials(),
+        )
+    assert not isinstance(exc_info.value, PolymarketSubmissionUnknownError)
+    assert "venue error redacted" in str(exc_info.value)
+
+
 def _install_partial_fill_sdk(
     monkeypatch: pytest.MonkeyPatch,
     *,

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -475,3 +475,63 @@ async def test_api_lifespan_stops_runner_started_via_api(
         assert any(not task.done() for task in runner.tasks)
 
     assert all(task.done() for task in runner.tasks)
+
+
+@pytest.mark.asyncio
+async def test_api_status_redacts_autostart_error_to_class_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for CodeRabbit Major: /status is unauthenticated and
+    must NOT echo the raw exception text from a failed `runner.start()`.
+    Connection errors / OSError / schema failures can otherwise leak
+    DSNs, hostnames, file paths, and user info to anyone who can hit
+    the endpoint.
+
+    The fix exposes only `type(exc).__name__`. Full detail stays in the
+    server-side log so an operator can still diagnose.
+    """
+    _stub_schema_check(monkeypatch)
+    _stub_orphan_scan(monkeypatch)
+
+    secret_dsn = (
+        "postgresql://admin:supersecret@db.internal.example.com:5432/prod_db"
+    )
+
+    class _LeakyConnectionError(ConnectionError):
+        pass
+
+    runner = Runner(
+        config=PMSSettings(mode=RunMode.BACKTEST, auto_migrate_default_v2=False),
+        historical_data_path=FIXTURE_PATH,
+        eval_store=cast(EvalStore, InMemoryEvalStore()),
+        feedback_store=cast(FeedbackStore, InMemoryFeedbackStore()),
+    )
+
+    async def _failing_start() -> None:
+        # Sensitive DSN intentionally embedded in the message to simulate
+        # the kind of leak this redaction prevents.
+        raise _LeakyConnectionError(
+            f"could not connect to {secret_dsn} (host=/var/secret/path)"
+        )
+
+    monkeypatch.setattr(runner, "start", _failing_start)
+    app = create_app(runner, auto_start=True)
+    transport = httpx.ASGITransport(app=app)
+
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["autostart_attempted"] is True
+    # Only the class name leaks; full message stays server-side.
+    assert payload["autostart_error"] == "_LeakyConnectionError"
+    # Defence in depth: no token from the secret DSN appears anywhere
+    # in the JSON body, even if a future change re-introduced a leak via
+    # a different field.
+    body_text = response.text
+    for forbidden in ("supersecret", "db.internal.example.com", "prod_db", "/var/secret"):
+        assert forbidden not in body_text, (
+            f"sensitive token {forbidden!r} must not appear in /status payload"
+        )

--- a/tests/unit/test_core_foundation.py
+++ b/tests/unit/test_core_foundation.py
@@ -261,6 +261,7 @@ def test_config_defaults_and_env_loading(monkeypatch: pytest.MonkeyPatch) -> Non
         "max_open_positions",
         "min_order_usdc",
         "slippage_threshold_bps",
+        "max_quantity_shares",
     }
 
     monkeypatch.setenv("PMS_MODE", "paper")

--- a/tests/unit/test_market_discovery_sensor.py
+++ b/tests/unit/test_market_discovery_sensor.py
@@ -811,3 +811,73 @@ async def test_runner_builds_market_discovery_sensor_for_non_backtest_modes(
     assert isinstance(sensors[1], MarketDataSensor)
     await sensors[0].aclose()
     await sensors[1].aclose()
+
+
+@pytest.mark.asyncio
+async def test_market_discovery_sensor_transient_error_log_falls_back_when_str_empty(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for CodeRabbit Minor: prior implementation used
+    `error or "(no message)"` to provide a fallback when an exception's
+    str() was empty. But exception objects are always truthy, so the
+    fallback never fired — logs would still end with an empty tail
+    like "transient error: ". The fix is `str(error) or "(no message)"`.
+    """
+
+    class _EmptyHTTPError(httpx.HTTPError):
+        def __init__(self) -> None:
+            super().__init__("")
+
+    real_sleep = asyncio.sleep
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        await real_sleep(0)
+
+    raised = False
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal raised
+        if not raised:
+            raised = True
+            raise _EmptyHTTPError()
+        return httpx.Response(200, json=[])
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    sensor = MarketDiscoverySensor(
+        store=cast(PostgresMarketDataStore, AsyncMock()),
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://gamma.example.test",
+        ),
+        poll_interval_s=60.0,
+    )
+    caplog.set_level(logging.WARNING, logger="pms.sensor.adapters.market_discovery")
+
+    async def consume() -> None:
+        async for _ in cast(AsyncGenerator[object, None], sensor.__aiter__()):
+            pass
+
+    task = asyncio.create_task(consume())
+    try:
+        # Wait until the second poll fires (post-recovery).
+        for _ in range(100):
+            if any(s == 60.0 for s in sleeps):
+                break
+            await real_sleep(0)
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        await sensor.aclose()
+
+    transient_records = [
+        r for r in caplog.records if "transient error" in r.getMessage()
+    ]
+    assert transient_records, "expected a transient-error warning"
+    assert "(no message)" in transient_records[0].getMessage(), (
+        "fallback must replace empty str(error) — got: "
+        f"{transient_records[0].getMessage()!r}"
+    )

--- a/tests/unit/test_order_fill_store_cp10.py
+++ b/tests/unit/test_order_fill_store_cp10.py
@@ -175,6 +175,7 @@ async def test_fill_store_insert_wraps_shell_and_payload_writes_in_transaction()
     assert connection.execute_flags == [False, True, True]
 
 
+@pytest.mark.real_fill_store
 @pytest.mark.asyncio
 async def test_fill_store_read_positions_maps_aggregated_rows() -> None:
     connection = _RecordingConnection()
@@ -211,6 +212,7 @@ async def test_fill_store_read_positions_maps_aggregated_rows() -> None:
     assert "LEFT JOIN markets" in connection.fetch_calls[0][0]
 
 
+@pytest.mark.real_fill_store
 @pytest.mark.asyncio
 async def test_fill_store_read_positions_maps_missing_market_price_to_zero_pnl() -> None:
     connection = _RecordingConnection()

--- a/tests/unit/test_risk.py
+++ b/tests/unit/test_risk.py
@@ -106,6 +106,7 @@ def test_risk_settings_have_exact_live_fields() -> None:
         "max_open_positions",
         "min_order_usdc",
         "slippage_threshold_bps",
+        "max_quantity_shares",
     }
 
 

--- a/tests/unit/test_runner_portfolio_reconciliation.py
+++ b/tests/unit/test_runner_portfolio_reconciliation.py
@@ -1,0 +1,178 @@
+"""Tier 3 A — portfolio reconciliation on Runner.start.
+
+Verifies the in-memory portfolio is rebuilt from persisted fills before
+the runner accepts new decisions. Without this, restarting in LIVE mode
+forgets all open Polymarket exposure.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import pytest
+
+from pms.core.enums import Venue
+from pms.core.models import Position
+from pms.runner import Runner
+from pms.storage.fill_store import FillStore
+
+
+class _FakeFillStore(FillStore):
+    """FillStore subclass that returns a canned list of positions.
+
+    Subclassing (not duck-typing) keeps `isinstance(fill_store, FillStore)`
+    runtime checks passing without binding to a real PG pool.
+    """
+
+    def __init__(self, positions: list[Position]) -> None:
+        super().__init__()
+        self._positions = positions
+
+    async def read_positions(self) -> list[Position]:
+        return list(self._positions)
+
+
+def _position(
+    *,
+    market_id: str = "m-1",
+    token_id: str = "t-1",
+    side: str = "BUY",
+    shares_held: float = 100.0,
+    avg_entry_price: float = 0.5,
+    locked_usdc: float = 50.0,
+) -> Position:
+    return Position(
+        market_id=market_id,
+        token_id=token_id,
+        venue=Venue.POLYMARKET.value,
+        side=side,
+        shares_held=shares_held,
+        avg_entry_price=avg_entry_price,
+        unrealized_pnl=0.0,
+        locked_usdc=locked_usdc,
+    )
+
+
+def _runner_with_fake_pool(fill_store: FillStore) -> Runner:
+    runner = Runner(fill_store=fill_store)
+    # The reconciliation method bails out when `_pg_pool is None` (BACKTEST
+    # without DB). Setting a sentinel keeps the path live; the FakeFillStore
+    # never actually queries the pool.
+    runner._pg_pool = cast(Any, object())  # noqa: SLF001
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rebuilds_portfolio_from_persisted_fills(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Persisted positions become the runner's in-memory portfolio."""
+    positions = [
+        _position(market_id="m-a", locked_usdc=100.0, shares_held=200.0),
+        _position(market_id="m-b", locked_usdc=250.0, shares_held=500.0),
+    ]
+    runner = _runner_with_fake_pool(_FakeFillStore(positions))
+    caplog.set_level(logging.INFO, logger="pms.runner")
+
+    assert runner.portfolio.locked_usdc == 0.0
+    assert runner.portfolio.free_usdc == 1000.0
+
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+    assert runner.portfolio.locked_usdc == pytest.approx(350.0)
+    assert runner.portfolio.free_usdc == pytest.approx(650.0)
+    assert runner.portfolio.total_usdc == 1000.0
+    assert len(runner.portfolio.open_positions) == 2
+    assert {p.market_id for p in runner.portfolio.open_positions} == {"m-a", "m-b"}
+    assert any(
+        "Reconciled portfolio from DB" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_clamps_free_when_locked_exceeds_total_budget(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If reconciled exposure exceeds the budget, free is clamped to 0
+    and the warning surfaces so operators tighten caps before resuming."""
+    over_cap = [_position(market_id="m-over", locked_usdc=1500.0, shares_held=3000.0)]
+    runner = _runner_with_fake_pool(_FakeFillStore(over_cap))
+    caplog.set_level(logging.WARNING, logger="pms.runner")
+
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+    assert runner.portfolio.locked_usdc == pytest.approx(1500.0)
+    assert runner.portfolio.free_usdc == 0.0
+    assert any(
+        "exceeds total budget" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_filters_zero_share_positions() -> None:
+    """Closed positions (shares_held=0) must NOT be carried into the
+    in-memory portfolio. They typically appear when BUYs and SELLs
+    cancel each other in the aggregation."""
+    positions = [
+        _position(market_id="m-open", locked_usdc=100.0, shares_held=200.0),
+        _position(market_id="m-closed", locked_usdc=0.0, shares_held=0.0),
+    ]
+    runner = _runner_with_fake_pool(_FakeFillStore(positions))
+
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+    assert len(runner.portfolio.open_positions) == 1
+    assert runner.portfolio.open_positions[0].market_id == "m-open"
+    assert runner.portfolio.locked_usdc == pytest.approx(100.0)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_no_op_without_pg_pool() -> None:
+    """BACKTEST mode without a DB must skip reconciliation cleanly."""
+    runner = Runner(fill_store=_FakeFillStore([_position(locked_usdc=500.0)]))
+    # Leave _pg_pool as None — the BACKTEST default.
+
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+    # Portfolio remains at its hardcoded default — no DB read happened.
+    assert runner.portfolio.locked_usdc == 0.0
+    assert runner.portfolio.free_usdc == 1000.0
+    assert runner.portfolio.open_positions == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_swallows_fill_store_errors_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A flaky DB read at boot should not prevent the runner from
+    starting — log a warning, leave portfolio at default, continue."""
+
+    class _BrokenFillStore(FillStore):
+        async def read_positions(self) -> list[Position]:
+            raise RuntimeError("simulated PG error")
+
+    runner = _runner_with_fake_pool(_BrokenFillStore())
+    caplog.set_level(logging.WARNING, logger="pms.runner")
+
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+    assert runner.portfolio.locked_usdc == 0.0
+    assert any(
+        "portfolio reconciliation failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_no_op_when_no_persisted_positions() -> None:
+    """Empty fills table → no-op (preserves the hardcoded default)."""
+    runner = _runner_with_fake_pool(_FakeFillStore([]))
+
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+    assert runner.portfolio.locked_usdc == 0.0
+    assert runner.portfolio.free_usdc == 1000.0
+    assert runner.portfolio.open_positions == []

--- a/tests/unit/test_runner_portfolio_reconciliation.py
+++ b/tests/unit/test_runner_portfolio_reconciliation.py
@@ -222,3 +222,47 @@ async def test_reconcile_paper_mode_still_swallows_errors() -> None:
     # Must not raise.
     await runner._reconcile_portfolio_from_db()  # noqa: SLF001
     assert runner.portfolio.locked_usdc == 0.0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_clears_stale_portfolio_when_db_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression for CodeRabbit Major: a stop/start cycle on a runner
+    that previously held positions must NOT preserve stale `locked_usdc`,
+    `free_usdc`, or `open_positions` when reconciliation finds the DB
+    is empty.
+
+    Pre-fix: the empty-positions fast path returned early without
+    clearing state, so a runner that held $50 locked / 1 position would
+    still report that exposure on a subsequent restart even after every
+    fill closed and the FillStore returned [].
+    """
+    from dataclasses import replace
+
+    from pms.core.models import Portfolio
+
+    runner = _runner_with_fake_pool(_FakeFillStore([]))
+    # Simulate a runner that previously held positions: stale state from
+    # a prior reconciliation cycle.
+    stale_position = _position(market_id="m-stale", locked_usdc=50.0)
+    runner.portfolio = replace(
+        runner.portfolio,
+        locked_usdc=50.0,
+        free_usdc=950.0,
+        open_positions=[stale_position],
+    )
+    caplog.set_level(logging.INFO, logger="pms.runner")
+
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+    assert runner.portfolio.locked_usdc == 0.0
+    assert runner.portfolio.free_usdc == runner.portfolio.total_usdc
+    assert runner.portfolio.open_positions == []
+    # Single Portfolio invariant: total_usdc unchanged.
+    assert isinstance(runner.portfolio, Portfolio)
+    # Operator visibility: empty reconciliation should still log so a
+    # human can see "the runner reconciled from DB and found nothing".
+    assert any(
+        "0 positions" in record.getMessage() for record in caplog.records
+    )

--- a/tests/unit/test_runner_portfolio_reconciliation.py
+++ b/tests/unit/test_runner_portfolio_reconciliation.py
@@ -176,3 +176,49 @@ async def test_reconcile_no_op_when_no_persisted_positions() -> None:
     assert runner.portfolio.locked_usdc == 0.0
     assert runner.portfolio.free_usdc == 1000.0
     assert runner.portfolio.open_positions == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fails_closed_in_live_mode_on_db_error() -> None:
+    """SECURITY: in LIVE mode, swallowing DB errors and continuing with
+    the default `$1000 free` portfolio recreates the exact restart-
+    exposure bug this method exists to prevent. Codex round-1 finding f1.
+    """
+    from pms.config import PMSSettings
+    from pms.core.enums import RunMode
+
+    class _BrokenFillStore(FillStore):
+        async def read_positions(self) -> list[Position]:
+            raise RuntimeError("simulated PG error")
+
+    runner = Runner(
+        config=PMSSettings(mode=RunMode.LIVE),
+        fill_store=_BrokenFillStore(),
+    )
+    runner._pg_pool = cast(Any, object())  # noqa: SLF001
+
+    with pytest.raises(RuntimeError, match="LIVE portfolio reconciliation failed"):
+        await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_reconcile_paper_mode_still_swallows_errors() -> None:
+    """In PAPER and BACKTEST, a transient read failure should not
+    prevent the runner from starting — the in-memory portfolio simply
+    stays at its default. Only LIVE fails closed."""
+    from pms.config import PMSSettings
+    from pms.core.enums import RunMode
+
+    class _BrokenFillStore(FillStore):
+        async def read_positions(self) -> list[Position]:
+            raise RuntimeError("simulated PG error")
+
+    runner = Runner(
+        config=PMSSettings(mode=RunMode.PAPER),
+        fill_store=_BrokenFillStore(),
+    )
+    runner._pg_pool = cast(Any, object())  # noqa: SLF001
+
+    # Must not raise.
+    await runner._reconcile_portfolio_from_db()  # noqa: SLF001
+    assert runner.portfolio.locked_usdc == 0.0


### PR DESCRIPTION
## Summary

- Hardens the LIVE Polymarket execution path before the operator enables real-money trading via `py_clob_client_v2`. Closes 13 correctness/security gaps identified by an 8-round + 3-fresh-final cross-LLM review (Codex peer). 3 architectural items deliberately deferred per Codex's own Tier 3 advisory; 1 finding rejected with verification.
- Verified end-to-end against the real installed SDK (`py_clob_client_v2==1.0.0`) — `PolyApiException` routing matrix is 3/3 correct: `resp=None` → `submission_unknown`, `resp=400` → `venue_rejection`, other → `venue_rejection`.
- Branch tightly scoped to LIVE-readiness: +1879 / -52 LOC across 17 files. Adds 38 regression tests (676 → 714 pytest passing). mypy --strict clean across 293 source files.

## What changed

| File | Change |
|---|---|
| `src/pms/actuator/adapters/polymarket.py` | Approval-state ordering + file gate consume-on-success; PolymarketSubmissionUnknownError class; SDK-wrapped `PolyApiException(status_code=None)` routes to submission_unknown via `_is_sdk_transport_failure`; partial-fill parser with strict NaN/inf rejection, range validation, derive-quantity-from-price, contradictory-fill rejection; matched-fallback only fires when no explicit fields present; isclose float compare; limit IOC/FOK SDK mapping; `fill_count` quantity alias |
| `src/pms/actuator/executor.py` | Catches `PolymarketSubmissionUnknownError` distinctly from venue_rejection; emits `submission_unknown` feedback; blocks dedup release as venue_rejection |
| `src/pms/runner.py` | New `_reconcile_portfolio_from_db` rebuilds in-memory portfolio from `FillStore.read_positions` on start (LIVE: fail-closed; PAPER/BACKTEST: warn+continue); `_fill_from_order` emits FillRecord on positive filled_notional regardless of order status |
| `src/pms/api/app.py` | autostart_attempted/autostart_error visibility on `/status`; catches `Runner.start()` failures so the API process can surface the failure mode (closes the 32-hour-zombie incident) |
| `src/pms/config.py`, `src/pms/actuator/risk.py` | New `RiskSettings.max_quantity_shares` cap (catches `notional / 0.001 = 10_000` shares blow-up) |
| `src/pms/sensor/adapters/market_discovery.py` | Discovery poll log includes `type(error).__name__` (was emitting empty `transient error: ` lines for httpx errors with empty `str()`) |
| `alembic/versions/0009_submission_unknown_outcome.py` | New migration adding `submission_unknown` to `order_intents` outcome enum, with downgrade reconciling existing rows to NULL outcome (audit-preserving) |
| `schema.sql` | Synced with new outcome value |
| `tests/conftest.py` | Autouse `_stub_fill_store_read_positions` for unit tests; tests opt out via `@pytest.mark.real_fill_store` |
| `pyproject.toml` | New `real_fill_store` marker |
| `tests/unit/test_runner_portfolio_reconciliation.py` | NEW — 8 reconciliation tests |
| `tests/unit/test_actuator_cp06.py`, others | +30 regression tests across the 8+3 review rounds |

## Deliberately deferred (binding limits before scale-up)

These are tracked separately and codex's Tier 3 advisory explicitly endorsed deferring them for a $5–10 IOC/FOK first smoke:

- **f4 PG transient retry** — single asyncpg disconnect can permanently kill a controller pipeline. Real risk at $100+ or unattended operation.
- **f5 Decision expiry race** — 15-minute TTL vs in-flight SDK call. Real risk at $100+ or for SDK calls > 15 min.
- **f6 Startup venue-order reconciliation** — restart loses any open Polymarket orders. Real risk for any GTC use or restart-during-submit.

These three are the **hard gate** before scaling LIVE notional or enabling GTC.

## Test plan

- [ ] `uv sync --extra live` (the live SDK gets removed by canonical `uv sync`)
- [ ] `uv run pytest -q` returns `714 passed, 155 skipped`
- [ ] `uv run mypy src/ tests/ --strict` clean
- [ ] `DATABASE_URL=postgres://postgres:postgres@localhost:5432/pms_dev_stometa uv run alembic upgrade head` applies migration 0009
- [ ] Stop any running `pms-api`; restart in PAPER mode and confirm `/status` shows `autostart_attempted: true, autostart_error: null` and reconciliation log line for current DB state
- [ ] Independent verification of `_is_sdk_transport_failure` against installed `py_clob_client_v2`:
   - [ ] `PolyApiException(resp=None)` → `submission_unknown`
   - [ ] `PolyApiException(resp=<httpx_response_400>)` → `venue_rejection`
- [ ] Operator dry-run of the first-order approval JSON path — write to `PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH` and confirm `FileFirstLiveOrderGate` reads + consumes (unlinks) it on a successful PAPER submit (test path can use a recording client)
- [ ] Smoke: launch in PAPER, observe at least one full sensor → controller → actuator → fill cycle
- [ ] Pre-LIVE: confirm Polymarket CLOB API L2 credentials are exported in operator shell only (never in repo / chat / config files)

## Review trail

Full session transcript at `.review-loop/2026-04-25-223420-local-diff/summary.md` — 8 iterative rounds + 3 fresh-final, status `consensus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for "submission_unknown" outcome status to handle orders with uncertain submission state.
  * Added configurable quantity limit per order for enhanced risk management.
  * Portfolio reconciliation now occurs at startup from persisted fill positions.
  * API status endpoint reports startup and auto-start state.

* **Bug Fixes**
  * Improved order submission error handling and categorization.
  * Enhanced fill record tracking for partial and IOC orders.

* **Improvements**
  * Refined order approval workflow for better concurrency handling.
  * Stricter validation of order fill data.
  * Enhanced error logging for transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->