### PR TITLE
[PMS P0-2] Replace Ripple fixture source with live factor source

### DIFF
--- a/src/pms/strategies/ripple/__init__.py
+++ b/src/pms/strategies/ripple/__init__.py
@@ -1,13 +1,20 @@
-"""Deterministic fixture-driven ripple strategy plugin."""
+"""Ripple strategy plugin."""
 
 from pms.strategies.ripple.agent import RippleAgent
 from pms.strategies.ripple.controller import RippleController
-from pms.strategies.ripple.source import RippleObservationFixture, RippleObservationSource
+from pms.strategies.ripple.source import (
+    LiveRippleSource,
+    RippleMarketSnapshot,
+    RippleObservationFixture,
+    RippleObservationSource,
+)
 from pms.strategies.ripple.strategy import RippleStrategyModule
 
 __all__ = [
+    "LiveRippleSource",
     "RippleAgent",
     "RippleController",
+    "RippleMarketSnapshot",
     "RippleObservationFixture",
     "RippleObservationSource",
     "RippleStrategyModule",

--- a/src/pms/strategies/ripple/source.py
+++ b/src/pms/strategies/ripple/source.py
@@ -1,14 +1,102 @@
-"""Fixture-backed observation source for the ripple strategy."""
+"""Observation sources for the ripple strategy."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
+from typing import Protocol
 
 from pms.core.enums import TimeInForce
 from pms.core.models import BookSide, Outcome, Venue
 from pms.strategies.intents import StrategyContext, StrategyObservation
+from pms.strategies.projections import FactorCompositionStep
+
+
+LIVE_RIPPLE_SOURCE = "live_factor_service"
+RIPPLE_FACTOR_REQUIREMENTS: tuple[FactorCompositionStep, ...] = (
+    FactorCompositionStep(
+        factor_id="metaculus_prior",
+        role="posterior_prior",
+        param="",
+        weight=2.0,
+        threshold=None,
+        required=True,
+        freshness_sla_s=3600.0,
+    ),
+    FactorCompositionStep(
+        factor_id="orderbook_imbalance",
+        role="weighted",
+        param="",
+        weight=1.0,
+        threshold=None,
+        required=True,
+        freshness_sla_s=30.0,
+    ),
+    FactorCompositionStep(
+        factor_id="fair_value_spread",
+        role="threshold_edge",
+        param="",
+        weight=1.0,
+        threshold=0.0,
+        required=True,
+        freshness_sla_s=3600.0,
+    ),
+)
+
+
+FactorKey = tuple[str, str]
+
+
+class RippleFactorSnapshot(Protocol):
+    values: Mapping[FactorKey, float]
+    missing_factors: tuple[FactorKey, ...]
+    stale_factors: tuple[FactorKey, ...]
+    snapshot_hash: str | None
+
+
+class RippleFactorSnapshotReader(Protocol):
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> RippleFactorSnapshot: ...
+
+
+class RippleMarketSnapshotReader(Protocol):
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> RippleMarketSnapshot | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class RippleMarketSnapshot:
+    market_id: str
+    title: str
+    token_id: str
+    yes_price: float
+    observed_at: datetime
+    best_bid: float | None = None
+    best_ask: float | None = None
+    venue: Venue = "polymarket"
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.market_id, "market_id")
+        _require_non_empty(self.title, "title")
+        _require_non_empty(self.token_id, "token_id")
+        _require_open_probability(self.yes_price, "yes_price")
+        if self.best_bid is not None:
+            _require_open_probability(self.best_bid, "best_bid")
+        if self.best_ask is not None:
+            _require_open_probability(self.best_ask, "best_ask")
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,7 +182,204 @@ class RippleObservationSource:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class LiveRippleSource:
+    """Live factor-backed source.
+
+    The concrete production factor reader should be
+    ``PostgresFactorSnapshotReader`` from the controller layer. This strategy
+    plugin keeps that dependency injected to preserve the strategy boundary
+    enforced by the import-linter contract.
+    """
+
+    market_ids: Sequence[str]
+    factor_reader: RippleFactorSnapshotReader
+    market_reader: RippleMarketSnapshotReader
+    notional_usdc: float = 25.0
+    max_slippage_bps: int = 50
+    time_in_force: TimeInForce = TimeInForce.GTC
+
+    def __post_init__(self) -> None:
+        if not self.market_ids:
+            msg = "market_ids must not be empty"
+            raise ValueError(msg)
+        for market_id in self.market_ids:
+            _require_non_empty(market_id, "market_id")
+        if self.notional_usdc <= 0.0:
+            msg = "notional_usdc must be > 0.0"
+            raise ValueError(msg)
+        if self.max_slippage_bps < 0:
+            msg = "max_slippage_bps must be >= 0"
+            raise ValueError(msg)
+
+    async def observe(self, context: StrategyContext) -> Sequence[StrategyObservation]:
+        observations: list[StrategyObservation] = []
+        for market_id in self.market_ids:
+            market = await self.market_reader.latest(
+                market_id,
+                as_of=context.as_of,
+            )
+            if market is None:
+                continue
+            snapshot = await self.factor_reader.snapshot(
+                market_id=market_id,
+                as_of=context.as_of,
+                required=RIPPLE_FACTOR_REQUIREMENTS,
+                strategy_id=context.strategy_id,
+                strategy_version_id=context.strategy_version_id,
+            )
+            observations.append(
+                _live_observation(
+                    context=context,
+                    market=market,
+                    snapshot=snapshot,
+                    notional_usdc=self.notional_usdc,
+                    max_slippage_bps=self.max_slippage_bps,
+                    time_in_force=self.time_in_force,
+                )
+            )
+        return tuple(observations)
+
+
 def _require_non_empty(value: str, field_name: str) -> None:
     if not value:
         msg = f"{field_name} must be non-empty"
         raise ValueError(msg)
+
+
+def _require_open_probability(value: float, field_name: str) -> None:
+    if value <= 0.0 or value >= 1.0:
+        msg = f"{field_name} must satisfy 0.0 < value < 1.0"
+        raise ValueError(msg)
+
+
+def _live_observation(
+    *,
+    context: StrategyContext,
+    market: RippleMarketSnapshot,
+    snapshot: RippleFactorSnapshot,
+    notional_usdc: float,
+    max_slippage_bps: int,
+    time_in_force: TimeInForce,
+) -> StrategyObservation:
+    probability_estimate = _bounded_probability(
+        _factor_value(snapshot, "metaculus_prior", fallback=market.yes_price),
+        "probability_estimate",
+    )
+    expected_edge = _factor_value(
+        snapshot,
+        "fair_value_spread",
+        fallback=probability_estimate - market.yes_price,
+    )
+    orderbook_imbalance = _factor_value(snapshot, "orderbook_imbalance", fallback=0.0)
+    limit_price = _bounded_probability(
+        market.best_ask if market.best_ask is not None else market.yes_price,
+        "limit_price",
+    )
+    evidence_refs = _live_evidence_refs(market, snapshot)
+    payload_metadata = {
+        "source": LIVE_RIPPLE_SOURCE,
+        "factor_snapshot_hash": snapshot.snapshot_hash,
+        "factor_values": _string_factor_values(snapshot.values),
+        "missing_factors": _string_factor_keys(snapshot.missing_factors),
+        "stale_factors": _string_factor_keys(snapshot.stale_factors),
+        "yes_price": market.yes_price,
+        "best_bid": market.best_bid,
+        "best_ask": market.best_ask,
+        "observed_at": market.observed_at.isoformat(),
+        "orderbook_imbalance": orderbook_imbalance,
+    }
+    payload = {
+        "market_id": market.market_id,
+        "title": market.title,
+        "thesis": (
+            "Live factor snapshot supports a YES edge of "
+            f"{expected_edge:.4f} against market price {market.yes_price:.4f}."
+        ),
+        "probability_estimate": probability_estimate,
+        "expected_edge": expected_edge,
+        "confidence": _live_confidence(snapshot),
+        "token_id": market.token_id,
+        "venue": market.venue,
+        "side": "BUY",
+        "outcome": "YES",
+        "limit_price": limit_price,
+        "notional_usdc": notional_usdc,
+        "expected_price": probability_estimate,
+        "max_slippage_bps": max_slippage_bps,
+        "time_in_force": time_in_force,
+        "contradiction_refs": (),
+        "metadata": payload_metadata,
+    }
+    return StrategyObservation(
+        observation_id=(
+            f"live-ripple-{market.market_id}-{context.as_of.isoformat()}"
+        ),
+        strategy_id=context.strategy_id,
+        strategy_version_id=context.strategy_version_id,
+        source=LIVE_RIPPLE_SOURCE,
+        observed_at=context.as_of,
+        summary=str(payload["thesis"]),
+        payload=payload,
+        evidence_refs=evidence_refs,
+    )
+
+
+def _factor_value(
+    snapshot: RippleFactorSnapshot,
+    factor_id: str,
+    *,
+    fallback: float,
+) -> float:
+    value = snapshot.values.get((factor_id, ""))
+    if value is None:
+        return fallback
+    return float(value)
+
+
+def _bounded_probability(value: float, field_name: str) -> float:
+    if value <= 0.0:
+        return 0.0001
+    if value >= 1.0:
+        return 0.9999
+    if value != value:
+        msg = f"{field_name} must not be NaN"
+        raise ValueError(msg)
+    return float(value)
+
+
+def _live_confidence(snapshot: RippleFactorSnapshot) -> float:
+    if snapshot.missing_factors or snapshot.stale_factors:
+        return 0.55
+    return 0.75
+
+
+def _live_evidence_refs(
+    market: RippleMarketSnapshot,
+    snapshot: RippleFactorSnapshot,
+) -> tuple[str, ...]:
+    factor_ref = (
+        f"factor_snapshot:{snapshot.snapshot_hash}"
+        if snapshot.snapshot_hash
+        else "factor_snapshot:unhashed"
+    )
+    market_ref = (
+        f"market_snapshot:{market.market_id}:{market.observed_at.isoformat()}"
+    )
+    return (factor_ref, market_ref)
+
+
+def _string_factor_values(values: Mapping[FactorKey, float]) -> dict[str, float]:
+    return {
+        _factor_key_label(key): float(values[key])
+        for key in sorted(values)
+    }
+
+
+def _string_factor_keys(keys: Sequence[FactorKey]) -> tuple[str, ...]:
+    return tuple(_factor_key_label(key) for key in keys)
+
+
+def _factor_key_label(key: FactorKey) -> str:
+    factor_id, param = key
+    return factor_id if not param else f"{factor_id}:{param}"

--- a/tests/unit/test_ripple_strategy_plugin.py
+++ b/tests/unit/test_ripple_strategy_plugin.py
@@ -24,7 +24,12 @@ from pms.strategies.intents import (
 )
 from pms.strategies.ripple.agent import RippleAgent
 from pms.strategies.ripple.controller import RippleController
-from pms.strategies.ripple.source import RippleObservationFixture, RippleObservationSource
+from pms.strategies.ripple.source import (
+    LiveRippleSource,
+    RippleMarketSnapshot,
+    RippleObservationFixture,
+    RippleObservationSource,
+)
 from pms.strategies.ripple.strategy import RippleStrategyModule
 
 
@@ -59,6 +64,45 @@ def _fixture(**overrides: object) -> RippleObservationFixture:
     }
     data.update(overrides)
     return RippleObservationFixture(**cast(Any, data))
+
+
+class _FakeFactorSnapshot:
+    values = {
+        ("metaculus_prior", ""): 0.67,
+        ("orderbook_imbalance", ""): 0.21,
+        ("fair_value_spread", ""): 0.08,
+    }
+    missing_factors: tuple[tuple[str, str], ...] = ()
+    stale_factors: tuple[tuple[str, str], ...] = ()
+    snapshot_hash = "factor-hash-1"
+
+
+class _RecordingFactorReader:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def snapshot(self, **kwargs: object) -> _FakeFactorSnapshot:
+        self.calls.append(kwargs)
+        return _FakeFactorSnapshot()
+
+
+class _StaticMarketReader:
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> RippleMarketSnapshot | None:
+        del as_of
+        return RippleMarketSnapshot(
+            market_id=market_id,
+            title="Will the live factor source resolve YES?",
+            token_id="token-ripple-yes",
+            yes_price=0.59,
+            best_bid=0.58,
+            best_ask=0.60,
+            observed_at=NOW,
+        )
 
 
 async def _candidate_from_fixture(
@@ -107,6 +151,56 @@ async def test_ripple_strategy_approves_fixture_candidate_and_emits_trade_intent
     assert intent.candidate_id == "candidate-ripple-observation-1"
     assert intent.token_id == "token-ripple-yes"
     assert intent.time_in_force is TimeInForce.GTC
+
+
+@pytest.mark.asyncio
+async def test_live_ripple_source_reads_factor_snapshot_and_market_price() -> None:
+    factor_reader = _RecordingFactorReader()
+    source = LiveRippleSource(
+        market_ids=("market-ripple-1",),
+        factor_reader=factor_reader,
+        market_reader=_StaticMarketReader(),
+    )
+
+    observations = await source.observe(_context())
+    candidates = await RippleController().propose(_context(), observations)
+
+    assert len(observations) == 1
+    observation = observations[0]
+    assert observation.source == "live_factor_service"
+    assert observation.payload["probability_estimate"] == 0.67
+    assert observation.payload["expected_edge"] == 0.08
+    assert observation.payload["limit_price"] == 0.60
+    assert observation.payload["expected_price"] == 0.67
+    assert observation.payload["metadata"]["yes_price"] == 0.59
+    assert observation.payload["metadata"]["factor_values"] == {
+        "fair_value_spread": 0.08,
+        "metaculus_prior": 0.67,
+        "orderbook_imbalance": 0.21,
+    }
+    assert observation.evidence_refs == (
+        "factor_snapshot:factor-hash-1",
+        "market_snapshot:market-ripple-1:2026-04-28T12:00:00+00:00",
+    )
+    assert len(factor_reader.calls) == 1
+    call = factor_reader.calls[0]
+    assert call["market_id"] == "market-ripple-1"
+    assert call["as_of"] == NOW
+    assert call["strategy_id"] == "ripple"
+    assert call["strategy_version_id"] == "ripple-v1"
+    required_factor_ids = {
+        step.factor_id
+        for step in cast(Any, call["required"])
+    }
+    assert required_factor_ids == {
+        "fair_value_spread",
+        "metaculus_prior",
+        "orderbook_imbalance",
+    }
+    assert candidates[0].metadata["source"] == "live_factor_service"
+    assert candidates[0].metadata["fixture_metadata"]["factor_snapshot_hash"] == (
+        "factor-hash-1"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_ripple_strategy_plugin.py
+++ b/tests/unit/test_ripple_strategy_plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -31,6 +31,7 @@ from pms.strategies.ripple.source import (
     RippleObservationSource,
 )
 from pms.strategies.ripple.strategy import RippleStrategyModule
+from pms.strategies.projections import FactorCompositionStep
 
 
 NOW = datetime(2026, 4, 28, 12, 0, tzinfo=UTC)
@@ -67,22 +68,38 @@ def _fixture(**overrides: object) -> RippleObservationFixture:
 
 
 class _FakeFactorSnapshot:
-    values = {
+    values: Mapping[tuple[str, str], float] = {
         ("metaculus_prior", ""): 0.67,
         ("orderbook_imbalance", ""): 0.21,
         ("fair_value_spread", ""): 0.08,
     }
     missing_factors: tuple[tuple[str, str], ...] = ()
     stale_factors: tuple[tuple[str, str], ...] = ()
-    snapshot_hash = "factor-hash-1"
+    snapshot_hash: str | None = "factor-hash-1"
 
 
 class _RecordingFactorReader:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
-    async def snapshot(self, **kwargs: object) -> _FakeFactorSnapshot:
-        self.calls.append(kwargs)
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> _FakeFactorSnapshot:
+        self.calls.append(
+            {
+                "market_id": market_id,
+                "as_of": as_of,
+                "required": required,
+                "strategy_id": strategy_id,
+                "strategy_version_id": strategy_version_id,
+            }
+        )
         return _FakeFactorSnapshot()
 
 


### PR DESCRIPTION
## Summary

Implements PMS P0-2 as a task-specific PR:

- Adds `LiveRippleSource` and `RippleMarketSnapshot` for live factor-backed Ripple observations.
- Emits production source identifier `live_factor_service` while preserving `ripple-fixture` for fixture/test paths.
- Consumes `metaculus_prior`, `fair_value_spread`, `orderbook_imbalance`, and live market/book snapshot fields through injected readers.
- Keeps the strategy plugin boundary clean: no controller, actuator, or venue adapter imports in the Ripple strategy package.
- Adds replay/debug metadata such as `factor_snapshot_hash`, `missing_factors`, and `stale_factors`.

## Scope Hygiene

This branch was rebuilt from current `origin/main` after review found the earlier task #4 branch had bundled LLM forecaster work. This PR is now scoped only to P0-2.

```text
$ git log --oneline origin/main..HEAD
47fef02 feat(strategies): add live ripple factor source
329ba13 test(strategies): define live ripple factor source contract

$ git diff --name-only origin/main...HEAD
src/pms/strategies/ripple/__init__.py
src/pms/strategies/ripple/source.py
tests/unit/test_ripple_strategy_plugin.py
```

## Screenshots / Runtime Evidence

No UI screenshots apply; this is a backend strategy-source PR. Validation evidence is command output.

```text
$ uv run pytest tests/unit/test_ripple_strategy_plugin.py tests/unit/test_strategy_plugin_intents.py tests/unit/test_agent_strategy_runtime_bridge.py -q
...........................                                              [100%]
27 passed in 0.23s

$ uv run pytest tests/unit/test_import_linter_contracts.py tests/unit/test_controller_runtime_selection_contract_cp01.py -q
...........                                                              [100%]
11 passed in 0.73s

$ uv run ruff check src/pms/strategies/ripple tests/unit/test_ripple_strategy_plugin.py
All checks passed!

$ uv run mypy src/pms/strategies/ripple tests/unit/test_ripple_strategy_plugin.py
Success: no issues found in 8 source files

$ uv run lint-imports
Contracts: 8 kept, 0 broken.
```

## Review Notes

@claude approved the strategy-code implementation in Slock and confirmed the approval applies unchanged to this clean branch. Trace ID remains a downstream integration concern because the current strategy context surface has no explicit `trace_id` field; this PR preserves that boundary and records `factor_snapshot_hash` plus missing/stale factor evidence for correlation.