### PR TITLE
[codex] close live reliability gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 # Local output directories (pms-v1 harness artifacts — kept ignored so a
 # stale working copy can't accidentally commit them into v2).
 reports/
+.data/
 
 # Rust
 target/

--- a/alembic/versions/0012_order_intent_cancelled_market_resolved.py
+++ b/alembic/versions/0012_order_intent_cancelled_market_resolved.py
@@ -1,0 +1,65 @@
+"""Allow market-resolved cancellation as an order intent outcome."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from alembic import op
+
+
+revision = "0012_cancelled_market_resolved"
+down_revision = "0011_live_reconcile_audit"
+branch_labels = None
+depends_on = None
+
+
+ORDER_INTENT_OUTCOMES: Final[tuple[str, ...]] = (
+    "matched",
+    "invalid",
+    "rejected",
+    "venue_rejection",
+    "submission_unknown",
+    "cancelled_ttl",
+    "cancelled_limit_invalidated",
+    "cancelled_session_end",
+    "cancelled_market_resolved",
+)
+
+_DOWNGRADE_OUTCOMES: Final[tuple[str, ...]] = (
+    "matched",
+    "invalid",
+    "rejected",
+    "venue_rejection",
+    "submission_unknown",
+    "cancelled_ttl",
+    "cancelled_limit_invalidated",
+    "cancelled_session_end",
+)
+
+
+def _check_constraint_sql(outcomes: tuple[str, ...]) -> str:
+    quoted = ", ".join(f"'{outcome}'" for outcome in outcomes)
+    return (
+        "ALTER TABLE order_intents "
+        "ADD CONSTRAINT order_intents_outcome_check "
+        f"CHECK (outcome IS NULL OR outcome IN ({quoted}))"
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE order_intents DROP CONSTRAINT IF EXISTS order_intents_outcome_check"
+    )
+    op.execute(_check_constraint_sql(ORDER_INTENT_OUTCOMES))
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE order_intents DROP CONSTRAINT IF EXISTS order_intents_outcome_check"
+    )
+    op.execute(
+        "UPDATE order_intents "
+        "SET outcome = NULL, released_at = NULL "
+        "WHERE outcome = 'cancelled_market_resolved'"
+    )
+    op.execute(_check_constraint_sql(_DOWNGRADE_OUTCOMES))

--- a/alembic/versions/0013_markets_live_status_fields.py
+++ b/alembic/versions/0013_markets_live_status_fields.py
@@ -1,0 +1,35 @@
+"""Add live tradability status fields to markets."""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0013_market_status_fields"
+down_revision = "0012_cancelled_market_resolved"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE markets
+          ADD COLUMN IF NOT EXISTS active BOOLEAN,
+          ADD COLUMN IF NOT EXISTS closed BOOLEAN,
+          ADD COLUMN IF NOT EXISTS accepting_orders BOOLEAN,
+          ADD COLUMN IF NOT EXISTS status_updated_at TIMESTAMPTZ
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE markets
+          DROP COLUMN IF EXISTS status_updated_at,
+          DROP COLUMN IF EXISTS accepting_orders,
+          DROP COLUMN IF EXISTS closed,
+          DROP COLUMN IF EXISTS active
+        """
+    )

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,6 +12,8 @@
 
 mode: backtest                 # backtest | paper | live
 live_trading_enabled: false    # must be true to switch into live mode
+live_account_reconciliation_required: false
+live_emergency_audit_path: .data/live-emergency-audit.jsonl
 
 risk:
   max_position_per_market: 100.0
@@ -28,6 +30,13 @@ controller:
   min_volume: 0.0
   max_slippage_bps: 50
   time_in_force: GTC
+  max_book_age_ms: 1000.0
+  allowed_book_clock_skew_ms: 250.0
+  max_spread_bps: 100.0
+  strict_factor_gates: true
+  quote_source: postgres_snapshot  # postgres_snapshot | venue_direct | dual
+  direct_quote_min_notional_usdc: 100.0
+  dual_quote_max_price_delta_bps: 25.0
 
 polymarket:
   host: https://clob.polymarket.com

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,7 +12,7 @@
 
 mode: backtest                 # backtest | paper | live
 live_trading_enabled: false    # must be true to switch into live mode
-live_account_reconciliation_required: false
+live_account_reconciliation_required: true
 live_emergency_audit_path: .data/live-emergency-audit.jsonl
 
 risk:

