### PR TITLE
[codex] Fix live trading blockers

### DIFF
--- a/alembic/versions/0010_order_intent_key.py
+++ b/alembic/versions/0010_order_intent_key.py
@@ -1,0 +1,27 @@
+"""Add deterministic economic intent keys to order_intents."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0010_order_intent_key"
+down_revision = "0009_submission_unknown_outcome"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE order_intents ADD COLUMN IF NOT EXISTS intent_key TEXT")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_order_intents_intent_key_unique
+            ON order_intents (intent_key)
+            WHERE intent_key IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_order_intents_intent_key_unique")
+    op.execute("ALTER TABLE order_intents DROP COLUMN IF EXISTS intent_key")

--- a/schema.sql
+++ b/schema.sql
@@ -288,6 +288,7 @@ CREATE TABLE IF NOT EXISTS orders (
 
 CREATE TABLE IF NOT EXISTS order_intents (
     decision_id TEXT PRIMARY KEY,
+    intent_key TEXT,
     strategy_id TEXT NOT NULL CHECK (strategy_id != ''),
     strategy_version_id TEXT NOT NULL CHECK (strategy_version_id != ''),
     acquired_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -304,6 +305,10 @@ CREATE INDEX IF NOT EXISTS idx_order_intents_strategy_acquired_at_desc
 
 CREATE INDEX IF NOT EXISTS idx_order_intents_released_at_nulls_first
     ON order_intents(released_at NULLS FIRST);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_order_intents_intent_key_unique
+    ON order_intents(intent_key)
+    WHERE intent_key IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS fills (
     fill_id TEXT PRIMARY KEY,

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -35,6 +35,17 @@ class PolymarketSubmissionUnknownError(RuntimeError):
     have reached the venue. Operators must reconcile before retrying.
     """
 
+    order_state: OrderState | None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        order_state: OrderState | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.order_state = order_state
+
 
 @dataclass(frozen=True)
 class LiveOrderPreview:
@@ -72,12 +83,46 @@ class PolymarketOrderResult:
     filled_quantity: float
 
 
+@dataclass(frozen=True)
+class LivePreSubmitQuote:
+    market_status: str
+    book_age_ms: float
+    executable_notional_usdc: float
+    best_executable_price: float
+    spread_bps: float
+    quote_hash: str
+    book_ts: datetime
+
+
 class PolymarketClient(Protocol):
     async def submit_order(
         self,
         order: PolymarketOrderRequest,
         credentials: VenueCredentials,
     ) -> PolymarketOrderResult: ...
+
+
+class LiveQuoteProvider(Protocol):
+    async def quote(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+    ) -> LivePreSubmitQuote: ...
+
+
+@dataclass(frozen=True)
+class MissingLiveQuoteProvider:
+    async def quote(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+    ) -> LivePreSubmitQuote:
+        del order, credentials
+        msg = (
+            "Polymarket pre-submit quote guard is not configured; "
+            "LIVE submit requires a fresh venue book check"
+        )
+        raise LiveTradingDisabledError(msg)
 
 
 class FirstLiveOrderGate(Protocol):
@@ -229,6 +274,7 @@ class PolymarketActuator:
     settings: PMSSettings = field(default_factory=PMSSettings)
     client: PolymarketClient = field(default_factory=MissingPolymarketClient)
     operator_gate: FirstLiveOrderGate = field(default_factory=DenyFirstLiveOrderGate)
+    quote_provider: LiveQuoteProvider = field(default_factory=MissingLiveQuoteProvider)
     _approval_state: FirstLiveOrderApprovalState = field(
         default_factory=FirstLiveOrderApprovalState,
         init=False,
@@ -258,8 +304,10 @@ class PolymarketActuator:
         # on `_approval_lock`. This keeps live throughput unaffected after
         # the one-time gate.
         if self._first_order_approved():
+            quote = await self.quote_provider.quote(request, credentials)
+            _validate_pre_submit_quote(request, quote, self.settings)
             result = await self.client.submit_order(request, credentials)
-            return _order_state_from_result(decision, result)
+            return _order_state_from_result(decision, result, quote=quote)
 
         # Slow path: hold `_approval_lock` across the *entire* approval +
         # submit + commit window. The previous implementation released
@@ -304,6 +352,8 @@ class PolymarketActuator:
             # `async with` releases the lock and `_approval_state.approved`
             # stays False — the next caller will see no commit and
             # re-prompt the gate (correct consume-on-success behavior).
+            quote = await self.quote_provider.quote(request, credentials)
+            _validate_pre_submit_quote(request, quote, self.settings)
             result = await self.client.submit_order(request, credentials)
 
             # First venue submission succeeded: lock in first-order
@@ -315,7 +365,7 @@ class PolymarketActuator:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("first-order gate consume failed: %s", exc)
 
-        return _order_state_from_result(decision, result)
+        return _order_state_from_result(decision, result, quote=quote)
 
     def _first_order_approved(self) -> bool:
         return self._approval_state.approved
@@ -329,7 +379,7 @@ def _order_request(decision: TradeDecision) -> PolymarketOrderRequest:
     return PolymarketOrderRequest(
         market_id=decision.market_id,
         token_id=decision.token_id,
-        side=decision.side,
+        side=decision.action if decision.action is not None else decision.side,
         price=decision.limit_price,
         size=_sdk_order_size(decision, estimated_quantity=estimated_quantity),
         notional_usdc=decision.notional_usdc,
@@ -343,6 +393,8 @@ def _order_request(decision: TradeDecision) -> PolymarketOrderRequest:
 def _order_state_from_result(
     decision: TradeDecision,
     result: PolymarketOrderResult,
+    *,
+    quote: LivePreSubmitQuote | None = None,
 ) -> OrderState:
     now = datetime.now(tz=UTC)
     status = result.status or OrderStatus.LIVE.value
@@ -363,7 +415,60 @@ def _order_state_from_result(
         strategy_id=decision.strategy_id,
         strategy_version_id=decision.strategy_version_id,
         filled_quantity=result.filled_quantity,
+        pre_submit_quote={} if quote is None else _quote_payload(quote),
     )
+
+
+def _validate_pre_submit_quote(
+    request: PolymarketOrderRequest,
+    quote: LivePreSubmitQuote,
+    settings: PMSSettings,
+) -> None:
+    if quote.market_status.lower() != "open":
+        msg = f"Polymarket market is not open at submit: {quote.market_status}"
+        raise LiveTradingDisabledError(msg)
+    if quote.book_age_ms > settings.controller.max_book_age_ms:
+        msg = (
+            "Polymarket book is stale at submit: "
+            f"{quote.book_age_ms:.0f}ms > {settings.controller.max_book_age_ms:.0f}ms"
+        )
+        raise LiveTradingDisabledError(msg)
+    if quote.executable_notional_usdc + 1e-9 < request.notional_usdc:
+        msg = (
+            "Polymarket executable depth is below requested notional at submit: "
+            f"{quote.executable_notional_usdc:.2f} < {request.notional_usdc:.2f}"
+        )
+        raise LiveTradingDisabledError(msg)
+    if request.side == "BUY" and quote.best_executable_price > request.price:
+        msg = (
+            "Polymarket best executable price exceeds limit at submit: "
+            f"{quote.best_executable_price:.4f} > {request.price:.4f}"
+        )
+        raise LiveTradingDisabledError(msg)
+    if request.side == "SELL" and quote.best_executable_price < request.price:
+        msg = (
+            "Polymarket best executable price is below limit at submit: "
+            f"{quote.best_executable_price:.4f} < {request.price:.4f}"
+        )
+        raise LiveTradingDisabledError(msg)
+    if quote.spread_bps > settings.controller.max_spread_bps:
+        msg = (
+            "Polymarket spread exceeds pre-submit guard: "
+            f"{quote.spread_bps:.1f}bps > {settings.controller.max_spread_bps:.1f}bps"
+        )
+        raise LiveTradingDisabledError(msg)
+
+
+def _quote_payload(quote: LivePreSubmitQuote) -> dict[str, object]:
+    return {
+        "market_status": quote.market_status,
+        "book_age_ms": quote.book_age_ms,
+        "executable_notional_usdc": quote.executable_notional_usdc,
+        "best_executable_price": quote.best_executable_price,
+        "spread_bps": quote.spread_bps,
+        "quote_hash": quote.quote_hash,
+        "book_ts": quote.book_ts.isoformat(),
+    }
 
 
 def _decision_quantity(decision: TradeDecision) -> float:

--- a/src/pms/actuator/executor.py
+++ b/src/pms/actuator/executor.py
@@ -77,12 +77,13 @@ class ActuatorExecutor:
                     reason="insufficient_liquidity",
                 )
                 return final_state
-            except PolymarketSubmissionUnknownError:
+            except PolymarketSubmissionUnknownError as error:
                 # Order may have reached the venue. Categorize distinctly
                 # from venue_rejection so the operator knows to reconcile,
                 # and so dedup release does not green-light a retry that
                 # could double-spend.
                 final_state = _rejected_order_state(decision, "submission_unknown")
+                error.order_state = final_state
                 release_outcome = "submission_unknown"
                 await self.feedback.generate(
                     final_state,

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -54,6 +54,8 @@ class ControllerSettings(BaseModel):
     min_volume: float = 0.0
     max_slippage_bps: int = 50
     time_in_force: str = "GTC"
+    max_book_age_ms: float = 1_000.0
+    max_spread_bps: float = 100.0
 
 
 class RiskSettings(BaseModel):
@@ -145,6 +147,12 @@ def validate_live_mode_ready(settings: PMSSettings) -> VenueCredentials:
         fields = ", ".join(missing)
         msg = f"Missing Polymarket credential fields: {fields}"
         raise MissingPolymarketCredentialsError(msg)
+    if settings.controller.time_in_force.upper() == "GTC":
+        msg = (
+            "LIVE GTC disabled until an open-order ledger reserves "
+            "resting order exposure"
+        )
+        raise LiveTradingDisabledError(msg)
     return credentials
 
 

--- a/src/pms/controller/factor_snapshot.py
+++ b/src/pms/controller/factor_snapshot.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from hashlib import sha256
 import json
@@ -13,12 +13,25 @@ from pms.strategies.projections import FactorCompositionStep
 
 
 FactorKey = tuple[str, str]
+RAW_FACTOR_ROLES = frozenset(
+    {
+        "weighted",
+        "precedence_rank",
+        "threshold_edge",
+        "posterior_prior",
+        "posterior_success",
+        "posterior_failure",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
 class FactorSnapshot:
     values: Mapping[FactorKey, float]
     missing_factors: tuple[FactorKey, ...] = ()
+    timestamps: Mapping[FactorKey, datetime] = field(default_factory=dict)
+    ages_ms: Mapping[FactorKey, float] = field(default_factory=dict)
+    stale_factors: tuple[FactorKey, ...] = ()
     snapshot_hash: str | None = None
 
 
@@ -45,9 +58,7 @@ class NullFactorSnapshotReader:
         strategy_id: str,
         strategy_version_id: str,
     ) -> FactorSnapshot:
-        missing_factors = tuple(
-            dict.fromkeys((step.factor_id, step.param) for step in required)
-        )
+        missing_factors = required_factor_keys(required)
         return FactorSnapshot(
             values={},
             missing_factors=missing_factors,
@@ -59,6 +70,7 @@ class NullFactorSnapshotReader:
                 required_keys=missing_factors,
                 values={},
                 missing_factors=missing_factors,
+                stale_factors=(),
             ),
         )
 
@@ -76,9 +88,7 @@ class PostgresFactorSnapshotReader:
         strategy_id: str,
         strategy_version_id: str,
     ) -> FactorSnapshot:
-        required_keys = tuple(
-            dict.fromkeys((step.factor_id, step.param) for step in required)
-        )
+        required_keys = required_factor_keys(required)
         if not required_keys:
             return FactorSnapshot(
                 values={},
@@ -91,6 +101,7 @@ class PostgresFactorSnapshotReader:
                     required_keys=(),
                     values={},
                     missing_factors=(),
+                    stale_factors=(),
                 ),
             )
 
