### PR TITLE
fix(live): harden preflight startup and factor writes

### DIFF
--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -62,7 +62,7 @@ from pms.api.routes.strategies import list_strategies as list_strategies_items
 from pms.api.routes.trades import list_trades as list_trades_items
 from pms.config import MissingPolymarketCredentialsError, PMSSettings, validate_live_mode_ready
 from pms.core.enums import RunMode
-from pms.core.models import EvalRecord, MarketSignal, TradeDecision
+from pms.core.models import EvalRecord, LiveTradingDisabledError, MarketSignal, TradeDecision
 from pms.evaluation.metrics import MetricsCollector, MetricsSnapshot
 from pms.metrics import metrics_snapshot
 from pms.runner import Runner
@@ -601,7 +601,10 @@ def create_app(
     async def run_start() -> dict[str, Any]:
         if _is_runner_running(active_runner):
             raise HTTPException(status_code=409, detail=RUNNER_ALREADY_RUNNING_DETAIL)
-        await active_runner.start()
+        try:
+            await active_runner.start()
+        except LiveTradingDisabledError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {
             "status": "started",
             "mode": active_runner.state.mode.value,

--- a/src/pms/factors/service.py
+++ b/src/pms/factors/service.py
@@ -11,6 +11,7 @@ import asyncpg
 
 from pms.core.models import Market, MarketSignal
 from pms.factors.base import FactorDefinition, FactorValueRow
+from pms.factors.catalog import ensure_factor_catalog
 from pms.research.cache import FactorPanel, load_factor_panel
 from pms.storage.market_data_store import PostgresMarketDataStore
 
@@ -97,10 +98,26 @@ class FactorService:
                 dedupe_key = (row.factor_id, row.market_id, row.param)
                 if self._last_persisted_ts.get(dedupe_key) == row.ts:
                     continue
-                await persist_factor_value(self.pool, row)
+                await self._persist_factor_value(row, signal)
                 self._last_persisted_ts[dedupe_key] = row.ts
                 persisted += 1
         return persisted
+
+    async def _persist_factor_value(
+        self,
+        row: FactorValueRow,
+        signal: MarketSignal,
+    ) -> None:
+        try:
+            await persist_factor_value(self.pool, row)
+        except asyncpg.ForeignKeyViolationError as exc:
+            if _is_constraint_violation(exc, "factor_values_factor_id_fkey"):
+                await ensure_factor_catalog(self.pool, factor_ids=(row.factor_id,))
+            elif _is_constraint_violation(exc, "factor_values_market_id_fkey"):
+                await self._ensure_market_shell(signal)
+            else:
+                raise
+            await persist_factor_value(self.pool, row)
 
     async def get_panel(
         self,
@@ -163,3 +180,11 @@ class FactorService:
                 last_seen_at=signal.timestamp,
             )
         )
+
+
+def _is_constraint_violation(
+    exc: asyncpg.ForeignKeyViolationError,
+    constraint_name: str,
+) -> bool:
+    actual_constraint = getattr(exc, "constraint_name", None)
+    return actual_constraint == constraint_name or constraint_name in str(exc)

--- a/tests/integration/test_factor_service_lifecycle.py
+++ b/tests/integration/test_factor_service_lifecycle.py
@@ -14,6 +14,7 @@ from pms.config import DatabaseSettings, PMSSettings
 from pms.core.enums import MarketStatus, RunMode
 from pms.core.models import Market, MarketSignal, Token
 from pms.factors.base import FactorDefinition, FactorValueRow
+from pms.factors.service import FactorService
 from pms.runner import Runner
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
@@ -74,6 +75,24 @@ class AlwaysFactor(FactorDefinition):
             ts=signal.timestamp,
             value=0.25,
         )
+
+
+class DeleteMarketAfterReadStore(PostgresMarketDataStore):
+    def __init__(self, pool: asyncpg.Pool, *, market_id: str) -> None:
+        super().__init__(pool)
+        self._market_id = market_id
+        self._deleted = False
+
+    async def read_market(self, market_id: str) -> Market | None:
+        market = await super().read_market(market_id)
+        if market is not None and market_id == self._market_id and not self._deleted:
+            async with self.pool.acquire() as connection:
+                await connection.execute(
+                    "DELETE FROM markets WHERE condition_id = $1",
+                    market_id,
+                )
+            self._deleted = True
+        return market
 
 
 def _settings(*, factor_cadence_s: float = 0.05) -> PMSSettings:
@@ -140,6 +159,76 @@ async def _assert_pool_still_works(pg_pool: asyncpg.Pool) -> None:
     async with pg_pool.acquire() as connection:
         value = await connection.fetchval("SELECT 1")
     assert value == 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_factor_service_reseeds_source_factor_after_catalog_truncation(
+    pg_pool: asyncpg.Pool,
+) -> None:
+    async with pg_pool.acquire() as connection:
+        await connection.execute("DELETE FROM factor_values")
+        await connection.execute(
+            "DELETE FROM factors WHERE factor_id = 'orderbook_imbalance'"
+        )
+
+    service = FactorService(
+        pool=pg_pool,
+        store=PostgresMarketDataStore(pg_pool),
+        cadence_s=0.05,
+        factors=(AlwaysFactor,),
+        signal_stream=RepeatingSensor(_signal()),
+    )
+
+    persisted = await service.compute_once([_signal()])
+
+    async with pg_pool.acquire() as connection:
+        factor_exists = await connection.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM factors WHERE factor_id = 'orderbook_imbalance')"
+        )
+        factor_values = await connection.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM factor_values
+            WHERE factor_id = 'orderbook_imbalance'
+            """
+        )
+
+    assert persisted == 1
+    assert factor_exists is True
+    assert factor_values == 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_factor_service_recreates_market_shell_after_runtime_delete(
+    pg_pool: asyncpg.Pool,
+) -> None:
+    await _seed_boot_prereqs(pg_pool)
+    service = FactorService(
+        pool=pg_pool,
+        store=DeleteMarketAfterReadStore(pg_pool, market_id="factor-lifecycle"),
+        cadence_s=0.05,
+        factors=(AlwaysFactor,),
+        signal_stream=RepeatingSensor(_signal()),
+    )
+
+    persisted = await service.compute_once([_signal()])
+
+    async with pg_pool.acquire() as connection:
+        market_exists = await connection.fetchval(
+            "SELECT EXISTS(SELECT 1 FROM markets WHERE condition_id = 'factor-lifecycle')"
+        )
+        factor_values = await connection.fetchval(
+            """
+            SELECT COUNT(*)
+            FROM factor_values
+            WHERE factor_id = 'orderbook_imbalance'
+              AND market_id = 'factor-lifecycle'
+            """
+        )
+
+    assert persisted == 1
+    assert market_exists is True
+    assert factor_values == 1
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -260,6 +260,27 @@ async def test_api_config_rejects_live_mode_when_credentials_are_missing() -> No
 
 
 @pytest.mark.asyncio
+async def test_api_run_start_rejects_live_mode_when_credentials_are_missing() -> None:
+    runner = Runner(
+        config=PMSSettings(
+            mode=RunMode.LIVE,
+            live_trading_enabled=True,
+            auto_migrate_default_v2=False,
+        ),
+        eval_store=cast(EvalStore, InMemoryEvalStore()),
+        feedback_store=cast(FeedbackStore, InMemoryFeedbackStore()),
+    )
+    app = create_app(runner, auto_start=False)
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/run/start")
+
+    assert response.status_code == 400
+    assert response.json()["detail"].startswith("Missing Polymarket credential fields:")
+
+
+@pytest.mark.asyncio
 async def test_api_run_start_stop_cycle(tmp_path: Path) -> None:
     runner = Runner(
         config=PMSSettings(


### PR DESCRIPTION
## Summary
- return controlled 400 responses when LIVE `/run/start` is missing live-readiness credentials
- retry FactorService writes after reseeding source-owned factor catalog rows or recreating market shells
- add regressions for live preflight startup and factor write FK recovery

## Verification
- `uv run pytest -q`
- `PMS_RUN_INTEGRATION=1 PMS_TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/pms_test uv run pytest -q -m integration`
- `uv run mypy src/ tests/ --strict`
- `uv run lint-imports`
- `uv run python -c "import py_clob_client_v2; print('SDK OK')"`
- `cd dashboard && npm run lint`
- `cd dashboard && npm test -- --run`
- `cd dashboard && npm run build`
- LIVE control-plane smoke on `pms_live_smoke_stometa`: `/status` 200, `/run/start` without credentials 400, DB decisions/orders/fills/feedback all 0

## Live Note
Use `pms_live_smoke_stometa` for the first LIVE smoke. `pms_dev_stometa` still contains PAPER soak fills.