--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -24,6 +24,8 @@ Export credentials in the operator shell or secret manager that launches PMS:
 ```bash
 export PMS_MODE=live
 export PMS_LIVE_TRADING_ENABLED=true
+export PMS_LIVE_ACCOUNT_RECONCILIATION_REQUIRED=true
+export PMS_CONTROLLER__TIME_IN_FORCE=IOC
 export PMS_POLYMARKET__PRIVATE_KEY=...
 export PMS_POLYMARKET__API_KEY=...
 export PMS_POLYMARKET__API_SECRET=...
@@ -41,9 +43,9 @@ and `funder_address`.
 
 The Polymarket adapter requires a first-order operator approval before any
 venue submission. The preview includes max notional, venue, market, token,
-side, limit price, and max slippage. If the approval gate is absent or denies
-the preview, the adapter raises `OperatorApprovalRequiredError` and submits
-nothing.
+side, outcome, market slug/question when available, limit price, and max
+slippage. If the approval gate is absent or denies the preview, the adapter
+raises `OperatorApprovalRequiredError` and submits nothing.
 
 For the built-in file gate, write a JSON approval file that exactly matches the
 preview:
@@ -56,6 +58,7 @@ preview:
   "market_id": "market-condition-id",
   "token_id": "outcome-token-id",
   "side": "BUY",
+  "outcome": "NO",
   "limit_price": 0.4,
   "max_slippage_bps": 50
 }

--- a/schema.sql
+++ b/schema.sql
@@ -24,7 +24,11 @@ ALTER TABLE markets
     ADD COLUMN IF NOT EXISTS last_trade_price NUMERIC(6,4),
     ADD COLUMN IF NOT EXISTS liquidity NUMERIC,
     ADD COLUMN IF NOT EXISTS spread_bps INTEGER,
-    ADD COLUMN IF NOT EXISTS price_updated_at TIMESTAMPTZ;
+    ADD COLUMN IF NOT EXISTS price_updated_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS active BOOLEAN,
+    ADD COLUMN IF NOT EXISTS closed BOOLEAN,
+    ADD COLUMN IF NOT EXISTS accepting_orders BOOLEAN,
+    ADD COLUMN IF NOT EXISTS status_updated_at TIMESTAMPTZ;
 
 CREATE INDEX IF NOT EXISTS idx_markets_price_updated_at
     ON markets (price_updated_at DESC)
@@ -314,7 +318,7 @@ CREATE TABLE IF NOT EXISTS order_intents (
         OR reconciliation_status IN ('filled', 'not_found', 'open')
     ),
     CONSTRAINT order_intents_outcome_check
-        CHECK (outcome IS NULL OR outcome IN ('matched', 'invalid', 'rejected', 'venue_rejection', 'submission_unknown', 'cancelled_ttl', 'cancelled_limit_invalidated', 'cancelled_session_end'))
+        CHECK (outcome IS NULL OR outcome IN ('matched', 'invalid', 'rejected', 'venue_rejection', 'submission_unknown', 'cancelled_ttl', 'cancelled_limit_invalidated', 'cancelled_session_end', 'cancelled_market_resolved'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_order_intents_strategy_acquired_at_desc

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -139,6 +139,13 @@ class LiveOrderBookClient(Protocol):
     ) -> LiveVenueBook: ...
 
 
+class LiveVenueAccountClient(Protocol):
+    async def read_account_snapshot(
+        self,
+        credentials: VenueCredentials,
+    ) -> VenueAccountSnapshot: ...
+
+
 class BookQuoteStore(Protocol):
     async def read_market(self, market_id: str) -> Market | None: ...
 
@@ -340,6 +347,12 @@ class PolymarketSDKClient:
     ) -> LiveVenueBook:
         return await asyncio.to_thread(self._read_order_book_sync, order, credentials)
 
+    async def read_account_snapshot(
+        self,
+        credentials: VenueCredentials,
+    ) -> VenueAccountSnapshot:
+        return await asyncio.to_thread(self._read_account_snapshot_sync, credentials)
+
     def _submit_order_sync(
         self,
         order: PolymarketOrderRequest,
@@ -449,17 +462,10 @@ class PolymarketSDKClient:
             token_id=order.token_id,
         )
 
-
-@dataclass(frozen=True)
-class PolymarketVenueAccountReconciler:
-    client: PolymarketSDKClient = field(default_factory=PolymarketSDKClient)
-    position_tolerance_shares: float = 1e-6
-    notional_tolerance_usdc: float = 1e-4
-
-    async def snapshot(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
-        return await asyncio.to_thread(self._snapshot_sync, credentials)
-
-    def _snapshot_sync(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+    def _read_account_snapshot_sync(
+        self,
+        credentials: VenueCredentials,
+    ) -> VenueAccountSnapshot:
         try:
             sdk = importlib.import_module("py_clob_client_v2")
         except ModuleNotFoundError:
@@ -468,20 +474,47 @@ class PolymarketVenueAccountReconciler:
                 "with `uv sync --extra live` before enabling LIVE mode."
             )
             raise LiveTradingDisabledError(msg) from None
-        client = _build_sdk_client(sdk, credentials)
-        open_orders = _order_states_from_open_orders(
-            _get_sdk_open_orders(client),
-            credentials=credentials,
-        )
-        positions = _positions_from_sdk_positions(
-            _get_sdk_positions(client, credentials),
-            credentials=credentials,
-        )
+
+        try:
+            client = _build_sdk_client(sdk, credentials)
+            open_orders = _order_states_from_open_orders(
+                _get_sdk_open_orders(client),
+                credentials=credentials,
+            )
+            positions = _positions_from_sdk_positions(
+                _get_sdk_positions(client, credentials),
+                credentials=credentials,
+            )
+            balances = _get_sdk_balances(client, sdk)
+        except Exception as exc:  # noqa: BLE001
+            redacted = _redacted_exception_message(exc, credentials)
+            logger.warning(
+                "Polymarket live account snapshot failed (%s): %s",
+                type(exc).__name__,
+                redacted,
+            )
+            msg = (
+                "Polymarket live account snapshot failed "
+                f"({type(exc).__name__}); venue error redacted"
+            )
+            raise LiveTradingDisabledError(msg) from None
+
         return VenueAccountSnapshot(
-            balances={},
+            balances=balances,
             open_orders=tuple(open_orders),
             positions=tuple(positions),
         )
+
+
+@dataclass(frozen=True)
+class PolymarketVenueAccountReconciler:
+    client: LiveVenueAccountClient = field(default_factory=PolymarketSDKClient)
+    position_tolerance_shares: float = 1e-6
+    notional_tolerance_usdc: float = 1e-4
+    cash_tolerance_usdc: float = 1e-4
+
+    async def snapshot(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+        return await self.client.read_account_snapshot(credentials)
 
     async def compare(
         self,
@@ -493,6 +526,15 @@ class PolymarketVenueAccountReconciler:
             mismatches.append(
                 f"venue has {len(venue_snapshot.open_orders)} open orders; "
                 "PMS has no durable live open-order ledger yet"
+            )
+        usdc_balance = _venue_usdc_balance(venue_snapshot.balances)
+        if (
+            usdc_balance is not None
+            and usdc_balance + self.cash_tolerance_usdc < db_portfolio.free_usdc
+        ):
+            mismatches.append(
+                "venue USDC balance below PMS free cash: "
+                f"venue={usdc_balance:.8f} DB={db_portfolio.free_usdc:.8f}"
             )
         mismatches.extend(
             _compare_positions(
@@ -1056,6 +1098,79 @@ def _get_sdk_positions(client: object, credentials: VenueCredentials) -> object:
     return ()
 
 
+def _get_sdk_balances(client: object, sdk: object) -> dict[str, float]:
+    for response in _sdk_balance_responses(client, sdk):
+        usdc = _usdc_balance_from_response(response)
+        if usdc is not None:
+            return {"USDC": usdc}
+    return {}
+
+
+def _sdk_balance_responses(client: object, sdk: object) -> list[object]:
+    responses: list[object] = []
+    balance_allowance = getattr(client, "get_balance_allowance", None)
+    if callable(balance_allowance):
+        params_cls = getattr(sdk, "BalanceAllowanceParams", None)
+        asset_type_cls = getattr(sdk, "AssetType", None)
+        asset_type = getattr(asset_type_cls, "COLLATERAL", "COLLATERAL")
+        if callable(params_cls):
+            try:
+                params = params_cls(asset_type=asset_type)
+                responses.append(balance_allowance(params=params))
+            except TypeError:
+                try:
+                    params = params_cls(asset_type=asset_type)
+                    responses.append(balance_allowance(params))
+                except TypeError:
+                    pass
+        try:
+            responses.append(balance_allowance(asset_type=asset_type))
+        except TypeError:
+            pass
+    for method_name in ("get_balance", "get_balances", "getBalance", "getBalances"):
+        method = getattr(client, method_name, None)
+        if callable(method):
+            try:
+                responses.append(method())
+            except TypeError:
+                pass
+    return responses
+
+
+def _usdc_balance_from_response(response: object) -> float | None:
+    direct = _coerce_float_or_none(response)
+    if direct is not None:
+        return direct
+    if isinstance(response, Sequence) and not isinstance(response, (str, bytes)):
+        for item in response:
+            asset = _response_value(item, "asset", "asset_type", "currency", "token")
+            if asset is None or str(asset).upper() in {"USDC", "COLLATERAL"}:
+                value = _coerce_float_or_none(
+                    _response_value(
+                        item,
+                        "balance",
+                        "available",
+                        "available_balance",
+                        "cash",
+                        "usdc",
+                    )
+                )
+                if value is not None:
+                    return value
+        return None
+    return _coerce_float_or_none(
+        _response_value(
+            response,
+            "balance",
+            "available",
+            "available_balance",
+            "cash",
+            "usdc",
+            "collateral",
+        )
+    )
+
+
 def _sdk_order_type(order_type_cls: object, order: PolymarketOrderRequest) -> object:
     # Polymarket SDK enum: GTC (rest), FAK (fill-and-kill = IOC), FOK (all-or-nothing),
     # GTD (good-till-date). PMS TimeInForce maps GTC→GTC, IOC→FAK, FOK→FOK
@@ -1288,7 +1403,7 @@ def _venue_book_from_sdk_response(
     )
     raw_hash = _response_value(response, "hash", "book_hash", "bookHash")
     quote_hash = str(raw_hash or f"venue:{token_id}:{book_ts.isoformat()}")
-    market_status = str(_response_value(response, "market_status", "status") or "open")
+    market_status = _venue_market_status_from_response(response)
     return LiveVenueBook(
         market_id=market_id,
         token_id=token_id,
@@ -1340,6 +1455,40 @@ def _book_levels_from_response_side(
             )
         )
     return levels
+
+
+def _venue_market_status_from_response(response: object) -> str:
+    if _coerce_bool_or_none(_response_value(response, "closed", "is_closed")) is True:
+        return "closed"
+    if _coerce_bool_or_none(_response_value(response, "active", "is_active")) is False:
+        return "inactive"
+    accepting_orders = _coerce_bool_or_none(
+        _response_value(response, "accepting_orders", "acceptingOrders")
+    )
+    if accepting_orders is False:
+        return "not_accepting_orders"
+    raw_status = _response_value(response, "market_status", "status")
+    if raw_status is None:
+        return "open"
+    normalized = str(raw_status).strip().lower()
+    return normalized or "open"
+
+
+def _coerce_bool_or_none(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y"}:
+            return True
+        if normalized in {"false", "0", "no", "n"}:
+            return False
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    return None
 
 
 def _coerce_datetime_or_now(value: object) -> datetime:
@@ -1479,6 +1628,13 @@ def _compare_positions(
                 f"venue={venue_position.locked_usdc:.8f}"
             )
     return mismatches
+
+
+def _venue_usdc_balance(balances: Mapping[str, float]) -> float | None:
+    for key, value in balances.items():
+        if key.upper() in {"USDC", "COLLATERAL"}:
+            return value
+    return None
 
 
 def _position_key(position: Position) -> tuple[str, str | None, str]:

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -5,11 +5,11 @@ import importlib
 import json
 import logging
 import math
-from collections.abc import Mapping
-from dataclasses import dataclass, field
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Final, Protocol, cast
+from typing import Any, Callable, Final, Literal, Protocol, cast
 from uuid import uuid4
 
 from pms.config import PMSSettings, validate_live_mode_ready
@@ -20,8 +20,11 @@ from pms.core.models import (
     LiveTradingDisabledError,
     Market,
     OrderState,
+    Position,
     Portfolio,
+    ReconciliationReport,
     TradeDecision,
+    VenueAccountSnapshot,
     VenueCredentials,
 )
 
@@ -98,6 +101,18 @@ class LivePreSubmitQuote:
     spread_bps: float
     quote_hash: str
     book_ts: datetime
+    source: Literal["postgres_snapshot", "venue_direct", "dual"] = "postgres_snapshot"
+
+
+@dataclass(frozen=True)
+class LiveVenueBook:
+    market_id: str
+    token_id: str
+    bids: tuple[BookLevel, ...]
+    asks: tuple[BookLevel, ...]
+    book_ts: datetime
+    quote_hash: str
+    market_status: str = "open"
 
 
 class PolymarketClient(Protocol):
@@ -114,6 +129,14 @@ class LiveQuoteProvider(Protocol):
         order: PolymarketOrderRequest,
         credentials: VenueCredentials,
     ) -> LivePreSubmitQuote: ...
+
+
+class LiveOrderBookClient(Protocol):
+    async def read_order_book(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+    ) -> LiveVenueBook: ...
 
 
 class BookQuoteStore(Protocol):
@@ -147,6 +170,7 @@ class MissingLiveQuoteProvider:
 class PolymarketBookQuoteProvider:
     store: BookQuoteStore
     clock: Callable[[], datetime] = field(default_factory=lambda: _utc_now)
+    allowed_clock_skew_ms: float = 250.0
 
     async def quote(
         self,
@@ -163,40 +187,95 @@ class PolymarketBookQuoteProvider:
         if snapshot is None:
             msg = f"Polymarket book snapshot missing for token {order.token_id}"
             raise LiveTradingDisabledError(msg)
+        _raise_if_future_book_ts(
+            snapshot.ts,
+            now=now,
+            allowed_clock_skew_ms=self.allowed_clock_skew_ms,
+        )
         levels = await self.store.read_levels_for_snapshot(snapshot.id)
-        bid_levels = sorted(
-            (level for level in levels if level.side == "BUY"),
-            key=lambda level: level.price,
-            reverse=True,
-        )
-        ask_levels = sorted(
-            (level for level in levels if level.side == "SELL"),
-            key=lambda level: level.price,
-        )
-        executable_levels = (
-            [level for level in ask_levels if level.price <= order.price]
-            if order.side == "BUY"
-            else [level for level in bid_levels if level.price >= order.price]
-        )
-        best_executable_price = (
-            executable_levels[0].price if executable_levels else order.price
-        )
-        executable_notional_usdc = sum(
-            max(0.0, level.price) * max(0.0, level.size)
-            for level in executable_levels
-        )
-        book_age_ms = max(0.0, (now - snapshot.ts).total_seconds() * 1000.0)
-        best_bid = bid_levels[0].price if bid_levels else None
-        best_ask = ask_levels[0].price if ask_levels else None
-        return LivePreSubmitQuote(
+        return _quote_from_levels(
+            order=order,
             market_status=_market_status(market, now),
-            book_age_ms=book_age_ms,
-            executable_notional_usdc=executable_notional_usdc,
-            best_executable_price=best_executable_price,
-            spread_bps=_spread_bps(best_bid=best_bid, best_ask=best_ask),
+            bid_levels=[level for level in levels if level.side == "BUY"],
+            ask_levels=[level for level in levels if level.side == "SELL"],
             quote_hash=snapshot.hash or f"snapshot:{snapshot.id}",
             book_ts=snapshot.ts,
+            now=now,
+            source="postgres_snapshot",
         )
+
+
+@dataclass(frozen=True)
+class PolymarketDirectQuoteProvider:
+    book_client: LiveOrderBookClient
+    clock: Callable[[], datetime] = field(default_factory=lambda: _utc_now)
+    allowed_clock_skew_ms: float = 250.0
+
+    async def quote(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+    ) -> LivePreSubmitQuote:
+        now = self.clock()
+        book = await self.book_client.read_order_book(order, credentials)
+        _raise_if_future_book_ts(
+            book.book_ts,
+            now=now,
+            allowed_clock_skew_ms=self.allowed_clock_skew_ms,
+        )
+        return _quote_from_levels(
+            order=order,
+            market_status=book.market_status,
+            bid_levels=book.bids,
+            ask_levels=book.asks,
+            quote_hash=book.quote_hash,
+            book_ts=book.book_ts,
+            now=now,
+            source="venue_direct",
+        )
+
+
+@dataclass(frozen=True)
+class PolymarketRoutingQuoteProvider:
+    snapshot_provider: LiveQuoteProvider
+    direct_provider: LiveQuoteProvider
+    settings: PMSSettings
+
+    async def quote(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+    ) -> LivePreSubmitQuote:
+        return await self.quote_for_order(
+            order,
+            credentials,
+            first_live_order=False,
+        )
+
+    async def quote_for_order(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+        *,
+        first_live_order: bool,
+    ) -> LivePreSubmitQuote:
+        source = self.settings.controller.quote_source
+        if (
+            source == "venue_direct"
+            or first_live_order
+            or _requires_direct_quote(order, self.settings)
+        ):
+            return await self.direct_provider.quote(order, credentials)
+        if source == "dual":
+            snapshot_quote = await self.snapshot_provider.quote(order, credentials)
+            direct_quote = await self.direct_provider.quote(order, credentials)
+            _validate_dual_quote_match(
+                snapshot_quote,
+                direct_quote,
+                self.settings,
+            )
+            return replace(direct_quote, source="dual")
+        return await self.snapshot_provider.quote(order, credentials)
 
 
 class FirstLiveOrderGate(Protocol):
@@ -253,6 +332,13 @@ class PolymarketSDKClient:
         credentials: VenueCredentials,
     ) -> PolymarketOrderResult:
         return await asyncio.to_thread(self._submit_order_sync, order, credentials)
+
+    async def read_order_book(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+    ) -> LiveVenueBook:
+        return await asyncio.to_thread(self._read_order_book_sync, order, credentials)
 
     def _submit_order_sync(
         self,
@@ -326,6 +412,97 @@ class PolymarketSDKClient:
             raise LiveTradingDisabledError(msg) from None
 
         return _order_result_from_sdk_response(order, response)
+
+    def _read_order_book_sync(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: VenueCredentials,
+    ) -> LiveVenueBook:
+        try:
+            sdk = importlib.import_module("py_clob_client_v2")
+        except ModuleNotFoundError:
+            msg = (
+                "Polymarket live SDK is not installed. Install the live extra "
+                "with `uv sync --extra live` before enabling LIVE mode."
+            )
+            raise LiveTradingDisabledError(msg) from None
+
+        try:
+            client = _build_sdk_client(sdk, credentials)
+            response = _get_sdk_order_book(client, order.token_id)
+        except Exception as exc:  # noqa: BLE001
+            redacted = _redacted_exception_message(exc, credentials)
+            logger.warning(
+                "Polymarket live order book fetch failed (%s): %s",
+                type(exc).__name__,
+                redacted,
+            )
+            msg = (
+                "Polymarket live order book fetch failed "
+                f"({type(exc).__name__}); venue error redacted"
+            )
+            raise LiveTradingDisabledError(msg) from None
+
+        return _venue_book_from_sdk_response(
+            response,
+            market_id=order.market_id,
+            token_id=order.token_id,
+        )
+
+
+@dataclass(frozen=True)
+class PolymarketVenueAccountReconciler:
+    client: PolymarketSDKClient = field(default_factory=PolymarketSDKClient)
+    position_tolerance_shares: float = 1e-6
+    notional_tolerance_usdc: float = 1e-4
+
+    async def snapshot(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+        return await asyncio.to_thread(self._snapshot_sync, credentials)
+
+    def _snapshot_sync(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+        try:
+            sdk = importlib.import_module("py_clob_client_v2")
+        except ModuleNotFoundError:
+            msg = (
+                "Polymarket live SDK is not installed. Install the live extra "
+                "with `uv sync --extra live` before enabling LIVE mode."
+            )
+            raise LiveTradingDisabledError(msg) from None
+        client = _build_sdk_client(sdk, credentials)
+        open_orders = _order_states_from_open_orders(
+            _get_sdk_open_orders(client),
+            credentials=credentials,
+        )
+        positions = _positions_from_sdk_positions(
+            _get_sdk_positions(client, credentials),
+            credentials=credentials,
+        )
+        return VenueAccountSnapshot(
+            balances={},
+            open_orders=tuple(open_orders),
+            positions=tuple(positions),
+        )
+
+    async def compare(
+        self,
+        db_portfolio: Portfolio,
+        venue_snapshot: VenueAccountSnapshot,
+    ) -> ReconciliationReport:
+        mismatches: list[str] = []
+        if venue_snapshot.open_orders:
+            mismatches.append(
+                f"venue has {len(venue_snapshot.open_orders)} open orders; "
+                "PMS has no durable live open-order ledger yet"
+            )
+        mismatches.extend(
+            _compare_positions(
+                db_portfolio.open_positions,
+                venue_snapshot.positions,
+                share_tolerance=self.position_tolerance_shares,
+                notional_tolerance=self.notional_tolerance_usdc,
+            )
+        )
+        return ReconciliationReport(ok=not mismatches, mismatches=tuple(mismatches))
 
 
 @dataclass(frozen=True)
@@ -462,9 +639,12 @@ class PolymarketActuator:
         self,
         market_id: str,
     ) -> tuple[str | None, str | None]:
-        if not isinstance(self.quote_provider, PolymarketBookQuoteProvider):
+        quote_provider = self.quote_provider
+        if isinstance(quote_provider, PolymarketRoutingQuoteProvider):
+            quote_provider = quote_provider.snapshot_provider
+        if not isinstance(quote_provider, PolymarketBookQuoteProvider):
             return None, None
-        market = await self.quote_provider.store.read_market(market_id)
+        market = await quote_provider.store.read_market(market_id)
         if market is None:
             return None, None
         return market.slug, market.question
@@ -476,7 +656,15 @@ class PolymarketActuator:
         request: PolymarketOrderRequest,
         credentials: VenueCredentials,
     ) -> OrderState:
-        quote = await self.quote_provider.quote(request, credentials)
+        quote_for_order = getattr(self.quote_provider, "quote_for_order", None)
+        if callable(quote_for_order):
+            quote = await quote_for_order(
+                request,
+                credentials,
+                first_live_order=not self._first_order_approved(),
+            )
+        else:
+            quote = await self.quote_provider.quote(request, credentials)
         _validate_pre_submit_quote(request, quote, self.settings)
         result = await self.client.submit_order(request, credentials)
         order_state = _order_state_from_result(decision, result, quote=quote)
@@ -605,6 +793,7 @@ def _quote_payload(quote: LivePreSubmitQuote) -> dict[str, object]:
         "spread_bps": quote.spread_bps,
         "quote_hash": quote.quote_hash,
         "book_ts": quote.book_ts.isoformat(),
+        "source": quote.source,
     }
 
 
@@ -613,9 +802,107 @@ def _utc_now() -> datetime:
 
 
 def _market_status(market: Market, now: datetime) -> str:
+    if market.closed is True:
+        return "closed"
+    if market.active is False:
+        return "inactive"
+    if market.accepting_orders is False:
+        return "not_accepting_orders"
     if market.resolves_at is not None and market.resolves_at <= now:
         return "closed"
     return "open"
+
+
+def _quote_from_levels(
+    *,
+    order: PolymarketOrderRequest,
+    market_status: str,
+    bid_levels: Sequence[BookLevel],
+    ask_levels: Sequence[BookLevel],
+    quote_hash: str,
+    book_ts: datetime,
+    now: datetime,
+    source: Literal["postgres_snapshot", "venue_direct", "dual"],
+) -> LivePreSubmitQuote:
+    sorted_bids = sorted(
+        bid_levels,
+        key=lambda level: level.price,
+        reverse=True,
+    )
+    sorted_asks = sorted(ask_levels, key=lambda level: level.price)
+    executable_levels = (
+        [level for level in sorted_asks if level.price <= order.price]
+        if order.side == "BUY"
+        else [level for level in sorted_bids if level.price >= order.price]
+    )
+    best_executable_price = (
+        executable_levels[0].price if executable_levels else order.price
+    )
+    executable_notional_usdc = sum(
+        max(0.0, level.price) * max(0.0, level.size)
+        for level in executable_levels
+    )
+    best_bid = sorted_bids[0].price if sorted_bids else None
+    best_ask = sorted_asks[0].price if sorted_asks else None
+    return LivePreSubmitQuote(
+        market_status=market_status,
+        book_age_ms=max(0.0, (now - book_ts).total_seconds() * 1000.0),
+        executable_notional_usdc=executable_notional_usdc,
+        best_executable_price=best_executable_price,
+        spread_bps=_spread_bps(best_bid=best_bid, best_ask=best_ask),
+        quote_hash=quote_hash,
+        book_ts=book_ts,
+        source=source,
+    )
+
+
+def _raise_if_future_book_ts(
+    book_ts: datetime,
+    *,
+    now: datetime,
+    allowed_clock_skew_ms: float,
+) -> None:
+    skew_ms = (book_ts - now).total_seconds() * 1000.0
+    if skew_ms <= allowed_clock_skew_ms:
+        return
+    msg = (
+        "Polymarket book snapshot timestamp is in the future; "
+        f"refusing live submit ({skew_ms:.0f}ms > {allowed_clock_skew_ms:.0f}ms)"
+    )
+    raise LiveTradingDisabledError(msg)
+
+
+def _requires_direct_quote(
+    order: PolymarketOrderRequest,
+    settings: PMSSettings,
+) -> bool:
+    threshold = settings.controller.direct_quote_min_notional_usdc
+    return threshold is not None and order.notional_usdc >= threshold
+
+
+def _validate_dual_quote_match(
+    snapshot_quote: LivePreSubmitQuote,
+    direct_quote: LivePreSubmitQuote,
+    settings: PMSSettings,
+) -> None:
+    delta_bps = _price_delta_bps(
+        snapshot_quote.best_executable_price,
+        direct_quote.best_executable_price,
+    )
+    if delta_bps > settings.controller.dual_quote_max_price_delta_bps:
+        msg = (
+            "Polymarket dual quote mismatch: best executable price delta "
+            f"{delta_bps:.1f}bps > "
+            f"{settings.controller.dual_quote_max_price_delta_bps:.1f}bps"
+        )
+        raise LiveTradingDisabledError(msg)
+
+
+def _price_delta_bps(first: float, second: float) -> float:
+    midpoint = (abs(first) + abs(second)) / 2.0
+    if midpoint <= 0.0:
+        return math.inf if first != second else 0.0
+    return (abs(first - second) / midpoint) * 10_000.0
 
 
 def _spread_bps(*, best_bid: float | None, best_ask: float | None) -> float:
@@ -731,6 +1018,42 @@ def _post_sdk_order(
         options=options,
         order_type=order_type,
     )
+
+
+def _get_sdk_order_book(client: object, token_id: str) -> object:
+    for method_name in ("get_order_book", "get_orderbook", "get_book"):
+        method = getattr(client, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            return method(token_id)
+        except TypeError:
+            return method(token_id=token_id)
+    msg = "Polymarket SDK client does not expose an order-book fetch method"
+    raise LiveTradingDisabledError(msg)
+
+
+def _get_sdk_open_orders(client: object) -> object:
+    for method_name in ("get_orders", "get_open_orders", "getOpenOrders"):
+        method = getattr(client, method_name, None)
+        if callable(method):
+            return method()
+    return ()
+
+
+def _get_sdk_positions(client: object, credentials: VenueCredentials) -> object:
+    for method_name in ("get_positions", "get_current_positions", "getPositions"):
+        method = getattr(client, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            return method(user=credentials.funder_address)
+        except TypeError:
+            try:
+                return method(credentials.funder_address)
+            except TypeError:
+                return method()
+    return ()
 
 
 def _sdk_order_type(order_type_cls: object, order: PolymarketOrderRequest) -> object:
@@ -952,6 +1275,214 @@ def _order_result_from_sdk_response(
         fill_price=fill_price,
         filled_quantity=filled_quantity,
     )
+
+
+def _venue_book_from_sdk_response(
+    response: object,
+    *,
+    market_id: str,
+    token_id: str,
+) -> LiveVenueBook:
+    book_ts = _coerce_datetime_or_now(
+        _response_value(response, "timestamp", "ts", "created_at", "createdAt")
+    )
+    raw_hash = _response_value(response, "hash", "book_hash", "bookHash")
+    quote_hash = str(raw_hash or f"venue:{token_id}:{book_ts.isoformat()}")
+    market_status = str(_response_value(response, "market_status", "status") or "open")
+    return LiveVenueBook(
+        market_id=market_id,
+        token_id=token_id,
+        bids=tuple(
+            _book_levels_from_response_side(
+                _response_value(response, "bids", "buy"),
+                market_id=market_id,
+                side="BUY",
+            )
+        ),
+        asks=tuple(
+            _book_levels_from_response_side(
+                _response_value(response, "asks", "sell"),
+                market_id=market_id,
+                side="SELL",
+            )
+        ),
+        book_ts=book_ts,
+        quote_hash=quote_hash,
+        market_status=market_status,
+    )
+
+
+def _book_levels_from_response_side(
+    raw_levels: object,
+    *,
+    market_id: str,
+    side: Literal["BUY", "SELL"],
+) -> list[BookLevel]:
+    if raw_levels is None:
+        return []
+    if not isinstance(raw_levels, Sequence) or isinstance(raw_levels, (str, bytes)):
+        msg = "Polymarket order book levels must be a sequence"
+        raise LiveTradingDisabledError(msg)
+    levels: list[BookLevel] = []
+    for raw_level in raw_levels:
+        price = _coerce_float_or_none(_response_value(raw_level, "price", "p"))
+        size = _coerce_float_or_none(_response_value(raw_level, "size", "s"))
+        if price is None or size is None:
+            msg = "Polymarket order book level has unparseable price or size"
+            raise LiveTradingDisabledError(msg)
+        levels.append(
+            BookLevel(
+                snapshot_id=0,
+                market_id=market_id,
+                side=side,
+                price=price,
+                size=size,
+            )
+        )
+    return levels
+
+
+def _coerce_datetime_or_now(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        raw = float(value)
+        if raw > 10_000_000_000:
+            raw = raw / 1000.0
+        return datetime.fromtimestamp(raw, tz=UTC)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return _utc_now()
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return _utc_now()
+
+
+def _order_states_from_open_orders(
+    raw_orders: object,
+    *,
+    credentials: VenueCredentials,
+) -> list[OrderState]:
+    if raw_orders is None:
+        return []
+    if not isinstance(raw_orders, Sequence) or isinstance(raw_orders, (str, bytes)):
+        return []
+    states: list[OrderState] = []
+    for raw_order in raw_orders:
+        now = _utc_now()
+        order_id = str(_response_value(raw_order, "order_id", "id", "orderID") or "")
+        if not order_id:
+            continue
+        market_id = str(
+            _response_value(raw_order, "market_id", "condition_id", "market") or ""
+        )
+        token_id_value = _response_value(raw_order, "token_id", "asset_id", "assetId")
+        remaining = _coerce_float_or_none(
+            _response_value(raw_order, "remaining_notional_usdc", "remaining", "size")
+        )
+        price = _coerce_float_or_none(_response_value(raw_order, "price"))
+        remaining_notional = remaining or 0.0
+        states.append(
+            OrderState(
+                order_id=order_id,
+                decision_id=f"venue-open-{order_id}",
+                status=OrderStatus.LIVE.value,
+                market_id=market_id or "unknown",
+                token_id=None if token_id_value is None else str(token_id_value),
+                venue=credentials.venue,
+                requested_notional_usdc=remaining_notional,
+                filled_notional_usdc=0.0,
+                remaining_notional_usdc=remaining_notional,
+                fill_price=price,
+                submitted_at=now,
+                last_updated_at=now,
+                raw_status=str(_response_value(raw_order, "status") or "open"),
+                strategy_id="venue",
+                strategy_version_id="venue",
+            )
+        )
+    return states
+
+
+def _positions_from_sdk_positions(
+    raw_positions: object,
+    *,
+    credentials: VenueCredentials,
+) -> list[Position]:
+    if raw_positions is None:
+        return []
+    if not isinstance(raw_positions, Sequence) or isinstance(raw_positions, (str, bytes)):
+        return []
+    positions: list[Position] = []
+    for raw_position in raw_positions:
+        shares = _coerce_float_or_none(
+            _response_value(raw_position, "shares", "size", "quantity", "balance")
+        )
+        if shares is None or shares <= 0.0:
+            continue
+        market_id = str(
+            _response_value(raw_position, "market_id", "condition_id", "market") or ""
+        )
+        token_id_value = _response_value(raw_position, "token_id", "asset_id", "assetId")
+        avg_price = _coerce_float_or_none(
+            _response_value(raw_position, "avg_entry_price", "avgPrice", "price")
+        )
+        current_price = _coerce_float_or_none(
+            _response_value(raw_position, "current_price", "curPrice")
+        )
+        entry_price = avg_price or current_price or 0.0
+        positions.append(
+            Position(
+                market_id=market_id or "unknown",
+                token_id=None if token_id_value is None else str(token_id_value),
+                venue=credentials.venue,
+                side=str(_response_value(raw_position, "side", "outcome") or "BUY"),
+                shares_held=shares,
+                avg_entry_price=entry_price,
+                unrealized_pnl=0.0,
+                locked_usdc=shares * entry_price,
+            )
+        )
+    return positions
+
+
+def _compare_positions(
+    db_positions: Sequence[Position],
+    venue_positions: Sequence[Position],
+    *,
+    share_tolerance: float,
+    notional_tolerance: float,
+) -> list[str]:
+    mismatches: list[str] = []
+    db_by_key = {_position_key(position): position for position in db_positions}
+    venue_by_key = {_position_key(position): position for position in venue_positions}
+    for key in sorted(set(db_by_key) | set(venue_by_key)):
+        db_position = db_by_key.get(key)
+        venue_position = venue_by_key.get(key)
+        if db_position is None:
+            mismatches.append(f"venue position missing from DB: {key}")
+            continue
+        if venue_position is None:
+            mismatches.append(f"DB position missing from venue: {key}")
+            continue
+        if abs(db_position.shares_held - venue_position.shares_held) > share_tolerance:
+            mismatches.append(
+                "position shares mismatch "
+                f"{key}: DB={db_position.shares_held:.8f} "
+                f"venue={venue_position.shares_held:.8f}"
+            )
+        if abs(db_position.locked_usdc - venue_position.locked_usdc) > notional_tolerance:
+            mismatches.append(
+                "position notional mismatch "
+                f"{key}: DB={db_position.locked_usdc:.8f} "
+                f"venue={venue_position.locked_usdc:.8f}"
+            )
+    return mismatches
+
+
+def _position_key(position: Position) -> tuple[str, str | None, str]:
+    return position.market_id, position.token_id, position.venue
 
 
 def _is_sdk_transport_failure(exc: BaseException) -> bool:

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import getpass
 import os
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 import yaml
 from pydantic import BaseModel, Field
@@ -55,8 +55,14 @@ class ControllerSettings(BaseModel):
     max_slippage_bps: int = 50
     time_in_force: str = "GTC"
     max_book_age_ms: float = 1_000.0
+    allowed_book_clock_skew_ms: float = 250.0
     max_spread_bps: float = 100.0
     strict_factor_gates: bool = True
+    quote_source: Literal["postgres_snapshot", "venue_direct", "dual"] = (
+        "postgres_snapshot"
+    )
+    direct_quote_min_notional_usdc: float | None = 100.0
+    dual_quote_max_price_delta_bps: float = 25.0
 
 
 class RiskSettings(BaseModel):
@@ -110,6 +116,7 @@ class PMSSettings(BaseSettings):
     api_host: str = "127.0.0.1"
     api_token: str | None = None
     live_account_reconciliation_required: bool = False
+    live_emergency_audit_path: str = ".data/live-emergency-audit.jsonl"
     polymarket: PolymarketSettings = Field(default_factory=PolymarketSettings)
     llm: LLMSettings = Field(default_factory=LLMSettings)
     risk: RiskSettings = Field(default_factory=RiskSettings)

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -115,7 +115,7 @@ class PMSSettings(BaseSettings):
     factor_cadence_s: float = 1.0
     api_host: str = "127.0.0.1"
     api_token: str | None = None
-    live_account_reconciliation_required: bool = False
+    live_account_reconciliation_required: bool = True
     live_emergency_audit_path: str = ".data/live-emergency-audit.jsonl"
     polymarket: PolymarketSettings = Field(default_factory=PolymarketSettings)
     llm: LLMSettings = Field(default_factory=LLMSettings)
@@ -160,6 +160,12 @@ def validate_live_mode_ready(settings: PMSSettings) -> VenueCredentials:
         msg = (
             "LIVE GTC disabled until an open-order ledger reserves "
             "resting order exposure"
+        )
+        raise LiveTradingDisabledError(msg)
+    if settings.mode == RunMode.LIVE and not settings.live_account_reconciliation_required:
+        msg = (
+            "LIVE account reconciliation must be required before autonomous "
+            "live trading can start"
         )
         raise LiveTradingDisabledError(msg)
     return credentials

--- a/src/pms/core/models.py
+++ b/src/pms/core/models.py
@@ -180,6 +180,19 @@ class Portfolio:
 
 
 @dataclass(frozen=True)
+class VenueAccountSnapshot:
+    balances: Mapping[str, float]
+    open_orders: tuple[OrderState, ...]
+    positions: tuple[Position, ...]
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    ok: bool
+    mismatches: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class VenueCredentials:
     venue: Venue
     host: str
@@ -212,6 +225,10 @@ class Market:
     liquidity: float | None = None
     spread_bps: int | None = None
     price_updated_at: datetime | None = None
+    active: bool | None = None
+    closed: bool | None = None
+    accepting_orders: bool | None = None
+    status_updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -17,11 +17,15 @@ from pms.actuator.adapters.paper import PaperActuator
 from pms.actuator.adapters.polymarket import (
     DenyFirstLiveOrderGate,
     FileFirstLiveOrderGate,
+    LiveQuoteProvider,
     MissingLiveQuoteProvider,
     PolymarketActuator,
     PolymarketBookQuoteProvider,
+    PolymarketDirectQuoteProvider,
+    PolymarketRoutingQuoteProvider,
     PolymarketSDKClient,
     PolymarketSubmissionUnknownError,
+    PolymarketVenueAccountReconciler,
 )
 from pms.actuator.executor import ActuatorAdapter, ActuatorExecutor
 from pms.actuator.feedback import ActuatorFeedback
@@ -48,7 +52,9 @@ from pms.core.models import (
     OrderState,
     Portfolio,
     Position,
+    ReconciliationReport as ReconciliationReport,
     TradeDecision,
+    VenueAccountSnapshot as VenueAccountSnapshot,
     VenueCredentials,
 )
 from pms.evaluation.adapters.scoring import Scorer
@@ -77,6 +83,7 @@ from pms.storage.decision_store import DecisionStore
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
 from pms.storage.fill_store import FillStore
+from pms.storage.live_emergency_audit import LiveEmergencyAuditWriter
 from pms.storage.market_data_store import PostgresMarketDataStore
 from pms.storage.market_subscription_store import PostgresMarketSubscriptionStore
 from pms.storage.opportunity_store import OpportunityStore
@@ -117,6 +124,12 @@ RAW_FACTOR_COMPOSITION_ROLES = frozenset(
 REGISTERED_FACTOR_IDS = frozenset(factor_cls.factor_id for factor_cls in REGISTERED)
 DEFAULT_V2_FACTOR_COMPOSITION = DEFAULT_STRATEGY_COMPOSITION
 T = TypeVar("T")
+
+
+class LivePersistenceFailureError(RuntimeError):
+    """Raised after a venue submit when LIVE persistence safety is broken."""
+
+
 ControllerReleaseCancelPoint = Literal[
     "before_first_cleanup_await",
     "between_cleanup_awaits",
@@ -163,19 +176,6 @@ class ActuatorWorkItem:
     def __iter__(self) -> Iterator[TradeDecision | MarketSignal | None]:
         yield self.decision
         yield self.signal
-
-
-@dataclass(frozen=True)
-class VenueAccountSnapshot:
-    balances: Mapping[str, float]
-    open_orders: tuple[OrderState, ...]
-    positions: tuple[Position, ...]
-
-
-@dataclass(frozen=True)
-class ReconciliationReport:
-    ok: bool
-    mismatches: tuple[str, ...] = ()
 
 
 class VenueAccountReconciler(Protocol):
@@ -777,15 +777,28 @@ class Runner:
             return BacktestActuator(self.historical_data_path)
         if mode == RunMode.PAPER:
             return PaperActuator(orderbooks=self._paper_orderbooks)
+        quote_provider: LiveQuoteProvider = MissingLiveQuoteProvider()
+        if self._pg_pool is not None:
+            quote_provider = PolymarketRoutingQuoteProvider(
+                snapshot_provider=PolymarketBookQuoteProvider(
+                    PostgresMarketDataStore(self._pg_pool),
+                    allowed_clock_skew_ms=(
+                        self.config.controller.allowed_book_clock_skew_ms
+                    ),
+                ),
+                direct_provider=PolymarketDirectQuoteProvider(
+                    book_client=PolymarketSDKClient(),
+                    allowed_clock_skew_ms=(
+                        self.config.controller.allowed_book_clock_skew_ms
+                    ),
+                ),
+                settings=self.config,
+            )
         return PolymarketActuator(
             self.config,
             client=PolymarketSDKClient(),
             operator_gate=_first_live_order_gate(self.config),
-            quote_provider=(
-                PolymarketBookQuoteProvider(PostgresMarketDataStore(self._pg_pool))
-                if self._pg_pool is not None
-                else MissingLiveQuoteProvider()
-            ),
+            quote_provider=quote_provider,
         )
 
     async def _controller_loop(self) -> None:
@@ -887,7 +900,11 @@ class Runner:
                             market_id=decision.market_id,
                             decision_id=decision.decision_id,
                         )
-                        await self._enqueue_decision(decision, signal=signal)
+                        await self._enqueue_decision(
+                            decision,
+                            signal=signal,
+                            queued_at=created_at,
+                        )
                 finally:
                     queue.task_done()
         except asyncio.CancelledError:
@@ -952,6 +969,11 @@ class Runner:
                     continue
                 if self.config.mode == RunMode.PAPER and signal is not None:
                     self._paper_orderbooks[decision.market_id] = signal.orderbook
+                await self._update_decision_status_if_supported(
+                    decision.decision_id,
+                    current_status="queued",
+                    next_status="submitted",
+                )
                 order_state = await _execute_actuator_work_item(
                     self.actuator_executor,
                     decision,
@@ -962,10 +984,30 @@ class Runner:
                 try:
                     await self.order_store.insert(order_state)
                 except Exception as error:  # noqa: BLE001
+                    if self.config.mode == RunMode.LIVE:
+                        await self._hard_halt_live_persistence_failure(
+                            phase="order_state",
+                            decision=decision,
+                            order_state=order_state,
+                            error=error,
+                        )
                     logger.warning("order persistence failed: %s", error)
                 fill = _fill_from_order(order_state, decision, signal)
                 if fill is not None:
                     _append_bounded(self.state.fills, fill)
+                    try:
+                        await self.fill_store.insert(fill)
+                    except Exception as error:  # noqa: BLE001
+                        if self.config.mode == RunMode.LIVE:
+                            await self._hard_halt_live_persistence_failure(
+                                phase="fill",
+                                decision=decision,
+                                order_state=order_state,
+                                error=error,
+                            )
+                        logger.warning("fill persistence failed: %s", error)
+                    self.portfolio = _portfolio_with_fill(self.portfolio, fill)
+                    self._evaluator_spool.enqueue(fill, decision)
                     await self.event_bus.publish(
                         "actuator.fill",
                         _fill_event_summary(fill),
@@ -974,12 +1016,11 @@ class Runner:
                         decision_id=fill.decision_id,
                         fill_id=fill.fill_id or fill.order_id,
                     )
-                    try:
-                        await self.fill_store.insert(fill)
-                    except Exception as error:  # noqa: BLE001
-                        logger.warning("fill persistence failed: %s", error)
-                    self.portfolio = _portfolio_with_fill(self.portfolio, fill)
-                    self._evaluator_spool.enqueue(fill, decision)
+                await self._update_decision_status_if_supported(
+                    decision.decision_id,
+                    current_status="submitted",
+                    next_status=_decision_status_from_order(order_state),
+                )
             except PolymarketSubmissionUnknownError as error:
                 self._live_trading_suspended_reason = "submission_unknown"
                 self._stop_event.set()
@@ -989,10 +1030,22 @@ class Runner:
                     try:
                         await self.order_store.insert(unknown_order_state)
                     except Exception as store_error:  # noqa: BLE001
+                        if self.config.mode == RunMode.LIVE:
+                            await self._hard_halt_live_persistence_failure(
+                                phase="submission_unknown_order_state",
+                                decision=decision,
+                                order_state=unknown_order_state,
+                                error=store_error,
+                            )
                         logger.warning(
                             "submission_unknown order persistence failed: %s",
                             store_error,
                         )
+                await self._update_decision_status_if_supported(
+                    decision.decision_id,
+                    current_status="submitted",
+                    next_status="submission_unknown",
+                )
                 await self.event_bus.publish(
                     "error",
                     f"live trading suspended for submission_unknown: {error}",
@@ -1000,6 +1053,8 @@ class Runner:
                     decision_id=decision.decision_id,
                 )
                 logger.warning("live trading suspended for submission_unknown: %s", error)
+            except LivePersistenceFailureError:
+                raise
             except Exception as error:
                 await self.event_bus.publish(
                     "error",
@@ -1035,6 +1090,7 @@ class Runner:
         *,
         signal: MarketSignal | None,
         dedup_acquired: bool = False,
+        queued_at: datetime | None = None,
     ) -> None:
         await self._decision_queue.put(
             ActuatorWorkItem(
@@ -1043,6 +1099,73 @@ class Runner:
                 dedup_acquired=dedup_acquired,
             )
         )
+        await self._update_decision_status_if_supported(
+            decision.decision_id,
+            current_status="accepted",
+            next_status="queued",
+            updated_at=queued_at or (signal.fetched_at if signal is not None else None),
+        )
+
+    async def _update_decision_status_if_supported(
+        self,
+        decision_id: str,
+        *,
+        current_status: str,
+        next_status: str,
+        updated_at: datetime | None = None,
+    ) -> bool:
+        update_status = getattr(self.decision_store, "update_status", None)
+        if not callable(update_status):
+            return False
+        try:
+            return bool(
+                await update_status(
+                    decision_id,
+                    current_status=current_status,
+                    next_status=next_status,
+                    updated_at=updated_at or datetime.now(tz=UTC),
+                )
+            )
+        except Exception as error:  # noqa: BLE001
+            logger.warning(
+                "decision status update failed for decision_id=%s %s->%s: %s",
+                decision_id,
+                current_status,
+                next_status,
+                error,
+            )
+            return False
+
+    async def _hard_halt_live_persistence_failure(
+        self,
+        *,
+        phase: str,
+        decision: TradeDecision,
+        order_state: OrderState | None,
+        error: BaseException,
+    ) -> None:
+        self._live_trading_suspended_reason = "persistence_failure"
+        self._stop_event.set()
+        audit_writer = LiveEmergencyAuditWriter(
+            Path(self.config.live_emergency_audit_path)
+        )
+        try:
+            await audit_writer.append(
+                phase=phase,
+                decision=decision,
+                order_state=order_state,
+                error=error,
+            )
+        except Exception as audit_error:  # noqa: BLE001
+            logger.warning("live emergency audit append failed: %s", audit_error)
+        await self.event_bus.publish(
+            "error",
+            f"live trading suspended: persistence failure during {phase}: {error}",
+            market_id=decision.market_id,
+            decision_id=decision.decision_id,
+        )
+        msg = f"LIVE persistence failure during {phase}: {error}"
+        raise LivePersistenceFailureError(msg) from error
 
     async def _sweep_expired_decisions_once(
         self,
@@ -1319,11 +1442,10 @@ class Runner:
             return
         reconciler = self.venue_account_reconciler
         if reconciler is None:
-            if self.config.live_account_reconciliation_required:
-                msg = "LIVE venue account reconciliation is required but not configured"
-                raise RuntimeError(msg)
-            logger.warning("LIVE venue account reconciliation is not configured")
-            return
+            if not self.config.live_account_reconciliation_required:
+                logger.warning("LIVE venue account reconciliation is not configured")
+                return
+            reconciler = PolymarketVenueAccountReconciler()
         credentials = validate_live_mode_ready(self.config)
         snapshot = await reconciler.snapshot(credentials)
         report = await reconciler.compare(self.portfolio, snapshot)
@@ -1794,6 +1916,31 @@ def _fill_from_order(
         strategy_version_id=decision.strategy_version_id,
         resolved_outcome=_resolved_outcome(signal),
     )
+
+
+def _decision_status_from_order(order_state: OrderState) -> str:
+    normalized_status = order_state.status.lower()
+    raw_status = order_state.raw_status.lower()
+    if (
+        order_state.filled_notional_usdc > 0.0
+        and order_state.remaining_notional_usdc > 1e-9
+    ):
+        return "partially_filled"
+    if order_state.filled_notional_usdc > 0.0:
+        return "filled"
+    if normalized_status == OrderStatus.MATCHED.value:
+        return "filled"
+    if normalized_status in {
+        OrderStatus.CANCELLED.value,
+        OrderStatus.CANCELED_MARKET_RESOLVED.value,
+        "canceled",
+    }:
+        return "cancelled"
+    if raw_status == "venue_rejection" or normalized_status == "rejected":
+        return "venue_rejected"
+    if normalized_status == OrderStatus.INVALID.value:
+        return "rejected"
+    return "submitted"
 
 
 def _portfolio_with_fill(portfolio: Portfolio, fill: FillRecord) -> Portfolio:

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -197,6 +197,15 @@ def _gamma_market_to_market(row: dict[str, Any], fetched_at: datetime) -> Market
         liquidity=prices.liquidity,
         spread_bps=prices.spread_bps,
         price_updated_at=prices.price_updated_at,
+        active=_optional_bool(row.get("active")),
+        closed=_optional_bool(row.get("closed")),
+        accepting_orders=_optional_bool(
+            _first_non_empty_value(
+                row.get("acceptingOrders"),
+                row.get("accepting_orders"),
+            )
+        ),
+        status_updated_at=fetched_at,
     )
 
 
@@ -423,6 +432,21 @@ def _optional_datetime(value: object) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=UTC)
     return parsed
+
+
+def _optional_bool(value: object) -> bool | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+    msg = "expected a bool-compatible value"
+    raise TypeError(msg)
 
 
 def _first_non_empty_value(*values: object) -> object | None:

--- a/src/pms/storage/decision_store.py
+++ b/src/pms/storage/decision_store.py
@@ -285,7 +285,7 @@ class DecisionStore:
                 UPDATE decisions
                 SET status = 'expired',
                     updated_at = $1
-                WHERE status = 'pending'
+                WHERE status IN ('pending', 'accepted', 'queued')
                   AND expires_at < $1
                 RETURNING decision_id
                 """,

--- a/src/pms/storage/live_emergency_audit.py
+++ b/src/pms/storage/live_emergency_audit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pms.core.models import OrderState, TradeDecision
+
+
+@dataclass(frozen=True, slots=True)
+class LiveEmergencyAuditWriter:
+    path: Path
+
+    async def append(
+        self,
+        *,
+        phase: str,
+        decision: TradeDecision,
+        order_state: OrderState | None,
+        error: BaseException,
+    ) -> None:
+        record = _audit_record(
+            phase=phase,
+            decision=decision,
+            order_state=order_state,
+            error=error,
+        )
+        await asyncio.to_thread(_append_jsonl, self.path, record)
+
+
+def _audit_record(
+    *,
+    phase: str,
+    decision: TradeDecision,
+    order_state: OrderState | None,
+    error: BaseException,
+) -> dict[str, Any]:
+    return {
+        "timestamp": datetime.now(tz=UTC).isoformat(),
+        "phase": phase,
+        "decision_id": decision.decision_id,
+        "intent_key": decision.intent_key,
+        "market_id": decision.market_id,
+        "token_id": decision.token_id,
+        "venue": decision.venue,
+        "strategy_id": decision.strategy_id,
+        "strategy_version_id": decision.strategy_version_id,
+        "order_id": None if order_state is None else order_state.order_id,
+        "raw_status": None if order_state is None else order_state.raw_status,
+        "status": None if order_state is None else order_state.status,
+        "pre_submit_quote": (
+            {} if order_state is None else dict(order_state.pre_submit_quote)
+        ),
+        "requested_notional_usdc": (
+            decision.notional_usdc
+            if order_state is None
+            else order_state.requested_notional_usdc
+        ),
+        "filled_notional_usdc": (
+            None if order_state is None else order_state.filled_notional_usdc
+        ),
+        "remaining_notional_usdc": (
+            None if order_state is None else order_state.remaining_notional_usdc
+        ),
+        "error_type": type(error).__name__,
+        "error": str(error),
+    }
+
+
+def _append_jsonl(path: Path, record: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
+        file.write("\n")

--- a/src/pms/storage/live_reconciliation.py
+++ b/src/pms/storage/live_reconciliation.py
@@ -23,22 +23,35 @@ class SubmissionUnknownReconciliationStore:
         note: str | None = None,
     ) -> bool:
         async with self.pool.acquire() as connection:
-            row = await connection.fetchrow(
-                """
-                UPDATE order_intents
-                SET reconciled_at = now(),
-                    venue_order_id = $2,
-                    reconciliation_status = $3,
-                    reconciled_by = $4,
-                    reconciliation_note = $5
-                WHERE decision_id = $1
-                  AND outcome = 'submission_unknown'
-                RETURNING decision_id
-                """,
-                decision_id,
-                venue_order_id,
-                status,
-                reconciled_by,
-                note,
-            )
+            async with connection.transaction():
+                row = await connection.fetchrow(
+                    """
+                    UPDATE order_intents
+                    SET reconciled_at = now(),
+                        venue_order_id = $2,
+                        reconciliation_status = $3,
+                        reconciled_by = $4,
+                        reconciliation_note = $5
+                    WHERE decision_id = $1
+                      AND outcome = 'submission_unknown'
+                    RETURNING decision_id
+                    """,
+                    decision_id,
+                    venue_order_id,
+                    status,
+                    reconciled_by,
+                    note,
+                )
+                if row is None:
+                    return False
+                await connection.execute(
+                    """
+                    UPDATE decisions
+                    SET status = 'reconciled',
+                        updated_at = now()
+                    WHERE decision_id = $1
+                      AND status = 'submission_unknown'
+                    """,
+                    decision_id,
+                )
         return row is not None

--- a/src/pms/storage/market_data_store.py
+++ b/src/pms/storage/market_data_store.py
@@ -51,6 +51,10 @@ class MarketCatalogRow:
     spread_bps: int | None = None
     price_updated_at: datetime | None = None
     subscription_source: str | None = None
+    active: bool | None = None
+    closed: bool | None = None
+    accepting_orders: bool | None = None
+    status_updated_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -71,6 +75,14 @@ def _optional_float(value: object) -> float | None:
     return float(cast(Any, value))
 
 
+def _row_value(row: object, key: str) -> object | None:
+    try:
+        value: object = cast(Any, row)[key]
+    except KeyError:
+        return None
+    return value
+
+
 class PostgresMarketDataStore:
     def __init__(self, pool: asyncpg.Pool) -> None:
         self._pool = pool
@@ -81,7 +93,19 @@ class PostgresMarketDataStore:
 
     async def read_market(self, market_id: str) -> Market | None:
         query = """
-        SELECT condition_id, slug, question, venue, resolves_at, created_at, last_seen_at, volume_24h
+        SELECT
+            condition_id,
+            slug,
+            question,
+            venue,
+            resolves_at,
+            created_at,
+            last_seen_at,
+            volume_24h,
+            active,
+            closed,
+            accepting_orders,
+            status_updated_at
         FROM markets
         WHERE condition_id = $1
         """
@@ -98,6 +122,16 @@ class PostgresMarketDataStore:
             created_at=row["created_at"],
             last_seen_at=row["last_seen_at"],
             volume_24h=row["volume_24h"],
+            active=cast(bool | None, _row_value(row, "active")),
+            closed=cast(bool | None, _row_value(row, "closed")),
+            accepting_orders=cast(
+                bool | None,
+                _row_value(row, "accepting_orders"),
+            ),
+            status_updated_at=cast(
+                datetime | None,
+                _row_value(row, "status_updated_at"),
+            ),
         )
 
     async def read_tokens_for_market(self, market_id: str) -> list[Token]:
@@ -144,6 +178,10 @@ class PostgresMarketDataStore:
             markets.liquidity,
             markets.spread_bps,
             markets.price_updated_at,
+            markets.active,
+            markets.closed,
+            markets.accepting_orders,
+            markets.status_updated_at,
             MAX(CASE WHEN tokens.outcome = 'YES' THEN tokens.token_id END) AS yes_token_id,
             MAX(CASE WHEN tokens.outcome = 'NO' THEN tokens.token_id END) AS no_token_id,
             MAX(market_subscriptions.source) AS subscription_source,
@@ -231,7 +269,11 @@ class PostgresMarketDataStore:
             markets.last_trade_price,
             markets.liquidity,
             markets.spread_bps,
-            markets.price_updated_at
+            markets.price_updated_at,
+            markets.active,
+            markets.closed,
+            markets.accepting_orders,
+            markets.status_updated_at
         ORDER BY
             COALESCE(markets.volume_24h, 0) DESC,
             markets.last_seen_at DESC,
@@ -285,6 +327,16 @@ class PostgresMarketDataStore:
                 spread_bps=cast(int | None, row["spread_bps"]),
                 price_updated_at=cast(datetime | None, row["price_updated_at"]),
                 subscription_source=cast(str | None, row["subscription_source"]),
+                active=cast(bool | None, _row_value(row, "active")),
+                closed=cast(bool | None, _row_value(row, "closed")),
+                accepting_orders=cast(
+                    bool | None,
+                    _row_value(row, "accepting_orders"),
+                ),
+                status_updated_at=cast(
+                    datetime | None,
+                    _row_value(row, "status_updated_at"),
+                ),
             )
             for row in rows
         ], total
@@ -384,6 +436,10 @@ class PostgresMarketDataStore:
             markets.created_at,
             markets.last_seen_at,
             markets.volume_24h,
+            markets.active,
+            markets.closed,
+            markets.accepting_orders,
+            markets.status_updated_at,
             tokens.token_id,
             tokens.outcome
         FROM markets
@@ -440,6 +496,16 @@ class PostgresMarketDataStore:
                             created_at=cast(datetime, row["created_at"]),
                             last_seen_at=cast(datetime, row["last_seen_at"]),
                             volume_24h=cast(float | None, row["volume_24h"]),
+                            active=cast(bool | None, _row_value(row, "active")),
+                            closed=cast(bool | None, _row_value(row, "closed")),
+                            accepting_orders=cast(
+                                bool | None,
+                                _row_value(row, "accepting_orders"),
+                            ),
+                            status_updated_at=cast(
+                                datetime | None,
+                                _row_value(row, "status_updated_at"),
+                            ),
                         ),
                         current_tokens,
                     )
@@ -480,10 +546,15 @@ class PostgresMarketDataStore:
             last_trade_price,
             liquidity,
             spread_bps,
-            price_updated_at
+            price_updated_at,
+            active,
+            closed,
+            accepting_orders,
+            status_updated_at
         ) VALUES (
             $1, $2, $3, $4, $5, $6, $7, $8,
-            $9, $10, $11, $12, $13, $14, $15, $16
+            $9, $10, $11, $12, $13, $14, $15, $16,
+            $17, $18, $19, $20
         )
         ON CONFLICT (condition_id) DO UPDATE
         SET slug = EXCLUDED.slug,
@@ -499,7 +570,11 @@ class PostgresMarketDataStore:
             last_trade_price = EXCLUDED.last_trade_price,
             liquidity = EXCLUDED.liquidity,
             spread_bps = EXCLUDED.spread_bps,
-            price_updated_at = EXCLUDED.price_updated_at
+            price_updated_at = EXCLUDED.price_updated_at,
+            active = EXCLUDED.active,
+            closed = EXCLUDED.closed,
+            accepting_orders = EXCLUDED.accepting_orders,
+            status_updated_at = EXCLUDED.status_updated_at
         """
         async with self._pool.acquire() as connection:
             await connection.execute(
@@ -520,6 +595,10 @@ class PostgresMarketDataStore:
                 market.liquidity,
                 market.spread_bps,
                 market.price_updated_at,
+                market.active,
+                market.closed,
+                market.accepting_orders,
+                market.status_updated_at,
             )
 
     async def write_price_snapshot(

--- a/tests/integration/test_alembic_order_intents_cp15.py
+++ b/tests/integration/test_alembic_order_intents_cp15.py
@@ -387,6 +387,24 @@ def test_alembic_order_intents_table_shape_constraints_and_idempotency() -> None
         assert invalid_outcome_result.returncode != 0
         assert "order_intents_outcome_check" in invalid_outcome_result.stderr
 
+        _run_psql(
+            temp_database_url,
+            "-c",
+            """
+            INSERT INTO order_intents (
+                decision_id,
+                strategy_id,
+                strategy_version_id,
+                outcome
+            ) VALUES (
+                'd-cancelled-market-resolved',
+                's1',
+                'v1',
+                'cancelled_market_resolved'
+            )
+            """,
+        )
+
         invalid_reconciliation_status_result = _run_psql_allow_failure(
             temp_database_url,
             "-c",

--- a/tests/integration/test_schema_apply_outer.py
+++ b/tests/integration/test_schema_apply_outer.py
@@ -31,6 +31,10 @@ EXPECTED_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("liquidity", "numeric"),
         ("spread_bps", "integer"),
         ("price_updated_at", "timestamp with time zone"),
+        ("active", "boolean"),
+        ("closed", "boolean"),
+        ("accepting_orders", "boolean"),
+        ("status_updated_at", "timestamp with time zone"),
     ],
     "market_price_snapshots": [
         ("condition_id", "text"),

--- a/tests/unit/test_alembic_live_reliability_closure_migrations.py
+++ b/tests/unit/test_alembic_live_reliability_closure_migrations.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_migration(filename: str) -> ModuleType:
+    path = ROOT / "alembic" / "versions" / filename
+    assert path.exists(), f"migration file missing: {path}"
+    module_name = f"test_alembic_{filename.replace('.', '_')}"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_order_intent_cancelled_market_resolved_migration_metadata() -> None:
+    module = _load_migration("0012_order_intent_cancelled_market_resolved.py")
+
+    assert module.revision == "0012_cancelled_market_resolved"
+    assert len(module.revision) <= 32
+    assert module.down_revision == "0011_live_reconcile_audit"
+    assert "cancelled_market_resolved" in module.ORDER_INTENT_OUTCOMES
+    assert callable(module.upgrade)
+    assert callable(module.downgrade)
+
+
+def test_markets_live_status_fields_migration_metadata() -> None:
+    module = _load_migration("0013_markets_live_status_fields.py")
+
+    assert module.revision == "0013_market_status_fields"
+    assert len(module.revision) <= 32
+    assert module.down_revision == "0012_cancelled_market_resolved"
+    assert callable(module.upgrade)
+    assert callable(module.downgrade)

--- a/tests/unit/test_decision_store_cp07.py
+++ b/tests/unit/test_decision_store_cp07.py
@@ -296,6 +296,6 @@ async def test_decision_store_expire_pending_updates_matching_rows() -> None:
     assert len(connection.fetch_calls) == 1
     query, args = connection.fetch_calls[0]
     assert "UPDATE decisions" in query
-    assert "status = 'pending'" in query
+    assert "status IN ('pending', 'accepted', 'queued')" in query
     assert "RETURNING decision_id" in query
     assert args == (cutoff,)

--- a/tests/unit/test_docs_honesty_cp05.py
+++ b/tests/unit/test_docs_honesty_cp05.py
@@ -31,6 +31,16 @@ def test_readme_and_claude_explicitly_document_gated_polymarket_live_mode() -> N
     assert "operator gate" in claude_text
 
 
+def test_live_runbook_first_order_example_includes_outcome_and_reconciliation_gate() -> None:
+    runbook_text = (ROOT / "docs" / "operations" / "live-polymarket-runbook.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"outcome": "NO"' in runbook_text
+    assert "PMS_LIVE_ACCOUNT_RECONCILIATION_REQUIRED=true" in runbook_text
+    assert "PMS_CONTROLLER__TIME_IN_FORCE=IOC" in runbook_text
+
+
 def test_live_and_kalshi_mentions_are_stubbed_not_capability_claims() -> None:
     offending_lines: list[str] = []
 

--- a/tests/unit/test_live_safety_followups.py
+++ b/tests/unit/test_live_safety_followups.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+import sys
+from types import SimpleNamespace
 from typing import Any, Literal, cast
 
 import asyncpg
@@ -21,9 +23,17 @@ from pms.actuator.adapters.polymarket import (
     PolymarketOrderRequest,
     PolymarketOrderResult,
     PolymarketRoutingQuoteProvider,
+    PolymarketSDKClient,
     PolymarketSubmissionUnknownError,
+    PolymarketVenueAccountReconciler,
 )
-from pms.config import ControllerSettings, PMSSettings, PolymarketSettings, RiskSettings
+from pms.config import (
+    ControllerSettings,
+    PMSSettings,
+    PolymarketSettings,
+    RiskSettings,
+    validate_live_mode_ready,
+)
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.factor_snapshot import FactorSnapshot
 from pms.controller.pipeline import ControllerPipeline
@@ -37,7 +47,9 @@ from pms.core.models import (
     MarketSignal,
     OrderState,
     Portfolio,
+    Position,
     TradeDecision,
+    VenueCredentials,
 )
 from pms.runner import (
     ReconciliationReport,
@@ -183,6 +195,13 @@ def _live_settings(**overrides: object) -> PMSSettings:
     }
     values.update(overrides)
     return PMSSettings(**values)
+
+
+def test_live_mode_ready_requires_account_reconciliation_gate() -> None:
+    settings = _live_settings(live_account_reconciliation_required=False)
+
+    with pytest.raises(LiveTradingDisabledError, match="account reconciliation"):
+        validate_live_mode_ready(settings)
 
 
 def _decision(
@@ -377,6 +396,59 @@ async def test_polymarket_direct_quote_provider_uses_venue_book() -> None:
     assert quote.quote_hash == "venue-book"
     assert quote.book_age_ms == pytest.approx(100.0)
     assert quote.executable_notional_usdc == pytest.approx(16.0)
+
+
+@pytest.mark.asyncio
+async def test_polymarket_sdk_direct_quote_honors_venue_accepting_orders_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+
+    class FakeApiCreds:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class FakeClobClient:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+        def get_order_book(self, token_id: str) -> dict[str, object]:
+            assert token_id == "t-yes"
+            return {
+                "timestamp": now.isoformat(),
+                "accepting_orders": False,
+                "bids": [{"price": 0.39, "size": 100.0}],
+                "asks": [{"price": 0.40, "size": 100.0}],
+            }
+
+    monkeypatch.setitem(
+        sys.modules,
+        "py_clob_client_v2",
+        SimpleNamespace(ApiCreds=FakeApiCreds, ClobClient=FakeClobClient),
+    )
+
+    provider = PolymarketDirectQuoteProvider(
+        book_client=PolymarketSDKClient(),
+        clock=lambda: now,
+    )
+
+    quote = await provider.quote(
+        PolymarketOrderRequest(
+            market_id="m-live-safety",
+            token_id="t-yes",
+            side="BUY",
+            price=0.40,
+            size=25.0,
+            notional_usdc=10.0,
+            estimated_quantity=25.0,
+            order_type="limit",
+            time_in_force="IOC",
+            max_slippage_bps=50,
+        ),
+        _live_settings().polymarket.credentials(),
+    )
+
+    assert quote.market_status == "not_accepting_orders"
 
 
 @pytest.mark.asyncio
@@ -903,12 +975,21 @@ class _Acquire:
         return None
 
 
+class _Transaction:
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
 class _Connection:
     def __init__(self) -> None:
         self.fetchval_result: int = 0
         self.fetchrow_result: dict[str, object] | None = None
         self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
         self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
 
     async def fetchval(self, query: str, *args: object) -> int:
         self.fetchval_calls.append((query, args))
@@ -917,6 +998,13 @@ class _Connection:
     async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
         self.fetchrow_calls.append((query, args))
         return self.fetchrow_result
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.execute_calls.append((query, args))
+        return "UPDATE 1"
+
+    def transaction(self) -> _Transaction:
+        return _Transaction()
 
 
 class _Pool:
@@ -970,6 +1058,11 @@ async def test_submission_unknown_reconciliation_store_marks_incident_resolved()
     assert "reconciled_at = now()" in query
     assert "outcome = 'submission_unknown'" in query
     assert args == ("d-unknown", "pm-123", "filled", "operator", "matched venue fill")
+    decision_query, decision_args = connection.execute_calls[0]
+    assert "UPDATE decisions" in decision_query
+    assert "status = 'reconciled'" in decision_query
+    assert "status = 'submission_unknown'" in decision_query
+    assert decision_args == ("d-unknown",)
 
 
 @pytest.mark.asyncio
@@ -1064,6 +1157,54 @@ class MismatchingVenueReconciler(MatchingVenueReconciler):
         return ReconciliationReport(ok=False, mismatches=("position mismatch",))
 
 
+@dataclass
+class FakeVenueAccountClient:
+    snapshot_value: VenueAccountSnapshot
+    calls: int = 0
+
+    async def read_account_snapshot(
+        self,
+        credentials: VenueCredentials,
+    ) -> VenueAccountSnapshot:
+        assert credentials.venue == "polymarket"
+        self.calls += 1
+        return self.snapshot_value
+
+
+def _venue_open_order() -> OrderState:
+    now = datetime(2026, 4, 27, tzinfo=UTC)
+    return OrderState(
+        order_id="pm-open-1",
+        decision_id="venue-open-pm-open-1",
+        status=OrderStatus.LIVE.value,
+        market_id="m-live-safety",
+        token_id="t-yes",
+        venue="polymarket",
+        requested_notional_usdc=5.0,
+        filled_notional_usdc=0.0,
+        remaining_notional_usdc=5.0,
+        fill_price=0.40,
+        submitted_at=now,
+        last_updated_at=now,
+        raw_status="open",
+        strategy_id="venue",
+        strategy_version_id="venue",
+    )
+
+
+def _venue_position(*, shares: float = 25.0) -> Position:
+    return Position(
+        market_id="m-live-safety",
+        token_id="t-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        shares_held=shares,
+        avg_entry_price=0.4,
+        unrealized_pnl=0.0,
+        locked_usdc=shares * 0.4,
+    )
+
+
 @pytest.mark.asyncio
 async def test_live_venue_account_reconciliation_blocks_mismatch() -> None:
     runner = Runner(
@@ -1083,3 +1224,41 @@ async def test_live_venue_account_reconciliation_allows_matching_snapshot() -> N
     )
 
     await runner._reconcile_venue_account()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_polymarket_venue_reconciler_reads_snapshot_client_and_blocks_open_orders() -> None:
+    client = FakeVenueAccountClient(
+        VenueAccountSnapshot(
+            balances={"USDC": 1000.0},
+            open_orders=(_venue_open_order(),),
+            positions=(),
+        )
+    )
+    reconciler = PolymarketVenueAccountReconciler(client=client)
+
+    snapshot = await reconciler.snapshot(_live_settings().polymarket.credentials())
+    report = await reconciler.compare(_portfolio(), snapshot)
+
+    assert client.calls == 1
+    assert report.ok is False
+    assert report.mismatches == (
+        "venue has 1 open orders; PMS has no durable live open-order ledger yet",
+    )
+
+
+@pytest.mark.asyncio
+async def test_polymarket_venue_reconciler_blocks_when_venue_cash_below_db_free() -> None:
+    snapshot = VenueAccountSnapshot(
+        balances={"USDC": 999.0},
+        open_orders=(),
+        positions=(),
+    )
+    reconciler = PolymarketVenueAccountReconciler()
+
+    report = await reconciler.compare(_portfolio(), snapshot)
+
+    assert report.ok is False
+    assert report.mismatches == (
+        "venue USDC balance below PMS free cash: venue=999.00000000 DB=1000.00000000",
+    )

--- a/tests/unit/test_live_safety_followups.py
+++ b/tests/unit/test_live_safety_followups.py
@@ -14,10 +14,13 @@ from pms.actuator.adapters.polymarket import (
     FileFirstLiveOrderGate,
     LiveOrderPreview,
     LivePreSubmitQuote,
+    LiveVenueBook,
     PolymarketActuator,
     PolymarketBookQuoteProvider,
+    PolymarketDirectQuoteProvider,
     PolymarketOrderRequest,
     PolymarketOrderResult,
+    PolymarketRoutingQuoteProvider,
     PolymarketSubmissionUnknownError,
 )
 from pms.config import ControllerSettings, PMSSettings, PolymarketSettings, RiskSettings
@@ -233,6 +236,21 @@ class FakeBookStore:
         return self.levels
 
 
+@dataclass
+class FakeVenueBookClient:
+    book: LiveVenueBook
+    calls: int = 0
+
+    async def read_order_book(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: object,
+    ) -> LiveVenueBook:
+        del order, credentials
+        self.calls += 1
+        return self.book
+
+
 @pytest.mark.asyncio
 async def test_polymarket_book_quote_provider_uses_fresh_book_depth() -> None:
     now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
@@ -306,6 +324,258 @@ async def test_polymarket_book_quote_provider_uses_fresh_book_depth() -> None:
     assert quote.quote_hash == "book-hash"
 
 
+@pytest.mark.asyncio
+async def test_polymarket_direct_quote_provider_uses_venue_book() -> None:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+    client = FakeVenueBookClient(
+        LiveVenueBook(
+            market_id="m-live-safety",
+            token_id="t-yes",
+            bids=(
+                BookLevel(
+                    snapshot_id=0,
+                    market_id="m-live-safety",
+                    side=Side.BUY.value,
+                    price=0.39,
+                    size=100.0,
+                ),
+            ),
+            asks=(
+                BookLevel(
+                    snapshot_id=0,
+                    market_id="m-live-safety",
+                    side=Side.SELL.value,
+                    price=0.40,
+                    size=40.0,
+                ),
+            ),
+            book_ts=now - timedelta(milliseconds=100),
+            quote_hash="venue-book",
+            market_status="open",
+        )
+    )
+    provider = PolymarketDirectQuoteProvider(book_client=client, clock=lambda: now)
+
+    quote = await provider.quote(
+        PolymarketOrderRequest(
+            market_id="m-live-safety",
+            token_id="t-yes",
+            side="BUY",
+            price=0.40,
+            size=25.0,
+            notional_usdc=10.0,
+            estimated_quantity=25.0,
+            order_type="limit",
+            time_in_force="IOC",
+            max_slippage_bps=50,
+        ),
+        _live_settings().polymarket.credentials(),
+    )
+
+    assert client.calls == 1
+    assert quote.source == "venue_direct"
+    assert quote.quote_hash == "venue-book"
+    assert quote.book_age_ms == pytest.approx(100.0)
+    assert quote.executable_notional_usdc == pytest.approx(16.0)
+
+
+@pytest.mark.asyncio
+async def test_routing_quote_provider_dual_mode_fails_on_material_mismatch() -> None:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+    snapshot_provider = PolymarketBookQuoteProvider(
+        store=FakeBookStore(
+            market=Market(
+                condition_id="m-live-safety",
+                slug="live-safety",
+                question="Will live safety pass?",
+                venue="polymarket",
+                resolves_at=now + timedelta(days=1),
+                created_at=now - timedelta(days=1),
+                last_seen_at=now,
+            ),
+            snapshot=BookSnapshot(
+                id=24,
+                market_id="m-live-safety",
+                token_id="t-yes",
+                ts=now - timedelta(milliseconds=100),
+                hash="snapshot-book",
+                source="subscribe",
+            ),
+            levels=[
+                BookLevel(
+                    snapshot_id=24,
+                    market_id="m-live-safety",
+                    side=Side.SELL.value,
+                    price=0.40,
+                    size=100.0,
+                ),
+            ],
+        ),
+        clock=lambda: now,
+    )
+    direct_provider = PolymarketDirectQuoteProvider(
+        book_client=FakeVenueBookClient(
+            LiveVenueBook(
+                market_id="m-live-safety",
+                token_id="t-yes",
+                bids=(),
+                asks=(
+                    BookLevel(
+                        snapshot_id=0,
+                        market_id="m-live-safety",
+                        side=Side.SELL.value,
+                        price=0.44,
+                        size=100.0,
+                    ),
+                ),
+                book_ts=now - timedelta(milliseconds=100),
+                quote_hash="direct-book",
+                market_status="open",
+            )
+        ),
+        clock=lambda: now,
+    )
+    settings = _live_settings(
+        controller=ControllerSettings(
+            time_in_force="IOC",
+            min_volume=0.0,
+            quote_source="dual",
+            dual_quote_max_price_delta_bps=25.0,
+        )
+    )
+    provider = PolymarketRoutingQuoteProvider(
+        snapshot_provider=snapshot_provider,
+        direct_provider=direct_provider,
+        settings=settings,
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="dual quote mismatch"):
+        await provider.quote(
+            PolymarketOrderRequest(
+                market_id="m-live-safety",
+                token_id="t-yes",
+                side="BUY",
+                price=0.45,
+                size=25.0,
+                notional_usdc=10.0,
+                estimated_quantity=25.0,
+                order_type="limit",
+                time_in_force="IOC",
+                max_slippage_bps=50,
+            ),
+            settings.polymarket.credentials(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_routing_quote_provider_uses_direct_quote_for_first_live_order() -> None:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+    direct_client = FakeVenueBookClient(
+        LiveVenueBook(
+            market_id="m-live-safety",
+            token_id="t-yes",
+            bids=(),
+            asks=(
+                BookLevel(
+                    snapshot_id=0,
+                    market_id="m-live-safety",
+                    side=Side.SELL.value,
+                    price=0.40,
+                    size=100.0,
+                ),
+            ),
+            book_ts=now - timedelta(milliseconds=100),
+            quote_hash="first-direct",
+            market_status="open",
+        )
+    )
+    provider = PolymarketRoutingQuoteProvider(
+        snapshot_provider=PolymarketBookQuoteProvider(
+            store=FakeBookStore(market=None, snapshot=None, levels=[]),
+            clock=lambda: now,
+        ),
+        direct_provider=PolymarketDirectQuoteProvider(
+            book_client=direct_client,
+            clock=lambda: now,
+        ),
+        settings=_live_settings(),
+    )
+
+    quote = await provider.quote_for_order(
+        PolymarketOrderRequest(
+            market_id="m-live-safety",
+            token_id="t-yes",
+            side="BUY",
+            price=0.40,
+            size=25.0,
+            notional_usdc=10.0,
+            estimated_quantity=25.0,
+            order_type="limit",
+            time_in_force="IOC",
+            max_slippage_bps=50,
+        ),
+        _live_settings().polymarket.credentials(),
+        first_live_order=True,
+    )
+
+    assert quote.source == "venue_direct"
+    assert quote.quote_hash == "first-direct"
+    assert direct_client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_future_dated_book_snapshot_fails_quote_guard() -> None:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+    provider = PolymarketBookQuoteProvider(
+        store=FakeBookStore(
+            market=Market(
+                condition_id="m-live-safety",
+                slug="live-safety",
+                question="Will live safety pass?",
+                venue="polymarket",
+                resolves_at=now + timedelta(days=1),
+                created_at=now - timedelta(days=1),
+                last_seen_at=now,
+            ),
+            snapshot=BookSnapshot(
+                id=22,
+                market_id="m-live-safety",
+                token_id="t-yes",
+                ts=now + timedelta(seconds=5),
+                hash="future-book",
+                source="subscribe",
+            ),
+            levels=[
+                BookLevel(
+                    snapshot_id=22,
+                    market_id="m-live-safety",
+                    side=Side.SELL.value,
+                    price=0.40,
+                    size=100.0,
+                ),
+            ],
+        ),
+        clock=lambda: now,
+    )
+
+    with pytest.raises(LiveTradingDisabledError, match="timestamp is in the future"):
+        await provider.quote(
+            PolymarketOrderRequest(
+                market_id="m-live-safety",
+                token_id="t-yes",
+                side="BUY",
+                price=0.40,
+                size=25.0,
+                notional_usdc=10.0,
+                estimated_quantity=25.0,
+                order_type="limit",
+                time_in_force="IOC",
+                max_slippage_bps=50,
+            ),
+            _live_settings().polymarket.credentials(),
+        )
+
+
 def test_runner_live_adapter_uses_real_quote_provider_when_live_enabled() -> None:
     runner = Runner(config=_live_settings())
     runner._pg_pool = cast(asyncpg.Pool, object())  # noqa: SLF001
@@ -313,7 +583,9 @@ def test_runner_live_adapter_uses_real_quote_provider_when_live_enabled() -> Non
     adapter = runner._build_adapter(RunMode.LIVE)  # noqa: SLF001
 
     assert isinstance(adapter, PolymarketActuator)
-    assert isinstance(adapter.quote_provider, PolymarketBookQuoteProvider)
+    assert isinstance(adapter.quote_provider, PolymarketRoutingQuoteProvider)
+    assert isinstance(adapter.quote_provider.snapshot_provider, PolymarketBookQuoteProvider)
+    assert isinstance(adapter.quote_provider.direct_provider, PolymarketDirectQuoteProvider)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_market_data_store_markets.py
+++ b/tests/unit/test_market_data_store_markets.py
@@ -407,6 +407,10 @@ async def test_write_market_upserts_current_price_fields() -> None:
         1500.0,
         200,
         price_updated_at,
+        None,
+        None,
+        None,
+        None,
     )
 
 

--- a/tests/unit/test_runner_active_perception.py
+++ b/tests/unit/test_runner_active_perception.py
@@ -20,7 +20,13 @@ from pms.config import (
     SensorSettings,
 )
 from pms.core.enums import RunMode
-from pms.core.models import MarketSignal
+from pms.core.models import (
+    MarketSignal,
+    Portfolio,
+    ReconciliationReport,
+    VenueAccountSnapshot,
+    VenueCredentials,
+)
 from pms.market_selection.merge import StrategyMarketSet
 from pms.runner import Runner, _default_active_strategy
 from tests.support.default_strategy_seed import build_default_v1_strategy
@@ -155,6 +161,21 @@ class RecordingSubscriptionController:
         return True
 
 
+@dataclass
+class MatchingVenueReconciler:
+    async def snapshot(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+        del credentials
+        return VenueAccountSnapshot(balances={"USDC": 10_000.0}, open_orders=(), positions=())
+
+    async def compare(
+        self,
+        db_portfolio: Portfolio,
+        venue_snapshot: VenueAccountSnapshot,
+    ) -> ReconciliationReport:
+        del db_portfolio, venue_snapshot
+        return ReconciliationReport(ok=True, mismatches=())
+
+
 def _settings(mode: RunMode) -> PMSSettings:
     return PMSSettings(
         mode=mode,
@@ -242,6 +263,8 @@ class _RecordingDefaultV2Registry:
 
 
 def _runner(mode: RunMode, **kwargs: Any) -> Runner:
+    if mode == RunMode.LIVE and "venue_account_reconciler" not in kwargs:
+        kwargs["venue_account_reconciler"] = MatchingVenueReconciler()
     return Runner(
         config=_settings(mode),
         historical_data_path=FIXTURE_PATH,
@@ -283,6 +306,14 @@ def _stub_factor_service(monkeypatch: pytest.MonkeyPatch) -> None:
             return None
 
     monkeypatch.setattr("pms.runner.FactorService", _NoopFactorService)
+
+
+@pytest.fixture(autouse=True)
+def _stub_live_venue_reconciler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pms.runner.PolymarketVenueAccountReconciler",
+        MatchingVenueReconciler,
+    )
 
 
 def _install_live_doubles(

--- a/tests/unit/test_runner_cp01.py
+++ b/tests/unit/test_runner_cp01.py
@@ -24,7 +24,14 @@ from pms.config import (
     RiskSettings,
 )
 from pms.core.enums import RunMode
-from pms.core.models import MarketSignal, OrderState, Portfolio
+from pms.core.models import (
+    MarketSignal,
+    OrderState,
+    Portfolio,
+    ReconciliationReport,
+    VenueAccountSnapshot,
+    VenueCredentials,
+)
 from pms.market_selection.merge import StrategyMarketSet
 from pms.runner import Runner
 from pms.strategies.projections import (
@@ -46,6 +53,28 @@ class FakePool:
 
     async def close(self) -> None:
         self.closed = True
+
+
+class MatchingVenueReconciler:
+    async def snapshot(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+        del credentials
+        return VenueAccountSnapshot(balances={"USDC": 10_000.0}, open_orders=(), positions=())
+
+    async def compare(
+        self,
+        db_portfolio: Portfolio,
+        venue_snapshot: VenueAccountSnapshot,
+    ) -> ReconciliationReport:
+        del db_portfolio, venue_snapshot
+        return ReconciliationReport(ok=True, mismatches=())
+
+
+@pytest.fixture(autouse=True)
+def _stub_live_venue_reconciler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pms.runner.PolymarketVenueAccountReconciler",
+        MatchingVenueReconciler,
+    )
 
 
 class IdleDiscoverySensor:

--- a/tests/unit/test_runner_decision_persistence_cp07.py
+++ b/tests/unit/test_runner_decision_persistence_cp07.py
@@ -120,6 +120,7 @@ class _RecordingDecisionStore:
     def __init__(self, runner: Runner) -> None:
         self.runner = runner
         self.calls: list[tuple[str, str | None, str]] = []
+        self.transitions: list[tuple[str, str, str, datetime]] = []
         self.created_at: datetime | None = None
         self.expires_at: datetime | None = None
 
@@ -137,6 +138,19 @@ class _RecordingDecisionStore:
         self.calls.append((decision.decision_id, factor_snapshot_hash, status))
         self.created_at = created_at
         self.expires_at = expires_at
+
+    async def update_status(
+        self,
+        decision_id: str,
+        *,
+        current_status: str,
+        next_status: str,
+        updated_at: datetime,
+    ) -> bool:
+        self.transitions.append(
+            (decision_id, current_status, next_status, updated_at)
+        )
+        return True
 
 
 class _RecordingSweepStore:
@@ -180,6 +194,20 @@ async def test_controller_pipeline_persists_decision_before_enqueuing_it() -> No
 
     decision_store = cast(_RecordingDecisionStore, runner.decision_store)
     assert decision_store.calls == [("decision-cp07", "snapshot-cp07", "pending")]
+    assert decision_store.transitions == [
+        (
+            "decision-cp07",
+            "pending",
+            "accepted",
+            datetime(2026, 4, 23, 10, 0, tzinfo=UTC),
+        ),
+        (
+            "decision-cp07",
+            "accepted",
+            "queued",
+            datetime(2026, 4, 23, 10, 0, tzinfo=UTC),
+        ),
+    ]
     assert decision_store.created_at == datetime(2026, 4, 23, 10, 0, tzinfo=UTC)
     assert decision_store.expires_at == datetime(2026, 4, 23, 10, 15, tzinfo=UTC)
 

--- a/tests/unit/test_runner_fill_persistence_cp06.py
+++ b/tests/unit/test_runner_fill_persistence_cp06.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -8,7 +9,8 @@ from typing import Any, cast
 
 import pytest
 
-from pms.config import PMSSettings, RiskSettings
+from pms.actuator.adapters.polymarket import PolymarketSubmissionUnknownError
+from pms.config import ControllerSettings, PMSSettings, PolymarketSettings, RiskSettings
 from pms.core.enums import MarketStatus, OrderStatus, RunMode, Side, TimeInForce
 from pms.core.models import MarketSignal, OrderState, Portfolio, TradeDecision
 from pms.runner import ActuatorWorkItem, Runner
@@ -24,6 +26,28 @@ def _settings() -> PMSSettings:
         risk=RiskSettings(
             max_position_per_market=1000.0,
             max_total_exposure=10_000.0,
+        ),
+    )
+
+
+def _live_settings(tmp_path: Path) -> PMSSettings:
+    return PMSSettings(
+        mode=RunMode.LIVE,
+        live_trading_enabled=True,
+        auto_migrate_default_v2=False,
+        live_emergency_audit_path=str(tmp_path / "live-emergency-audit.jsonl"),
+        controller=ControllerSettings(time_in_force="IOC"),
+        risk=RiskSettings(
+            max_position_per_market=1000.0,
+            max_total_exposure=10_000.0,
+        ),
+        polymarket=PolymarketSettings(
+            private_key="private-key",
+            api_key="api-key",
+            api_secret="api-secret",
+            api_passphrase="passphrase",
+            signature_type=1,
+            funder_address="0xabc",
         ),
     )
 
@@ -160,6 +184,13 @@ class _FlakyOrderStore(_RecordingOrderStore):
             raise RuntimeError("order store down")
 
 
+class _AlwaysFailOrderStore(_RecordingOrderStore):
+    async def insert(self, order: OrderState) -> None:
+        assert self.runner.state.orders[-1] == order
+        self.calls.append(order.market_id)
+        raise RuntimeError("order store down")
+
+
 class _RecordingFillStore:
     def __init__(self, runner: Runner) -> None:
         self.runner = runner
@@ -181,6 +212,49 @@ class _FlakyFillStore(_RecordingFillStore):
         if self.fail_first:
             self.fail_first = False
             raise RuntimeError("fill store down")
+
+
+class _AlwaysFailFillStore(_RecordingFillStore):
+    async def insert(self, fill: Any) -> None:
+        assert self.runner.state.fills[-1] == fill
+        self.calls.append(fill.market_id)
+        raise RuntimeError("fill store down")
+
+
+class _SubmissionUnknownExecutorDouble:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def execute(
+        self,
+        decision: TradeDecision,
+        portfolio: Portfolio,
+        *,
+        dedup_acquired: bool = False,
+    ) -> OrderState:
+        del portfolio, dedup_acquired
+        self.calls.append(decision.market_id)
+        raise PolymarketSubmissionUnknownError(
+            "venue timeout",
+            order_state=_matched_order(decision),
+        )
+
+
+class _DecisionStatusStore:
+    def __init__(self) -> None:
+        self.transitions: list[tuple[str, str, str]] = []
+
+    async def update_status(
+        self,
+        decision_id: str,
+        *,
+        current_status: str,
+        next_status: str,
+        updated_at: datetime,
+    ) -> bool:
+        del updated_at
+        self.transitions.append((decision_id, current_status, next_status))
+        return True
 
 
 def _mark_controller_done(runner: Runner) -> None:
@@ -333,4 +407,135 @@ async def test_actuator_loop_supports_legacy_executor_without_dedup_kwarg() -> N
     assert [fill.market_id for fill in runner.state.fills] == ["market-cp06-legacy"]
     assert cast(_LegacyExecutorDouble, runner.actuator_executor).calls == [
         "market-cp06-legacy"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_order_persistence_failure_suspends_trading(
+    tmp_path: Path,
+) -> None:
+    runner = Runner(config=_live_settings(tmp_path))
+    runner.actuator_executor = cast(Any, _ExecutorDouble())
+    runner._evaluator_spool = cast(Any, _EvaluatorSpoolDouble())  # noqa: SLF001
+    runner.order_store = cast(Any, _AlwaysFailOrderStore(runner))
+    runner.fill_store = cast(Any, _RecordingFillStore(runner))
+    _mark_controller_done(runner)
+
+    await runner._decision_queue.put(  # noqa: SLF001
+        ActuatorWorkItem(
+            _decision(market_id="market-live-order-fail"),
+            _signal(market_id="market-live-order-fail"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="LIVE persistence failure"):
+        await _run_actuator_loop(runner)
+
+    assert runner.live_trading_suspended is True
+    assert runner._stop_event.is_set()  # noqa: SLF001
+    assert runner.portfolio.locked_usdc == pytest.approx(0.0)
+    assert cast(_RecordingFillStore, runner.fill_store).calls == []
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "live-emergency-audit.jsonl").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    assert audit_rows[0]["phase"] == "order_state"
+    assert audit_rows[0]["decision_id"] == "decision-market-live-order-fail"
+    assert audit_rows[0]["order_id"] == "order-market-live-order-fail"
+
+
+@pytest.mark.asyncio
+async def test_live_fill_persistence_failure_suspends_trading(
+    tmp_path: Path,
+) -> None:
+    runner = Runner(config=_live_settings(tmp_path))
+    runner.actuator_executor = cast(Any, _ExecutorDouble())
+    runner._evaluator_spool = cast(Any, _EvaluatorSpoolDouble())  # noqa: SLF001
+    runner.order_store = cast(Any, _RecordingOrderStore(runner))
+    runner.fill_store = cast(Any, _AlwaysFailFillStore(runner))
+    _mark_controller_done(runner)
+
+    await runner._decision_queue.put(  # noqa: SLF001
+        ActuatorWorkItem(
+            _decision(market_id="market-live-fill-fail"),
+            _signal(market_id="market-live-fill-fail"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="LIVE persistence failure"):
+        await _run_actuator_loop(runner)
+
+    assert runner.live_trading_suspended is True
+    assert runner._stop_event.is_set()  # noqa: SLF001
+    assert runner.portfolio.locked_usdc == pytest.approx(0.0)
+    assert cast(_EvaluatorSpoolDouble, runner._evaluator_spool).calls == []
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "live-emergency-audit.jsonl").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    assert audit_rows[0]["phase"] == "fill"
+    assert audit_rows[0]["decision_id"] == "decision-market-live-fill-fail"
+    assert audit_rows[0]["order_id"] == "order-market-live-fill-fail"
+
+
+@pytest.mark.asyncio
+async def test_submission_unknown_persistence_failure_hard_halts(
+    tmp_path: Path,
+) -> None:
+    runner = Runner(config=_live_settings(tmp_path))
+    runner.actuator_executor = cast(Any, _SubmissionUnknownExecutorDouble())
+    runner.order_store = cast(Any, _AlwaysFailOrderStore(runner))
+    runner.fill_store = cast(Any, _RecordingFillStore(runner))
+    _mark_controller_done(runner)
+
+    await runner._decision_queue.put(  # noqa: SLF001
+        ActuatorWorkItem(
+            _decision(market_id="market-submission-unknown-store-fail"),
+            _signal(market_id="market-submission-unknown-store-fail"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="LIVE persistence failure"):
+        await _run_actuator_loop(runner)
+
+    assert runner.live_trading_suspended is True
+    assert runner._stop_event.is_set()  # noqa: SLF001
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "live-emergency-audit.jsonl").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    assert audit_rows[0]["phase"] == "submission_unknown_order_state"
+    assert audit_rows[0]["decision_id"] == (
+        "decision-market-submission-unknown-store-fail"
+    )
+
+
+@pytest.mark.asyncio
+async def test_actuator_loop_advances_decision_status_through_filled() -> None:
+    runner = _runner()
+    runner.actuator_executor = cast(Any, _ExecutorDouble())
+    runner._evaluator_spool = cast(Any, _EvaluatorSpoolDouble())  # noqa: SLF001
+    runner.order_store = cast(Any, _RecordingOrderStore(runner))
+    runner.fill_store = cast(Any, _RecordingFillStore(runner))
+    runner.decision_store = cast(Any, _DecisionStatusStore())
+    _mark_controller_done(runner)
+
+    await runner._decision_queue.put(  # noqa: SLF001
+        ActuatorWorkItem(
+            _decision(market_id="market-decision-status"),
+            _signal(market_id="market-decision-status"),
+        )
+    )
+
+    await _run_actuator_loop(runner)
+
+    assert cast(_DecisionStatusStore, runner.decision_store).transitions == [
+        ("decision-market-decision-status", "queued", "submitted"),
+        ("decision-market-decision-status", "submitted", "filled"),
     ]

--- a/tests/unit/test_strategy_change_reselection.py
+++ b/tests/unit/test_strategy_change_reselection.py
@@ -18,7 +18,13 @@ from pms.config import (
     RiskSettings,
 )
 from pms.core.enums import RunMode
-from pms.core.models import MarketSignal
+from pms.core.models import (
+    MarketSignal,
+    Portfolio,
+    ReconciliationReport,
+    VenueAccountSnapshot,
+    VenueCredentials,
+)
 from pms.market_selection.merge import StrategyMarketSet
 from pms.runner import Runner
 from pms.storage.strategy_registry import PostgresStrategyRegistry
@@ -95,6 +101,28 @@ class FakePool:
 
     def acquire(self) -> FakeAcquire:
         return FakeAcquire(self._connection)
+
+
+class MatchingVenueReconciler:
+    async def snapshot(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+        del credentials
+        return VenueAccountSnapshot(balances={"USDC": 10_000.0}, open_orders=(), positions=())
+
+    async def compare(
+        self,
+        db_portfolio: Portfolio,
+        venue_snapshot: VenueAccountSnapshot,
+    ) -> ReconciliationReport:
+        del db_portfolio, venue_snapshot
+        return ReconciliationReport(ok=True, mismatches=())
+
+
+@pytest.fixture(autouse=True)
+def _stub_live_venue_reconciler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pms.runner.PolymarketVenueAccountReconciler",
+        MatchingVenueReconciler,
+    )
 
 
 @dataclass

--- a/tests/unit/test_strategy_lifecycle_cp08.py
+++ b/tests/unit/test_strategy_lifecycle_cp08.py
@@ -19,7 +19,15 @@ from pms.config import (
     RiskSettings,
 )
 from pms.core.enums import RunMode, TimeInForce
-from pms.core.models import MarketSignal, Opportunity, Portfolio, TradeDecision
+from pms.core.models import (
+    MarketSignal,
+    Opportunity,
+    Portfolio,
+    ReconciliationReport,
+    TradeDecision,
+    VenueAccountSnapshot,
+    VenueCredentials,
+)
 from pms.market_selection.merge import StrategyMarketSet
 from pms.runner import ControllerReleaseCancelPoint, Runner
 from pms.strategies.projections import (
@@ -41,6 +49,28 @@ class FakePool:
 
     async def close(self) -> None:
         self.close_calls += 1
+
+
+class MatchingVenueReconciler:
+    async def snapshot(self, credentials: VenueCredentials) -> VenueAccountSnapshot:
+        del credentials
+        return VenueAccountSnapshot(balances={"USDC": 10_000.0}, open_orders=(), positions=())
+
+    async def compare(
+        self,
+        db_portfolio: Portfolio,
+        venue_snapshot: VenueAccountSnapshot,
+    ) -> ReconciliationReport:
+        del db_portfolio, venue_snapshot
+        return ReconciliationReport(ok=True, mismatches=())
+
+
+@pytest.fixture(autouse=True)
+def _stub_live_venue_reconciler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "pms.runner.PolymarketVenueAccountReconciler",
+        MatchingVenueReconciler,
+    )
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Hard-halt LIVE trading on order/fill/submission_unknown persistence failures, with append-only emergency audit fallback.
- Require LIVE venue account reconciliation by default; compare venue open orders, positions, and USDC cash against PMS state before autonomous start.
- Advance submission_unknown incidents through the decision lifecycle when reconciled, and add cancelled_market_resolved schema support.
- Add Polymarket direct/dual quote routing, venue tradability flag parsing, future book timestamp rejection, market live-status fields, and runbook/config updates.

## Why
Autonomous LIVE trading must not continue after a venue-side submission if durable order/fill state cannot be persisted, and it must not start if the venue account cannot be reconciled against PMS state. This closes the highest-risk split-brain paths between venue exposure, PMS portfolio state, decisions, intents, and operator audit trails.

## Validation
- `uv sync`
- `uv run pytest -q` -> `767 passed, 158 skipped`
- `uv run mypy src/ tests/ --strict` -> `Success: no issues found in 300 source files`
- `uv run lint-imports` -> `7 kept, 0 broken`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Market operational status fields (active, closed, accepting orders) now tracked
  - Multiple quote sourcing strategies: database snapshot, direct venue, or dual-mode with cross-validation
  - Live account reconciliation and emergency audit logging for trading safety

* **Configuration Changes**
  - Quote source selection and validation parameters
  - Emergency audit logging path configuration
  - Live reconciliation requirement settings

* **Database Updates**
  - Market status tracking columns and timestamp
  - New order outcome value for market-resolved cancellations

* **Documentation**
  - Updated live trading runbook with reconciliation gating requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->