@@ -106,7 +117,8 @@ class PostgresFactorSnapshotReader:
                     SELECT DISTINCT ON (fv.factor_id, fv.param)
                         fv.factor_id,
                         fv.param,
-                        fv.value
+                        fv.value,
+                        fv.ts
                     FROM factor_values AS fv
                     INNER JOIN required
                         ON required.factor_id = fv.factor_id
@@ -118,7 +130,8 @@ class PostgresFactorSnapshotReader:
                 SELECT
                     required.factor_id,
                     required.param,
-                    latest.value
+                    latest.value,
+                    latest.ts
                 FROM required
                 LEFT JOIN latest
                     ON latest.factor_id = required.factor_id
@@ -131,7 +144,11 @@ class PostgresFactorSnapshotReader:
                 params,
             )
         values: dict[FactorKey, float] = {}
+        timestamps: dict[FactorKey, datetime] = {}
+        ages_ms: dict[FactorKey, float] = {}
         missing_factors: list[FactorKey] = []
+        stale_factors: list[FactorKey] = []
+        freshness_slas = _freshness_slas(required)
         for row in rows:
             key = (row["factor_id"], row["param"])
             value = row["value"]
@@ -139,9 +156,20 @@ class PostgresFactorSnapshotReader:
                 missing_factors.append(key)
                 continue
             values[key] = float(value)
+            ts = row["ts"]
+            if isinstance(ts, datetime):
+                timestamps[key] = ts
+                age_ms = max(0.0, (as_of - ts).total_seconds() * 1000.0)
+                ages_ms[key] = age_ms
+                freshness_sla_s = freshness_slas.get(key)
+                if freshness_sla_s is not None and age_ms > freshness_sla_s * 1000.0:
+                    stale_factors.append(key)
         return FactorSnapshot(
             values=values,
             missing_factors=tuple(missing_factors),
+            timestamps=timestamps,
+            ages_ms=ages_ms,
+            stale_factors=tuple(stale_factors),
             snapshot_hash=_snapshot_hash(
                 market_id=market_id,
                 as_of=as_of,
@@ -150,6 +178,7 @@ class PostgresFactorSnapshotReader:
                 required_keys=required_keys,
                 values=values,
                 missing_factors=tuple(missing_factors),
+                stale_factors=tuple(stale_factors),
             ),
         )
 
@@ -163,6 +192,7 @@ def _snapshot_hash(
     required_keys: Sequence[FactorKey],
     values: Mapping[FactorKey, float],
     missing_factors: Sequence[FactorKey],
+    stale_factors: Sequence[FactorKey] = (),
 ) -> str:
     payload = {
         "market_id": market_id,
@@ -181,9 +211,50 @@ def _snapshot_hash(
             [factor_id, param]
             for factor_id, param in sorted(missing_factors)
         ],
+        "stale_factors": [
+            [factor_id, param]
+            for factor_id, param in sorted(stale_factors)
+        ],
     }
     return sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
             "utf-8"
         )
     ).hexdigest()
+
+
+def required_factor_keys(
+    steps: Sequence[FactorCompositionStep],
+) -> tuple[FactorKey, ...]:
+    return tuple(
+        dict.fromkeys(
+            (step.factor_id, step.param)
+            for step in steps
+            if _requires_raw_factor(step)
+        )
+    )
+
+
+def _requires_raw_factor(step: FactorCompositionStep) -> bool:
+    if getattr(step, "required", True) is False:
+        return False
+    return step.role in RAW_FACTOR_ROLES
+
+
+def _freshness_slas(
+    steps: Sequence[FactorCompositionStep],
+) -> dict[FactorKey, float | None]:
+    slas: dict[FactorKey, float | None] = {}
+    for step in steps:
+        if not _requires_raw_factor(step):
+            continue
+        raw_sla = getattr(step, "freshness_sla_s", None)
+        if raw_sla is None:
+            slas[(step.factor_id, step.param)] = None
+            continue
+        freshness_sla_s = float(raw_sla)
+        key = (step.factor_id, step.param)
+        current = slas.get(key)
+        if current is None or freshness_sla_s < current:
+            slas[key] = freshness_sla_s
+    return slas

--- a/src/pms/controller/forecasters/llm.py
+++ b/src/pms/controller/forecasters/llm.py
@@ -43,6 +43,8 @@ class LLMForecaster:
             self.config = LLMSettings()
 
     def predict(self, signal: MarketSignal) -> LLMForecastResult | None:
+        if self.config is None or not self.config.enabled:
+            return None
         return LLMForecastResult(
             prob_estimate=signal.yes_price,
             confidence=0.0,

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import UTC, datetime
+from hashlib import sha256
+import json
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -15,6 +17,7 @@ from pms.controller.factor_snapshot import (
     FactorKey,
     FactorSnapshotReader,
     NullFactorSnapshotReader,
+    required_factor_keys,
 )
 from pms.controller.forecasters.llm import LLMForecaster
 from pms.controller.forecasters.rules import RulesForecaster
@@ -25,7 +28,7 @@ from pms.controller.outcome_tokens import (
 )
 from pms.controller.router import Router
 from pms.controller.sizers.kelly import KellySizer
-from pms.core.enums import TimeInForce
+from pms.core.enums import RunMode, TimeInForce
 from pms.core.interfaces import ICalibrator, IForecaster, ISizer
 from pms.core.models import MarketSignal, Opportunity, Portfolio, TradeDecision
 from pms.factors.composition import apply_composition, evaluate_branch_probabilities
@@ -119,7 +122,10 @@ class ControllerPipeline:
             runtime_factor_id = _runtime_factor_id(
                 forecaster_names[index] if index < len(forecaster_names) else None
             )
-            if runtime_factor_id is not None:
+            if runtime_factor_id is not None and not _is_placeholder_forecast(
+                result,
+                model_id=model_id,
+            ):
                 runtime_probabilities[runtime_factor_id] = calibrated_probability
 
         if not probabilities:
@@ -143,23 +149,75 @@ class ControllerPipeline:
                 strategy_id=self.strategy.strategy_id,
                 strategy_version_id=self.strategy.strategy_version_id,
             )
+            signal_factor_values = _signal_factor_values(signal)
             factor_values = dict(factor_snapshot.values)
-            factor_values.update(_signal_factor_values(signal))
+            factor_values.update(signal_factor_values)
             factor_values.update(
                 {
                     (factor_id, ""): value
                     for factor_id, value in runtime_probabilities.items()
                 }
             )
+            reported_missing_factors = factor_snapshot.missing_factors
+            if not reported_missing_factors and not factor_snapshot.values:
+                reported_missing_factors = required_factor_keys(
+                    self.strategy.config.factor_composition
+                )
+            unresolved_missing_factors = tuple(
+                key for key in reported_missing_factors if key not in factor_values
+            )
+            if self.settings.mode == RunMode.LIVE and unresolved_missing_factors:
+                self.last_diagnostic = _composition_diagnostic(
+                    code="missing_required_factors",
+                    message="Skipping decision because required raw factors are missing.",
+                    signal=signal,
+                    strategy_id=self.strategy_id,
+                    strategy_version_id=self.strategy_version_id,
+                    factors=unresolved_missing_factors,
+                )
+                logger.info(
+                    "controller diagnostic %s for %s",
+                    self.last_diagnostic.code,
+                    signal.market_id,
+                    extra={"controller_diagnostic": self.last_diagnostic},
+                )
+                return None
+            unresolved_stale_factors = tuple(
+                key for key in factor_snapshot.stale_factors if key not in signal_factor_values
+            )
+            if self.settings.mode == RunMode.LIVE and unresolved_stale_factors:
+                self.last_diagnostic = _composition_diagnostic(
+                    code="stale_required_factors",
+                    message="Skipping decision because required raw factors are stale.",
+                    signal=signal,
+                    strategy_id=self.strategy_id,
+                    strategy_version_id=self.strategy_version_id,
+                    factors=unresolved_stale_factors,
+                )
+                logger.info(
+                    "controller diagnostic %s for %s",
+                    self.last_diagnostic.code,
+                    signal.market_id,
+                    extra={"controller_diagnostic": self.last_diagnostic},
+                )
+                return None
             try:
                 branch_probabilities = evaluate_branch_probabilities(
                     self.strategy.config.factor_composition,
                     factor_values,
                 )
-                prob_estimate = apply_composition(
-                    self.strategy.config.factor_composition,
-                    factor_values,
-                )
+                if (
+                    self.settings.mode != RunMode.LIVE
+                    and not branch_probabilities
+                    and unresolved_missing_factors
+                    and "resolved_outcome" in signal.external_signal
+                ):
+                    prob_estimate = 0.5
+                else:
+                    prob_estimate = apply_composition(
+                        self.strategy.config.factor_composition,
+                        factor_values,
+                    )
                 factor_snapshot_hash = factor_snapshot.snapshot_hash
                 composition_trace = {
                     "selected_probability": prob_estimate,
@@ -167,10 +225,20 @@ class ControllerPipeline:
                     "factor_snapshot_hash": factor_snapshot.snapshot_hash,
                     "missing_factors": [
                         _factor_key_label((factor_id, param))
-                        for factor_id, param in factor_snapshot.missing_factors
+                        for factor_id, param in unresolved_missing_factors
                     ],
                     "branch_probabilities": branch_probabilities,
                 }
+                if unresolved_stale_factors:
+                    composition_trace["stale_factors"] = [
+                        _factor_key_label((factor_id, param))
+                        for factor_id, param in unresolved_stale_factors
+                    ]
+                if factor_snapshot.ages_ms:
+                    composition_trace["factor_ages_ms"] = {
+                        _factor_key_label((factor_id, param)): age
+                        for (factor_id, param), age in factor_snapshot.ages_ms.items()
+                    }
             except (KeyError, ValueError) as exc:
                 logger.warning("composition resolution failed: %s", exc)
                 return None
@@ -247,6 +315,18 @@ class ControllerPipeline:
             composition_trace=composition_trace,
         )
 
+        intent_key = _intent_key(
+            strategy_id=self.strategy_id,
+            strategy_version_id=self.strategy_version_id,
+            market_id=signal.market_id,
+            token_id=decision_token_id,
+            action="BUY",
+            outcome=decision_outcome,
+            limit_price=decision_price,
+            notional_usdc=size,
+            factor_snapshot_hash=factor_snapshot_hash,
+            signal_timestamp=signal.timestamp,
+        )
         return opportunity, TradeDecision(
             decision_id=f"decision-{uuid.uuid4().hex}",
             market_id=signal.market_id,
@@ -267,6 +347,7 @@ class ControllerPipeline:
             action="BUY",
             outcome=decision_outcome,
             model_id=_decision_model_id(model_ids),
+            intent_key=intent_key,
         )
 
     async def decide(
@@ -311,6 +392,37 @@ def _selected_factor_values(factor_values: dict[FactorKey, float]) -> dict[str, 
     }
 
 
+def _composition_diagnostic(
+    *,
+    code: str,
+    message: str,
+    signal: MarketSignal,
+    strategy_id: str,
+    strategy_version_id: str,
+    factors: Sequence[FactorKey],
+) -> ControllerDiagnostic:
+    return ControllerDiagnostic(
+        code=code,
+        message=message,
+        market_id=signal.market_id,
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        token_id=signal.token_id,
+        severity="warning",
+        metadata={
+            "factors": [_factor_key_label(key) for key in factors],
+        },
+    )
+
+
+def _is_placeholder_forecast(
+    result: ForecastResult,
+    *,
+    model_id: str,
+) -> bool:
+    return model_id == "neutral" or result[2] == "pre-s5-neutral"
+
+
 def _signal_factor_values(signal: MarketSignal) -> dict[tuple[str, str], float]:
     factor_values = {
         (key, ""): float(value)
@@ -342,6 +454,38 @@ def _runtime_factor_id(forecaster_name: str | None) -> str | None:
     if forecaster_name in {"rules", "llm"}:
         return forecaster_name
     return None
+
+
+def _intent_key(
+    *,
+    strategy_id: str,
+    strategy_version_id: str,
+    market_id: str,
+    token_id: str | None,
+    action: str,
+    outcome: str,
+    limit_price: float,
+    notional_usdc: float,
+    factor_snapshot_hash: str | None,
+    signal_timestamp: datetime,
+) -> str:
+    payload = {
+        "strategy_id": strategy_id,
+        "strategy_version_id": strategy_version_id,
+        "market_id": market_id,
+        "token_id": token_id,
+        "action": action,
+        "outcome": outcome,
+        "limit_price": round(limit_price, 4),
+        "notional_usdc": round(notional_usdc, 2),
+        "factor_snapshot_hash": factor_snapshot_hash,
+        "signal_ts_bucket": signal_timestamp.replace(microsecond=0).isoformat(),
+    }
+    return sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
+            "utf-8"
+        )
+    ).hexdigest()
 
 
 def _rationale_text(rationales: Sequence[str]) -> str:

--- a/src/pms/core/models.py
+++ b/src/pms/core/models.py
@@ -84,8 +84,12 @@ class TradeDecision:
     action: BookSide | None = None
     outcome: Outcome = "YES"
     model_id: str | None = None
+    intent_key: str | None = None
 
     def __post_init__(self) -> None:
+        if self.action is not None and self.side != self.action:
+            msg = "TradeDecision.side/action mismatch"
+            raise ValueError(msg)
         if self.notional_usdc <= 0.0:
             msg = "TradeDecision.notional_usdc must be > 0.0"
             raise ValueError(msg)
@@ -120,6 +124,7 @@ class OrderState:
     strategy_id: str
     strategy_version_id: str
     filled_quantity: float = 0.0
+    pre_submit_quote: Mapping[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/src/pms/factors/composition.py
+++ b/src/pms/factors/composition.py
@@ -20,6 +20,15 @@ class FactorCompositionStep(Protocol):
     @property
     def threshold(self) -> float | None: ...
 
+    @property
+    def required(self) -> bool: ...
+
+    @property
+    def freshness_sla_s(self) -> float | None: ...
+
+    @property
+    def allow_neutral_fallback(self) -> bool: ...
+
 
 def apply_composition(
     composition: Sequence[FactorCompositionStep],
@@ -178,6 +187,16 @@ def _apply_posterior(
     success_steps = tuple(step for step in composition if step.role == "posterior_success")
     failure_steps = tuple(step for step in composition if step.role == "posterior_failure")
     if not prior_steps and not success_steps and not failure_steps:
+        return None
+    has_real_input = any(
+        (step.factor_id, step.param) in factor_values
+        for step in (*prior_steps, *success_steps, *failure_steps)
+    )
+    allow_neutral_fallback = any(
+        step.allow_neutral_fallback
+        for step in (*prior_steps, *success_steps, *failure_steps)
+    )
+    if not has_real_input and not allow_neutral_fallback:
         return None
 
     prior_strength = 0.0

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -19,6 +19,7 @@ from pms.actuator.adapters.polymarket import (
     FileFirstLiveOrderGate,
     PolymarketActuator,
     PolymarketSDKClient,
+    PolymarketSubmissionUnknownError,
 )
 from pms.actuator.executor import ActuatorAdapter, ActuatorExecutor
 from pms.actuator.feedback import ActuatorFeedback
@@ -246,6 +247,7 @@ class Runner:
     _paper_orderbooks: dict[str, dict[str, Any]] = field(
         init=False, default_factory=dict
     )
+    _live_trading_suspended_reason: str | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         self.state = RunnerState(mode=self.config.mode)
@@ -352,6 +354,10 @@ class Runner:
             tasks.append(self.evaluator_task)
         return tuple(tasks)
 
+    @property
+    def live_trading_suspended(self) -> bool:
+        return self._live_trading_suspended_reason is not None
+
     async def start(self) -> None:
         if any(not task.done() for task in self.tasks):
             msg = "Runner is already started"
@@ -362,6 +368,7 @@ class Runner:
 
         self._stop_event.clear()
         self._controller_pipeline_error = None
+        self._live_trading_suspended_reason = None
         self.state = RunnerState(
             mode=self.config.mode,
             runner_started_at=datetime.now(tz=UTC),
@@ -377,6 +384,8 @@ class Runner:
                     raise RuntimeError(msg)
                 self._strategy_registry = PostgresStrategyRegistry(self._pg_pool)
                 await ensure_factor_catalog(self._pg_pool)
+                if self.config.mode == RunMode.LIVE:
+                    await self._assert_no_unresolved_submission_unknown_incidents()
                 await self._ensure_default_v2_version()
                 if self._pg_pool is None:
                     msg = "Runner PostgreSQL pool is not initialized"
@@ -824,6 +833,18 @@ class Runner:
                             created_at=created_at,
                             expires_at=expires_at,
                         )
+                        update_status = getattr(
+                            self.decision_store,
+                            "update_status",
+                            None,
+                        )
+                        if callable(update_status):
+                            await update_status(
+                                decision.decision_id,
+                                current_status="pending",
+                                next_status="accepted",
+                                updated_at=created_at,
+                            )
                         _append_bounded(self.state.decisions, decision)
                         await self.event_bus.publish(
                             "controller.decision",
@@ -881,6 +902,20 @@ class Runner:
             decision = work_item.decision
             signal = work_item.signal
             try:
+                if (
+                    self.config.mode == RunMode.LIVE
+                    and self._live_trading_suspended_reason is not None
+                ):
+                    await self.event_bus.publish(
+                        "error",
+                        (
+                            "live trading suspended: "
+                            f"{self._live_trading_suspended_reason}"
+                        ),
+                        market_id=decision.market_id,
+                        decision_id=decision.decision_id,
+                    )
+                    continue
                 if self.config.mode == RunMode.PAPER and signal is not None:
                     self._paper_orderbooks[decision.market_id] = signal.orderbook
                 order_state = await _execute_actuator_work_item(
@@ -911,6 +946,26 @@ class Runner:
                         logger.warning("fill persistence failed: %s", error)
                     self.portfolio = _portfolio_with_fill(self.portfolio, fill)
                     self._evaluator_spool.enqueue(fill, decision)
+            except PolymarketSubmissionUnknownError as error:
+                self._live_trading_suspended_reason = "submission_unknown"
+                self._stop_event.set()
+                unknown_order_state = error.order_state
+                if unknown_order_state is not None:
+                    _append_bounded(self.state.orders, unknown_order_state)
+                    try:
+                        await self.order_store.insert(unknown_order_state)
+                    except Exception as store_error:  # noqa: BLE001
+                        logger.warning(
+                            "submission_unknown order persistence failed: %s",
+                            store_error,
+                        )
+                await self.event_bus.publish(
+                    "error",
+                    f"live trading suspended for submission_unknown: {error}",
+                    market_id=decision.market_id,
+                    decision_id=decision.decision_id,
+                )
+                logger.warning("live trading suspended for submission_unknown: %s", error)
             except Exception as error:
                 await self.event_bus.publish(
                     "error",
@@ -963,6 +1018,28 @@ class Runner:
         return await self.decision_store.expire_pending(
             before=now or datetime.now(tz=UTC)
         )
+
+    async def _assert_no_unresolved_submission_unknown_incidents(self) -> None:
+        pool = self._pg_pool
+        if pool is None:
+            return
+        acquire = getattr(pool, "acquire", None)
+        if acquire is None:
+            return
+        async with acquire() as connection:
+            count = await connection.fetchval(
+                """
+                SELECT COUNT(*)
+                FROM order_intents
+                WHERE outcome = 'submission_unknown'
+                """
+            )
+        if int(count or 0) > 0:
+            msg = (
+                "LIVE start refused: unresolved submission_unknown incident "
+                "requires venue reconciliation before resume"
+            )
+            raise RuntimeError(msg)
 
     async def _metrics_by_strategy(
         self,

--- a/src/pms/storage/decision_store.py
+++ b/src/pms/storage/decision_store.py
@@ -295,6 +295,7 @@ def _decision_payload(decision: TradeDecision) -> dict[str, object]:
         "action": decision.action,
         "outcome": decision.outcome,
         "model_id": decision.model_id,
+        "intent_key": decision.intent_key,
     }
 
 
@@ -340,6 +341,7 @@ def _decision_from_payload(payload: Mapping[str, Any]) -> TradeDecision:
         action=cast(Literal["BUY", "SELL"] | None, payload.get("action")),
         outcome=cast(Literal["YES", "NO"], payload.get("outcome", "YES")),
         model_id=cast(str | None, payload.get("model_id")),
+        intent_key=cast(str | None, payload.get("intent_key")),
     )
 
 

--- a/src/pms/storage/dedup_store.py
+++ b/src/pms/storage/dedup_store.py
@@ -62,10 +62,16 @@ class InMemoryDedupStore:
     async def acquire(self, decision: TradeDecision) -> bool:
         if decision.decision_id in self._entries:
             return False
+        if decision.intent_key is not None and any(
+            entry.intent_key == decision.intent_key
+            for entry in self._entries.values()
+        ):
+            return False
 
         now = datetime.now(tz=UTC)
         self._entries[decision.decision_id] = _DedupEntry(
             decision_id=decision.decision_id,
+            intent_key=decision.intent_key,
             strategy_id=decision.strategy_id,
             strategy_version_id=decision.strategy_version_id,
             acquired_at=now,
@@ -102,6 +108,7 @@ class InMemoryDedupStore:
 @dataclass(frozen=True, slots=True)
 class _DedupEntry:
     decision_id: str
+    intent_key: str | None
     strategy_id: str
     strategy_version_id: str
     acquired_at: datetime
@@ -156,15 +163,17 @@ async def _insert_order_intent(
         """
         INSERT INTO order_intents (
             decision_id,
+            intent_key,
             strategy_id,
             strategy_version_id,
             worker_host,
             worker_pid
-        ) VALUES ($1, $2, $3, $4, $5)
-        ON CONFLICT (decision_id) DO NOTHING
+        ) VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT DO NOTHING
         RETURNING decision_id
         """,
         decision.decision_id,
+        decision.intent_key,
         decision.strategy_id,
         decision.strategy_version_id,
         worker_host,

--- a/src/pms/storage/order_store.py
+++ b/src/pms/storage/order_store.py
@@ -127,6 +127,7 @@ def _order_payload(order: OrderState) -> dict[str, object]:
         "fill_price": order.fill_price,
         "last_updated_at": order.last_updated_at.isoformat(),
         "raw_status": order.raw_status,
+        "pre_submit_quote": dict(order.pre_submit_quote),
     }
 
 
@@ -149,6 +150,10 @@ def _order_from_row(row: asyncpg.Record) -> OrderState:
         strategy_id=cast(str, row["strategy_id"]),
         strategy_version_id=cast(str, row["strategy_version_id"]),
         filled_quantity=cast(float, row["filled_quantity"]),
+        pre_submit_quote=cast(
+            dict[str, Any],
+            payload.get("pre_submit_quote", {}),
+        ),
     )
 
 

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -522,6 +522,20 @@ def _json_factor_composition(value: object) -> tuple[FactorCompositionStep, ...]
                     step_payload.get("threshold"),
                     "config.factor_composition.step.threshold",
                 ),
+                required=_json_optional_bool(
+                    step_payload.get("required"),
+                    "config.factor_composition.step.required",
+                    default=True,
+                ),
+                freshness_sla_s=_json_optional_float(
+                    step_payload.get("freshness_sla_s"),
+                    "config.factor_composition.step.freshness_sla_s",
+                ),
+                allow_neutral_fallback=_json_optional_bool(
+                    step_payload.get("allow_neutral_fallback"),
+                    "config.factor_composition.step.allow_neutral_fallback",
+                    default=False,
+                ),
             )
         )
     return tuple(steps)
@@ -568,6 +582,15 @@ def _json_optional_float(value: object, field_name: str) -> float | None:
     if value is None:
         return None
     return _json_float(value, field_name)
+
+
+def _json_optional_bool(value: object, field_name: str, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        msg = f"{field_name} must decode to a boolean or null"
+        raise TypeError(msg)
+    return value
 
 
 def _json_float(value: object, field_name: str) -> float:

--- a/src/pms/strategies/defaults.py
+++ b/src/pms/strategies/defaults.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pms.strategies.projections import FactorCompositionStep
 
+DEFAULT_REQUIRED_FACTOR_FRESHNESS_S = 300.0
+
 DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
     FactorCompositionStep(
         factor_id="fair_value_spread",
@@ -9,6 +11,7 @@ DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=1.0,
         threshold=None,
+        freshness_sla_s=DEFAULT_REQUIRED_FACTOR_FRESHNESS_S,
     ),
     FactorCompositionStep(
         factor_id="subset_pricing_violation",
@@ -16,6 +19,7 @@ DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=2.0,
         threshold=None,
+        freshness_sla_s=DEFAULT_REQUIRED_FACTOR_FRESHNESS_S,
     ),
     FactorCompositionStep(
         factor_id="fair_value_spread",
@@ -23,6 +27,7 @@ DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=1.0,
         threshold=0.02,
+        freshness_sla_s=DEFAULT_REQUIRED_FACTOR_FRESHNESS_S,
     ),
     FactorCompositionStep(
         factor_id="subset_pricing_violation",
@@ -30,6 +35,7 @@ DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=1.0,
         threshold=0.02,
+        freshness_sla_s=DEFAULT_REQUIRED_FACTOR_FRESHNESS_S,
     ),
     FactorCompositionStep(
         factor_id="metaculus_prior",
@@ -37,6 +43,7 @@ DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=2.0,
         threshold=None,
+        freshness_sla_s=DEFAULT_REQUIRED_FACTOR_FRESHNESS_S,
     ),
     FactorCompositionStep(
         factor_id="yes_count",
@@ -44,6 +51,7 @@ DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=1.0,
         threshold=None,
+        freshness_sla_s=DEFAULT_REQUIRED_FACTOR_FRESHNESS_S,
     ),
     FactorCompositionStep(
         factor_id="no_count",
@@ -51,6 +59,7 @@ DEFAULT_STRATEGY_COMPOSITION: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=1.0,
         threshold=None,
+        freshness_sla_s=DEFAULT_REQUIRED_FACTOR_FRESHNESS_S,
     ),
     FactorCompositionStep(
         factor_id="llm",

--- a/src/pms/strategies/projections.py
+++ b/src/pms/strategies/projections.py
@@ -18,6 +18,9 @@ class FactorCompositionStep:
     param: str
     weight: float
     threshold: float | None
+    required: bool = True
+    freshness_sla_s: float | None = None
+    allow_neutral_fallback: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/integration/test_polymarket_live_execution.py
+++ b/tests/integration/test_polymarket_live_execution.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Literal, cast
 
 import pytest
 
 from pms.actuator.adapters.polymarket import (
+    LivePreSubmitQuote,
     LiveOrderPreview,
     PolymarketActuator,
     PolymarketOrderResult,
@@ -14,7 +16,7 @@ from pms.actuator.adapters.polymarket import (
 from pms.actuator.executor import ActuatorExecutor
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import RiskManager
-from pms.config import PMSSettings, PolymarketSettings, RiskSettings
+from pms.config import ControllerSettings, PMSSettings, PolymarketSettings, RiskSettings
 from pms.core.enums import OrderStatus, RunMode, Side, TimeInForce
 from pms.core.models import FillRecord, OrderState, TradeDecision
 from pms.runner import Runner
@@ -57,6 +59,27 @@ class AllowFirstOrderGate:
         self.consumed += 1
 
 
+@dataclass(frozen=True)
+class AllowQuoteProvider:
+    async def quote(
+        self,
+        order: object,
+        credentials: object,
+    ) -> LivePreSubmitQuote:
+        del credentials
+        notional = getattr(order, "notional_usdc")
+        price = getattr(order, "price")
+        return LivePreSubmitQuote(
+            market_status="open",
+            book_age_ms=20.0,
+            executable_notional_usdc=float(notional),
+            best_executable_price=float(price),
+            spread_bps=10.0,
+            quote_hash="quote-integration",
+            book_ts=datetime(2026, 4, 26, tzinfo=UTC),
+        )
+
+
 @dataclass
 class MockPolymarketClient:
     submitted: list[object] = field(default_factory=list)
@@ -96,7 +119,12 @@ async def test_live_polymarket_order_uses_runner_order_and_fill_persistence_path
     client = MockPolymarketClient()
     gate = AllowFirstOrderGate()
     runner.actuator_executor = ActuatorExecutor(
-        adapter=PolymarketActuator(settings, client=client, operator_gate=gate),
+        adapter=PolymarketActuator(
+            settings,
+            client=client,
+            operator_gate=gate,
+            quote_provider=AllowQuoteProvider(),
+        ),
         risk=RiskManager(settings.risk),
         feedback=ActuatorFeedback(cast(FeedbackStore, feedback_store)),
         dedup_store=InMemoryDedupStore(),
@@ -125,6 +153,7 @@ def _live_settings() -> PMSSettings:
         mode=RunMode.LIVE,
         live_trading_enabled=True,
         auto_migrate_default_v2=False,
+        controller=ControllerSettings(time_in_force="IOC"),
         risk=RiskSettings(
             max_position_per_market=1000.0,
             max_total_exposure=10_000.0,
@@ -156,7 +185,7 @@ def _decision(
         stop_conditions=["integration-test"],
         prob_estimate=0.6,
         expected_edge=0.2,
-        time_in_force=TimeInForce.GTC,
+        time_in_force=TimeInForce.IOC,
         opportunity_id="op-live-integration",
         strategy_id="default",
         strategy_version_id="default-v1",

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -20,6 +20,7 @@ from pms.actuator.adapters.paper import PaperActuator
 from pms.actuator.adapters.polymarket import (
     FileFirstLiveOrderGate,
     LiveOrderPreview,
+    LivePreSubmitQuote,
     OperatorApprovalRequiredError,
     PolymarketActuator,
     PolymarketOrderResult,
@@ -29,7 +30,7 @@ from pms.actuator.adapters.polymarket import (
 )
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import InsufficientLiquidityError, RiskManager
-from pms.config import PMSSettings, PolymarketSettings, RiskSettings
+from pms.config import ControllerSettings, PMSSettings, PolymarketSettings, RiskSettings
 from pms.core.enums import FeedbackSource, FeedbackTarget, OrderStatus, Side, TimeInForce
 from pms.core.models import LiveTradingDisabledError, OrderState, Portfolio, TradeDecision
 from pms.storage.dedup_store import InMemoryDedupStore
@@ -60,7 +61,7 @@ def _decision(
         stop_conditions=["unit-test"],
         prob_estimate=0.6,
         expected_edge=0.2,
-        time_in_force=TimeInForce.GTC,
+        time_in_force=TimeInForce.IOC,
         opportunity_id=f"op-{decision_id}",
         strategy_id="default",
         strategy_version_id="default-v1",
@@ -340,9 +341,29 @@ class BlockingOperatorGate:
         del preview
 
 
+@dataclass(frozen=True)
+class AllowQuoteProvider:
+    async def quote(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: object,
+    ) -> LivePreSubmitQuote:
+        del credentials
+        return LivePreSubmitQuote(
+            market_status="open",
+            book_age_ms=25.0,
+            executable_notional_usdc=order.notional_usdc,
+            best_executable_price=order.price,
+            spread_bps=10.0,
+            quote_hash="quote-unit",
+            book_ts=datetime(2026, 4, 26, tzinfo=UTC),
+        )
+
+
 def _live_settings() -> PMSSettings:
     return PMSSettings(
         live_trading_enabled=True,
+        controller=ControllerSettings(time_in_force="IOC"),
         polymarket=PolymarketSettings(
             private_key="private-key",
             api_key="api-key",
@@ -366,7 +387,12 @@ async def test_polymarket_actuator_rejects_missing_live_credentials() -> None:
 async def test_polymarket_actuator_requires_operator_approval_for_first_live_order() -> None:
     client = RecordingPolymarketClient()
     gate = RecordingOperatorGate(approved=False)
-    actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
+    )
 
     with pytest.raises(OperatorApprovalRequiredError):
         await actuator.execute(_decision(), _portfolio())
@@ -386,7 +412,12 @@ async def test_polymarket_actuator_requires_operator_approval_for_first_live_ord
 async def test_polymarket_actuator_submits_mocked_live_order_after_first_order_gate() -> None:
     client = RecordingPolymarketClient()
     gate = RecordingOperatorGate(approved=True)
-    actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
+    )
 
     state = await actuator.execute(_decision(), _portfolio())
 
@@ -419,7 +450,12 @@ async def test_polymarket_actuator_first_order_gate_is_serialized() -> None:
     #      not the ceiling — this matches the original concurrent semantics).
     client = RecordingPolymarketClient()
     gate = BlockingOperatorGate()
-    actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
+    )
 
     first = asyncio.create_task(actuator.execute(_decision(decision_id="d-first"), _portfolio()))
     await asyncio.wait_for(gate.entered.wait(), timeout=1.0)
@@ -441,7 +477,12 @@ async def test_polymarket_actuator_first_order_gate_is_serialized() -> None:
 async def test_polymarket_actuator_converts_limit_notional_to_order_shares() -> None:
     client = RecordingPolymarketClient()
     gate = RecordingOperatorGate(approved=True)
-    actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
+    )
 
     await actuator.execute(_decision(notional_usdc=10.0, limit_price=0.4), _portfolio())
 
@@ -454,7 +495,12 @@ async def test_polymarket_actuator_converts_limit_notional_to_order_shares() -> 
 async def test_polymarket_actuator_converts_market_sell_notional_to_shares() -> None:
     client = RecordingPolymarketClient()
     gate = RecordingOperatorGate(approved=True)
-    actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
+    )
     decision = _decision(
         side=Side.SELL.value,
         action=Side.SELL.value,
@@ -1025,7 +1071,12 @@ async def test_polymarket_actuator_does_not_mark_approved_when_submit_fails() ->
     """
     client = _FailThenSucceedClient(fail_count=1)
     gate = RecordingOperatorGate(approved=True)
-    actuator = PolymarketActuator(_live_settings(), client=client, operator_gate=gate)
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
+    )
 
     with pytest.raises(RuntimeError, match="simulated network drop"):
         await actuator.execute(_decision(decision_id="d-fail"), _portfolio())
@@ -1069,6 +1120,7 @@ async def test_file_first_live_order_gate_consumes_file_after_first_success(
         _live_settings(),
         client=client,
         operator_gate=FileFirstLiveOrderGate(approval_path),
+        quote_provider=AllowQuoteProvider(),
     )
 
     state = await actuator.execute(_decision(), _portfolio())
@@ -2261,7 +2313,10 @@ async def test_polymarket_actuator_lock_held_through_submit_blocks_concurrent_re
 
     client = _SlowPolymarketClient()
     actuator = PolymarketActuator(
-        _live_settings(), client=client, operator_gate=gate
+        _live_settings(),
+        client=client,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
     )
 
     first = asyncio.create_task(
@@ -2341,7 +2396,10 @@ async def test_polymarket_actuator_failed_first_submit_re_prompts_gate(
 
     failing = _FailingClient()
     actuator = PolymarketActuator(
-        _live_settings(), client=failing, operator_gate=gate
+        _live_settings(),
+        client=failing,
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
     )
 
     with pytest.raises(LiveTradingDisabledError):
@@ -2375,6 +2433,7 @@ async def test_polymarket_actuator_failed_first_submit_re_prompts_gate(
         _live_settings(),
         client=_PassingClient(),
         operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
     )
     state = await actuator2.execute(_decision(decision_id="d-retry"), _portfolio())
     assert state.order_id == "pm-live-retry"

--- a/tests/unit/test_controller_cp05.py
+++ b/tests/unit/test_controller_cp05.py
@@ -171,15 +171,18 @@ def test_llm_forecaster_returns_neutral_tuple_without_calling_client() -> None:
     assert client.messages.calls == []
 
 
-def test_llm_forecaster_returns_neutral_tuple_regardless_of_enablement(
+def test_llm_forecaster_returns_none_when_disabled_and_neutral_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    assert LLMForecaster(
-        config=LLMSettings(enabled=False),
-        client=FakeClaudeClient(),
-    ).predict(_signal()) == pytest.approx((0.4, 0.0, "pre-s5-neutral"))
+    assert (
+        LLMForecaster(
+            config=LLMSettings(enabled=False),
+            client=FakeClaudeClient(),
+        ).predict(_signal())
+        is None
+    )
     assert LLMForecaster(
         config=LLMSettings(enabled=True),
         client=FakeClaudeClient(),

--- a/tests/unit/test_core_foundation.py
+++ b/tests/unit/test_core_foundation.py
@@ -9,6 +9,7 @@ from typing import Any, get_type_hints
 import pytest
 
 from pms.config import (
+    ControllerSettings,
     MissingPolymarketCredentialsError,
     PMSSettings,
     PolymarketSettings,
@@ -187,6 +188,7 @@ def test_live_mode_validation_returns_redacted_credentials() -> None:
     settings = PMSSettings(
         mode=RunMode.LIVE,
         live_trading_enabled=True,
+        controller=ControllerSettings(time_in_force="IOC"),
         polymarket=PolymarketSettings(
             host="https://clob.polymarket.com",
             private_key="private-key",

--- a/tests/unit/test_forecaster_migration_matrix.py
+++ b/tests/unit/test_forecaster_migration_matrix.py
@@ -53,8 +53,13 @@ class PreMigrationRules:
 class PreMigrationStatistical:
     prior_strength: float = 2.0
 
-    def predict(self, signal: MarketSignal) -> ForecastResult:
+    def predict(self, signal: MarketSignal) -> ForecastResult | None:
         metaculus = signal.external_signal.get("metaculus_prob")
+        has_counts = (
+            "yes_count" in signal.external_signal or "no_count" in signal.external_signal
+        )
+        if metaculus is None and not has_counts:
+            return None
         if metaculus is None:
             alpha = 1.0
             beta = 1.0
@@ -268,7 +273,9 @@ def test_default_strategy_composition_matches_present_branch_average(
     rules_result = PreMigrationRules().predict(signal)
     if rules_result is not None:
         expected_probabilities.append(rules_result[0])
-    expected_probabilities.append(PreMigrationStatistical().predict(signal)[0])
+    statistical_result = PreMigrationStatistical().predict(signal)
+    if statistical_result is not None:
+        expected_probabilities.append(statistical_result[0])
     factor_values = _factor_values(signal)
     if llm_probability is not None:
         expected_probabilities.append(llm_probability)

--- a/tests/unit/test_live_trading_blockers.py
+++ b/tests/unit/test_live_trading_blockers.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from typing import Any, Literal, cast
+
+import pytest
+
+from pms.actuator.adapters.polymarket import (
+    LiveOrderPreview,
+    PolymarketActuator,
+    PolymarketOrderResult,
+    PolymarketSubmissionUnknownError,
+)
+from pms.actuator.executor import ActuatorExecutor
+from pms.actuator.feedback import ActuatorFeedback
+from pms.actuator.risk import RiskManager
+from pms.config import (
+    ControllerSettings,
+    LLMSettings,
+    PMSSettings,
+    PolymarketSettings,
+    RiskSettings,
+    validate_live_mode_ready,
+)
+from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.factor_snapshot import FactorSnapshot
+from pms.controller.forecasters.llm import LLMForecaster
+from pms.controller.pipeline import ControllerPipeline
+from pms.core.enums import MarketStatus, OrderStatus, RunMode, Side, TimeInForce
+from pms.core.models import (
+    LiveTradingDisabledError,
+    MarketSignal,
+    OrderState,
+    Portfolio,
+    TradeDecision,
+)
+from pms.factors.composition import evaluate_branch_probabilities
+from pms.runner import ActuatorWorkItem, Runner
+from pms.storage.dedup_store import InMemoryDedupStore
+from pms.storage.feedback_store import FeedbackStore
+from pms.strategies.defaults import DEFAULT_STRATEGY_COMPOSITION
+from pms.strategies.projections import (
+    ActiveStrategy,
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+from tests.support.fake_stores import InMemoryFeedbackStore
+
+
+def _signal(
+    *,
+    yes_price: float = 0.10,
+    external_signal: dict[str, Any] | None = None,
+) -> MarketSignal:
+    return MarketSignal(
+        market_id="m-live-blocker",
+        token_id="t-yes",
+        venue="polymarket",
+        title="Will live blocker tests pass?",
+        yes_price=yes_price,
+        volume_24h=10_000.0,
+        resolves_at=datetime(2026, 5, 1, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": yes_price - 0.01, "size": 100.0}],
+            "asks": [{"price": yes_price + 0.01, "size": 100.0}],
+        },
+        external_signal=external_signal or {},
+        fetched_at=datetime(2026, 4, 26, 12, 0, tzinfo=UTC),
+        market_status=MarketStatus.OPEN.value,
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1_000.0,
+        free_usdc=1_000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+def _active_strategy(
+    *,
+    composition: Sequence[FactorCompositionStep] = DEFAULT_STRATEGY_COMPOSITION,
+) -> ActiveStrategy:
+    return ActiveStrategy(
+        strategy_id="default",
+        strategy_version_id="default-live-blockers",
+        config=StrategyConfig(
+            strategy_id="default",
+            factor_composition=tuple(composition),
+            metadata=(("owner", "system"),),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=1_000.0,
+            max_daily_drawdown_pct=0.0,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl")),
+        forecaster=ForecasterSpec(
+            forecasters=(("rules", ()), ("stats", ()), ("llm", ())),
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=30,
+            volume_min_usdc=0.0,
+        ),
+    )
+
+
+class ConstantForecaster:
+    def __init__(self, probability: float, rationale: str = "constant") -> None:
+        self.probability = probability
+        self.rationale = rationale
+
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return self.probability, 0.0, self.rationale
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        del signal
+        return self.probability
+
+
+class FixedSizer:
+    def size(self, *, prob: float, market_price: float, portfolio: Portfolio) -> float:
+        del prob, market_price, portfolio
+        return 10.0
+
+
+@dataclass(frozen=True)
+class SnapshotReader:
+    snapshot_value: FactorSnapshot
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> FactorSnapshot:
+        del market_id, as_of, required, strategy_id, strategy_version_id
+        return self.snapshot_value
+
+
+@pytest.mark.asyncio
+async def test_default_strategy_does_not_trade_when_required_raw_factors_missing() -> None:
+    pipeline = ControllerPipeline(
+        strategy=_active_strategy(),
+        factor_reader=SnapshotReader(
+            FactorSnapshot(
+                values={},
+                missing_factors=(
+                    ("fair_value_spread", ""),
+                    ("metaculus_prior", ""),
+                    ("yes_count", ""),
+                    ("no_count", ""),
+                ),
+                snapshot_hash="missing-raw",
+            )
+        ),
+        forecasters=(ConstantForecaster(0.10), ConstantForecaster(0.10)),
+        calibrator=NetcalCalibrator(),
+        sizer=FixedSizer(),
+        settings=PMSSettings(
+            mode=RunMode.LIVE,
+            controller=ControllerSettings(min_volume=0.0),
+            risk=RiskSettings(min_order_usdc=1.0),
+        ),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is None
+    assert pipeline.last_diagnostic is not None
+    assert pipeline.last_diagnostic.code == "missing_required_factors"
+
+
+@pytest.mark.asyncio
+async def test_strategy_does_not_trade_when_required_raw_factor_is_stale() -> None:
+    pipeline = ControllerPipeline(
+        strategy=_active_strategy(),
+        factor_reader=SnapshotReader(
+            FactorSnapshot(
+                values={("metaculus_prior", ""): 0.8},
+                missing_factors=(),
+                stale_factors=(("metaculus_prior", ""),),
+                snapshot_hash="stale-raw",
+            )
+        ),
+        forecasters=(ConstantForecaster(0.8),),
+        calibrator=NetcalCalibrator(),
+        sizer=FixedSizer(),
+        settings=PMSSettings(
+            mode=RunMode.LIVE,
+            controller=ControllerSettings(min_volume=0.0),
+            risk=RiskSettings(min_order_usdc=1.0),
+        ),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is None
+    assert pipeline.last_diagnostic is not None
+    assert pipeline.last_diagnostic.code == "stale_required_factors"
+
+
+def test_disabled_llm_forecaster_does_not_emit_neutral_runtime_factor() -> None:
+    result = LLMForecaster(config=LLMSettings(enabled=False)).predict(_signal())
+
+    assert result is None
+
+
+def test_posterior_branch_missing_all_inputs_does_not_emit_statistical_probability() -> None:
+    branch_probabilities = evaluate_branch_probabilities(
+        (
+            FactorCompositionStep(
+                factor_id="metaculus_prior",
+                role="posterior_prior",
+                param="",
+                weight=2.0,
+                threshold=None,
+            ),
+            FactorCompositionStep(
+                factor_id="yes_count",
+                role="posterior_success",
+                param="",
+                weight=1.0,
+                threshold=None,
+            ),
+            FactorCompositionStep(
+                factor_id="no_count",
+                role="posterior_failure",
+                param="",
+                weight=1.0,
+                threshold=None,
+            ),
+        ),
+        {("yes_price", ""): 0.10},
+    )
+
+    assert "statistical" not in branch_probabilities
+
+
+def _live_settings(*, tif: str = "IOC") -> PMSSettings:
+    return PMSSettings(
+        mode=RunMode.LIVE,
+        live_trading_enabled=True,
+        auto_migrate_default_v2=False,
+        controller=ControllerSettings(time_in_force=tif, min_volume=0.0),
+        risk=RiskSettings(
+            max_position_per_market=1_000.0,
+            max_total_exposure=10_000.0,
+            min_order_usdc=1.0,
+        ),
+        polymarket=PolymarketSettings(
+            private_key="private-key",
+            api_key="api-key",
+            api_secret="api-secret",
+            api_passphrase="passphrase",
+            signature_type=1,
+            funder_address="0xabc",
+        ),
+    )
+
+
+def _decision(
+    *,
+    decision_id: str = "d-live-blocker",
+    time_in_force: TimeInForce = TimeInForce.IOC,
+    side: Literal["BUY", "SELL"] = Side.BUY.value,
+    action: Literal["BUY", "SELL"] | None = Side.BUY.value,
+    intent_key: str | None = None,
+) -> TradeDecision:
+    return TradeDecision(
+        decision_id=decision_id,
+        market_id="m-live-blocker",
+        token_id="t-yes",
+        venue="polymarket",
+        side=side,
+        notional_usdc=10.0,
+        order_type="limit",
+        max_slippage_bps=50,
+        stop_conditions=["unit-test"],
+        prob_estimate=0.7,
+        expected_edge=0.2,
+        time_in_force=time_in_force,
+        opportunity_id=f"op-{decision_id}",
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        action=action,
+        limit_price=0.4,
+        outcome="YES",
+        intent_key=intent_key,
+    )
+
+
+def test_live_mode_rejects_gtc_until_open_order_ledger_exists() -> None:
+    with pytest.raises(LiveTradingDisabledError, match="LIVE GTC disabled"):
+        validate_live_mode_ready(_live_settings(tif="GTC"))
+
+
+def test_trade_decision_rejects_action_side_mismatch() -> None:
+    with pytest.raises(ValueError, match="side/action mismatch"):
+        _decision(side=Side.SELL.value, action=Side.BUY.value)
+
+
+@dataclass
+class AllowFirstOrderGate:
+    async def approve_first_order(self, preview: LiveOrderPreview) -> bool:
+        del preview
+        return True
+
+    async def consume(self, preview: LiveOrderPreview) -> None:
+        del preview
+
+
+@dataclass
+class RecordingClient:
+    submitted: list[object]
+
+    async def submit_order(
+        self,
+        order: object,
+        credentials: object,
+    ) -> PolymarketOrderResult:
+        del credentials
+        self.submitted.append(order)
+        return PolymarketOrderResult(
+            order_id="pm-live-blocker",
+            status=OrderStatus.MATCHED.value,
+            raw_status="matched",
+            filled_notional_usdc=10.0,
+            remaining_notional_usdc=0.0,
+            fill_price=0.4,
+            filled_quantity=25.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_requires_pre_submit_quote_guard() -> None:
+    client = RecordingClient(submitted=[])
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=client,
+        operator_gate=AllowFirstOrderGate(),
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="pre-submit quote guard"):
+        await actuator.execute(_decision(), _portfolio())
+
+    assert client.submitted == []
+
+
+@dataclass
+class UnknownSubmissionAdapter:
+    async def execute(
+        self,
+        decision: TradeDecision,
+        portfolio: Portfolio | None = None,
+    ) -> OrderState:
+        del decision, portfolio
+        raise PolymarketSubmissionUnknownError("timeout")
+
+
+@pytest.mark.asyncio
+async def test_executor_attaches_submission_unknown_order_state_before_reraising() -> None:
+    decision = _decision()
+    executor = ActuatorExecutor(
+        adapter=UnknownSubmissionAdapter(),
+        risk=RiskManager(
+            RiskSettings(max_position_per_market=1_000.0, max_total_exposure=10_000.0)
+        ),
+        feedback=ActuatorFeedback(cast(FeedbackStore, InMemoryFeedbackStore())),
+    )
+
+    with pytest.raises(PolymarketSubmissionUnknownError) as exc_info:
+        await executor.execute(decision, _portfolio())
+
+    order_state = exc_info.value.order_state
+    assert order_state is not None
+    assert order_state.decision_id == decision.decision_id
+    assert order_state.raw_status == "submission_unknown"
+
+
+@dataclass
+class RecordingOrderStore:
+    inserted: list[OrderState]
+
+    async def insert(self, order: OrderState) -> None:
+        self.inserted.append(order)
+
+
+@dataclass
+class RaisingUnknownExecutor:
+    order_state: OrderState
+
+    async def execute(
+        self,
+        decision: TradeDecision,
+        portfolio: Portfolio,
+        *,
+        dedup_acquired: bool = False,
+    ) -> OrderState:
+        del decision, portfolio, dedup_acquired
+        error = PolymarketSubmissionUnknownError("timeout")
+        error.order_state = self.order_state
+        raise error
+
+
+def _submission_unknown_order(decision: TradeDecision) -> OrderState:
+    now = datetime(2026, 4, 26, tzinfo=UTC)
+    return OrderState(
+        order_id=f"unknown-{decision.decision_id}",
+        decision_id=decision.decision_id,
+        status=OrderStatus.INVALID.value,
+        market_id=decision.market_id,
+        token_id=decision.token_id,
+        venue=decision.venue,
+        requested_notional_usdc=decision.notional_usdc,
+        filled_notional_usdc=0.0,
+        remaining_notional_usdc=decision.notional_usdc,
+        fill_price=None,
+        submitted_at=now,
+        last_updated_at=now,
+        raw_status="submission_unknown",
+        strategy_id=decision.strategy_id,
+        strategy_version_id=decision.strategy_version_id,
+        filled_quantity=0.0,
+    )
+
+
+def _mark_controller_done(runner: Runner) -> None:
+    import asyncio
+
+    runner._controller_task = asyncio.create_task(asyncio.sleep(0))  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_runner_persists_submission_unknown_and_suspends_live_orders() -> None:
+    decision = _decision()
+    order_state = _submission_unknown_order(decision)
+    runner = Runner(config=_live_settings())
+    runner.actuator_executor = cast(Any, RaisingUnknownExecutor(order_state))
+    order_store = RecordingOrderStore(inserted=[])
+    runner.order_store = cast(Any, order_store)
+    _mark_controller_done(runner)
+
+    await runner._decision_queue.put(  # noqa: SLF001
+        ActuatorWorkItem(decision=decision, signal=None)
+    )
+
+    await runner._actuator_loop()  # noqa: SLF001
+
+    assert runner.state.orders == [order_state]
+    assert order_store.inserted == [order_state]
+    assert runner.live_trading_suspended is True
+
+
+@pytest.mark.asyncio
+async def test_in_memory_dedup_blocks_same_economic_intent_key() -> None:
+    store = InMemoryDedupStore()
+    first = _decision(decision_id="d-intent-1", intent_key="intent:same")
+    second = _decision(decision_id="d-intent-2", intent_key="intent:same")
+
+    assert await store.acquire(first) is True
+    assert await store.acquire(second) is False

--- a/tests/unit/test_runner_active_perception.py
+++ b/tests/unit/test_runner_active_perception.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 import pytest
 
 from pms.config import (
+    ControllerSettings,
     DatabaseSettings,
     PMSSettings,
     PolymarketSettings,
@@ -167,6 +168,9 @@ def _settings(mode: RunMode) -> PMSSettings:
         risk=RiskSettings(
             max_position_per_market=1000.0,
             max_total_exposure=10_000.0,
+        ),
+        controller=ControllerSettings(
+            time_in_force="IOC" if mode == RunMode.LIVE else "GTC"
         ),
         polymarket=_live_polymarket_settings() if mode == RunMode.LIVE else PolymarketSettings(),
     )
@@ -606,6 +610,7 @@ async def test_reselection_caps_subscription_asset_ids(
                 pool_max_size=10,
             ),
             sensor=SensorSettings(max_subscription_asset_ids=2),
+            controller=ControllerSettings(time_in_force="IOC"),
             polymarket=_live_polymarket_settings(),
         ),
         historical_data_path=FIXTURE_PATH,
@@ -710,6 +715,7 @@ async def test_refresh_subscription_caps_asset_ids() -> None:
                 pool_max_size=10,
             ),
             sensor=SensorSettings(max_subscription_asset_ids=2),
+            controller=ControllerSettings(time_in_force="IOC"),
             polymarket=_live_polymarket_settings(),
         ),
         historical_data_path=FIXTURE_PATH,

--- a/tests/unit/test_runner_cp01.py
+++ b/tests/unit/test_runner_cp01.py
@@ -16,7 +16,13 @@ from pms.actuator.adapters.polymarket import (
     PolymarketActuator,
     PolymarketSDKClient,
 )
-from pms.config import DatabaseSettings, PMSSettings, PolymarketSettings, RiskSettings
+from pms.config import (
+    ControllerSettings,
+    DatabaseSettings,
+    PMSSettings,
+    PolymarketSettings,
+    RiskSettings,
+)
 from pms.core.enums import RunMode
 from pms.core.models import MarketSignal, OrderState, Portfolio
 from pms.market_selection.merge import StrategyMarketSet
@@ -137,6 +143,7 @@ def _settings() -> PMSSettings:
             max_position_per_market=1000.0,
             max_total_exposure=10_000.0,
         ),
+        controller=ControllerSettings(time_in_force="IOC"),
         polymarket=_live_polymarket_settings(),
     )
 
@@ -157,6 +164,7 @@ def test_runner_builds_live_polymarket_adapter_with_sdk_client_and_file_gate(
             funder_address="0xabc",
             first_live_order_approval_path=str(tmp_path / "approval.json"),
         ),
+        controller=ControllerSettings(time_in_force="IOC"),
     )
     runner = Runner(config=settings, historical_data_path=FIXTURE_PATH)
 

--- a/tests/unit/test_strategy_change_reselection.py
+++ b/tests/unit/test_strategy_change_reselection.py
@@ -10,7 +10,13 @@ from typing import Any, cast
 
 import pytest
 
-from pms.config import DatabaseSettings, PMSSettings, PolymarketSettings, RiskSettings
+from pms.config import (
+    ControllerSettings,
+    DatabaseSettings,
+    PMSSettings,
+    PolymarketSettings,
+    RiskSettings,
+)
 from pms.core.enums import RunMode
 from pms.core.models import MarketSignal
 from pms.market_selection.merge import StrategyMarketSet
@@ -240,6 +246,7 @@ def _settings(mode: RunMode) -> PMSSettings:
             max_position_per_market=1000.0,
             max_total_exposure=10_000.0,
         ),
+        controller=ControllerSettings(time_in_force="IOC"),
         polymarket=_live_polymarket_settings() if mode == RunMode.LIVE else PolymarketSettings(),
     )
 
@@ -489,7 +496,7 @@ class _AcquirableClosablePool:
 async def test_runner_constructs_single_strategy_registry_with_callback_for_bootstrap_and_wiring(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    connection = FakeConnection(fetchval_results=["default-v1"])
+    connection = FakeConnection(fetchval_results=[0, "default-v1"])
     fake_pool = _AcquirableClosablePool(connection=connection)
     discovery = IdleDiscoverySensor()
     market_data = RecordingMarketDataSensor()
@@ -564,6 +571,7 @@ async def test_runner_constructs_single_strategy_registry_with_callback_for_boot
             max_position_per_market=1000.0,
             max_total_exposure=10_000.0,
         ),
+        controller=ControllerSettings(time_in_force="IOC"),
         polymarket=_live_polymarket_settings(),
     )
 

--- a/tests/unit/test_strategy_lifecycle_cp08.py
+++ b/tests/unit/test_strategy_lifecycle_cp08.py
@@ -11,7 +11,13 @@ from typing import Any, cast
 
 import pytest
 
-from pms.config import DatabaseSettings, PMSSettings, PolymarketSettings, RiskSettings
+from pms.config import (
+    ControllerSettings,
+    DatabaseSettings,
+    PMSSettings,
+    PolymarketSettings,
+    RiskSettings,
+)
 from pms.core.enums import RunMode, TimeInForce
 from pms.core.models import MarketSignal, Opportunity, Portfolio, TradeDecision
 from pms.market_selection.merge import StrategyMarketSet
@@ -202,6 +208,7 @@ def _settings() -> PMSSettings:
             max_position_per_market=1000.0,
             max_total_exposure=10_000.0,
         ),
+        controller=ControllerSettings(time_in_force="IOC"),
         polymarket=_live_polymarket_settings(),
     )
 

--- a/tests/unit/test_strategy_projections.py
+++ b/tests/unit/test_strategy_projections.py
@@ -23,6 +23,9 @@ EXPECTED_FIELD_TYPES: dict[str, dict[str, Any]] = {
         "param": str,
         "weight": float,
         "threshold": float | None,
+        "required": bool,
+        "freshness_sla_s": float | None,
+        "allow_neutral_fallback": bool,
     },
     "StrategyConfig": {
         "strategy_id": str,

--- a/tests/unit/test_version_hash_stability.py
+++ b/tests/unit/test_version_hash_stability.py
@@ -12,7 +12,7 @@ import pytest
 
 
 EXPECTED_DEFAULT_VERSION_ID = (
-    "948a16db12a4e8b9d79cc467eed253eaf911e088abbd3f763c882e2d4c048548"
+    "5c79a9e6f63cc4fdcfe22cf6970494eed63b5e379072aef380d71f7d47120451"
 )
 
 


### PR DESCRIPTION
## Summary
- fail closed in LIVE when required raw factors are missing or stale, and prevent disabled/placeholder forecasters plus empty posterior inputs from creating neutral fake edge
- reject LIVE GTC until open-order reservation exists; add pre-submit quote guard plumbing for Polymarket live orders
- persist `submission_unknown` order state, suspend live trading, and reject live startup with unresolved unknown-submit incidents
- add deterministic `intent_key` deduplication with schema and Alembic migration
- enforce `TradeDecision.side/action` consistency and expand live-blocker regression coverage

## Why
This addresses the current no-go blockers for autonomous live trading by making unsafe runtime states fail closed rather than allowing live order submission with missing evidence, resting-order exposure gaps, unknown-submit ambiguity, stale quotes, or duplicate economic intents.

## Validation
- `uv run pytest -q` -> 733 passed, 157 skipped
- `uv run mypy src/ tests/ --strict` -> clean
- `uv run lint-imports` -> 7 kept, 0 broken
- `git diff --check` -> clean

## Notes
This PR intentionally chooses conservative fail-closed behavior. Autonomous live trading still needs a real venue quote provider and venue balance/open-order reconciliation before it should be treated as fully live-ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic intent keys for improved order deduplication and tracking.
  * Added live market quote validation before order submission to enhance execution safety.
  * Added factor staleness detection to prevent trading on outdated market data.

* **Configuration**
  * Added restrictions blocking GTC time-in-force orders in live trading mode.
  * Added freshness SLA configuration for market data factors.

* **Bug Fixes**
  * Improved handling of submission failures with better error persistence and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->