### PR TITLE
[PMS P0-1] Activate LLM forecaster

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ pms-live = "pms.live_cli:main"
 pms-research = "pms.research.cli:main"
 
 [project.optional-dependencies]
-# CP05: Anthropic SDK powers the optional LLM forecaster. Install with
-# `uv pip install 'pms[llm]'`. LLMForecaster imports it lazily, so the default
-# rule-based/statistical controller path does not require it.
-llm = ["anthropic>=0.40.0"]
+# CP05/P0-1: Provider SDKs power the optional LLM forecaster. Install with
+# `uv pip install 'pms[llm]'`. LLMForecaster imports them lazily, so the default
+# rule-based/statistical controller path does not require them.
+llm = ["anthropic>=0.40.0", "openai>=1.50.0"]
 live = ["py-clob-client-v2>=1.0.0,<2.0.0"]
 
 [dependency-groups]

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -49,10 +49,10 @@ class LLMSettings(BaseModel):
     api_key: str | None = None
     base_url: str | None = None
     model: str = "claude-sonnet-4-6"
-    timeout_s: float = 5.0
-    cache_ttl_s: float = 30.0
-    max_tokens: int = 256
-    max_daily_llm_cost_usdc: float | None = 5.0
+    timeout_s: float = Field(default=5.0, gt=0)
+    cache_ttl_s: float = Field(default=30.0, ge=0)
+    max_tokens: int = Field(default=256, gt=0)
+    max_daily_llm_cost_usdc: float | None = Field(default=5.0, gt=0)
 
     @model_validator(mode="after")
     def _validate_when_enabled(self) -> Self:

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Literal, Self
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pms.core.enums import RunMode
@@ -45,9 +45,26 @@ class PolymarketSettings(BaseModel):
 
 class LLMSettings(BaseModel):
     enabled: bool = False
-    provider: str | None = None
+    provider: Literal["anthropic", "openai"] | None = None
     api_key: str | None = None
-    model: str = "claude-3-5-sonnet-latest"
+    base_url: str | None = None
+    model: str = "claude-sonnet-4-6"
+    timeout_s: float = 5.0
+    cache_ttl_s: float = 30.0
+    max_tokens: int = 256
+    max_daily_llm_cost_usdc: float | None = 5.0
+
+    @model_validator(mode="after")
+    def _validate_when_enabled(self) -> Self:
+        if not self.enabled:
+            return self
+        if self.provider is None:
+            raise ValueError("provider is required when LLM is enabled")
+        if not self.api_key:
+            raise ValueError("api_key is required when LLM is enabled")
+        if self.provider == "openai" and not self.base_url:
+            raise ValueError("base_url is required when provider is openai")
+        return self
 
 
 class ControllerSettings(BaseModel):

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -62,8 +62,6 @@ class LLMSettings(BaseModel):
             raise ValueError("provider is required when LLM is enabled")
         if not self.api_key:
             raise ValueError("api_key is required when LLM is enabled")
-        if self.provider == "openai" and not self.base_url:
-            raise ValueError("base_url is required when provider is openai")
         return self
 
 

--- a/src/pms/controller/forecasters/llm.py
+++ b/src/pms/controller/forecasters/llm.py
@@ -11,6 +11,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from importlib import import_module
 from typing import Protocol, Self, cast
+from weakref import ReferenceType, ref
 
 from pms.config import LLMSettings
 from pms.core.models import MarketSignal
@@ -24,6 +25,17 @@ _SYSTEM_PROMPT = (
     "prob_estimate, confidence, and rationale."
 )
 _ESTIMATED_CALL_COST_USDC = Decimal("0.002")
+
+
+@dataclass
+class _BudgetTracker:
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    cost_day: date | None = None
+    daily_cost_usdc: Decimal = Decimal("0")
+
+
+_BUDGET_TRACKERS: dict[int, tuple[ReferenceType[LLMSettings], _BudgetTracker]] = {}
+_BUDGET_TRACKERS_LOCK = threading.Lock()
 
 
 class _LLMClient(Protocol):
@@ -63,9 +75,6 @@ class LLMForecaster:
     client: object | None = None
     _cache: dict[str, tuple[float, LLMForecastResult]] = field(default_factory=dict)
     _cache_lock: threading.Lock = field(default_factory=threading.Lock)
-    _cost_lock: threading.Lock = field(default_factory=threading.Lock)
-    _cost_day: date | None = None
-    _daily_cost_usdc: Decimal = field(default_factory=lambda: Decimal("0"))
 
     def __post_init__(self) -> None:
         if self.config is None:
@@ -273,28 +282,30 @@ class LLMForecaster:
 
     def _reserve_budget(self, estimated_cost_usdc: Decimal) -> bool:
         assert self.config is not None
-        with self._cost_lock:
+        tracker = self._budget_tracker()
+        with tracker.lock:
             today = _today_utc()
-            if self._cost_day != today:
-                self._cost_day = today
-                self._daily_cost_usdc = Decimal("0")
+            if tracker.cost_day != today:
+                tracker.cost_day = today
+                tracker.daily_cost_usdc = Decimal("0")
             max_daily = self.config.max_daily_llm_cost_usdc
             max_daily_decimal = (
                 None if max_daily is None else Decimal(str(max_daily))
             )
             if (
                 max_daily_decimal is not None
-                and self._daily_cost_usdc + estimated_cost_usdc > max_daily_decimal
+                and tracker.daily_cost_usdc + estimated_cost_usdc > max_daily_decimal
             ):
                 return False
-            self._daily_cost_usdc += estimated_cost_usdc
+            tracker.daily_cost_usdc += estimated_cost_usdc
             return True
 
     def _refund_budget(self, estimated_cost_usdc: Decimal) -> None:
-        with self._cost_lock:
-            self._daily_cost_usdc = max(
+        tracker = self._budget_tracker()
+        with tracker.lock:
+            tracker.daily_cost_usdc = max(
                 Decimal("0"),
-                self._daily_cost_usdc - estimated_cost_usdc,
+                tracker.daily_cost_usdc - estimated_cost_usdc,
             )
 
     def _record_cost(self, estimated_cost_usdc: Decimal, signal: MarketSignal) -> None:
@@ -313,8 +324,21 @@ class LLMForecaster:
         )
 
     def _daily_cost_usdc_float(self) -> float:
-        with self._cost_lock:
-            return float(self._daily_cost_usdc)
+        tracker = self._budget_tracker()
+        with tracker.lock:
+            return float(tracker.daily_cost_usdc)
+
+    def _budget_tracker(self) -> _BudgetTracker:
+        assert self.config is not None
+        key = id(self.config)
+        with _BUDGET_TRACKERS_LOCK:
+            entry = _BUDGET_TRACKERS.get(key)
+            if entry is not None and entry[0]() is self.config:
+                return entry[1]
+            else:
+                tracker = _BudgetTracker()
+                _BUDGET_TRACKERS[key] = (ref(self.config), tracker)
+            return tracker
 
 
 def _safe_import(name: str) -> object | None:

--- a/src/pms/controller/forecasters/llm.py
+++ b/src/pms/controller/forecasters/llm.py
@@ -8,6 +8,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
+from decimal import Decimal
 from importlib import import_module
 from typing import Protocol, Self, cast
 
@@ -22,7 +23,7 @@ _SYSTEM_PROMPT = (
     "orderbook, and external signals as evidence. Return valid JSON only with "
     "prob_estimate, confidence, and rationale."
 )
-_ESTIMATED_CALL_COST_USDC = 0.002
+_ESTIMATED_CALL_COST_USDC = Decimal("0.002")
 
 
 class _LLMClient(Protocol):
@@ -64,7 +65,7 @@ class LLMForecaster:
     _cache_lock: threading.Lock = field(default_factory=threading.Lock)
     _cost_lock: threading.Lock = field(default_factory=threading.Lock)
     _cost_day: date | None = None
-    _daily_cost_usdc: float = 0.0
+    _daily_cost_usdc: Decimal = field(default_factory=lambda: Decimal("0"))
 
     def __post_init__(self) -> None:
         if self.config is None:
@@ -77,26 +78,30 @@ class LLMForecaster:
         if cached is not None:
             return cached
         estimated_cost = self._estimated_call_cost_usdc()
-        if not self._check_budget(estimated_cost):
+        if not self._reserve_budget(estimated_cost):
             logger.info(
                 "llm_forecaster_budget_exhausted",
                 extra={
                     "market_id": signal.market_id,
                     "provider": self.config.provider,
                     "model": self.config.model,
-                    "estimated_cost_usdc": estimated_cost,
-                    "daily_cost_usdc": self._daily_cost_usdc,
+                    "estimated_cost_usdc": float(estimated_cost),
+                    "daily_cost_usdc": self._daily_cost_usdc_float(),
                     "max_daily_llm_cost_usdc": self.config.max_daily_llm_cost_usdc,
                 },
             )
             return None
         client = self._client()
         if client is None:
+            self._refund_budget(estimated_cost)
             return None
         try:
             raw = self._call(client, signal)
             self._record_cost(estimated_cost, signal)
             result = self._parse(raw)
+        except (LLMTimeoutError, LLMTransientError):
+            self._refund_budget(estimated_cost)
+            return None
         except (LLMTimeoutError, LLMTransientError, LLMParseError):
             return None
         self._cache_put(signal.market_id, result)
@@ -263,39 +268,53 @@ class LLMForecaster:
                 oldest = min(self._cache, key=lambda k: self._cache[k][0])
                 del self._cache[oldest]
 
-    def _estimated_call_cost_usdc(self) -> float:
+    def _estimated_call_cost_usdc(self) -> Decimal:
         return _ESTIMATED_CALL_COST_USDC
 
-    def _check_budget(self, estimated_cost_usdc: float) -> bool:
+    def _reserve_budget(self, estimated_cost_usdc: Decimal) -> bool:
         assert self.config is not None
         with self._cost_lock:
             today = _today_utc()
             if self._cost_day != today:
                 self._cost_day = today
-                self._daily_cost_usdc = 0.0
+                self._daily_cost_usdc = Decimal("0")
             max_daily = self.config.max_daily_llm_cost_usdc
-            if max_daily is None:
-                return True
-            return self._daily_cost_usdc + estimated_cost_usdc <= max_daily
-
-    def _record_cost(self, estimated_cost_usdc: float, signal: MarketSignal) -> None:
-        assert self.config is not None
-        with self._cost_lock:
-            if self._cost_day is None:
-                self._cost_day = _today_utc()
+            max_daily_decimal = (
+                None if max_daily is None else Decimal(str(max_daily))
+            )
+            if (
+                max_daily_decimal is not None
+                and self._daily_cost_usdc + estimated_cost_usdc > max_daily_decimal
+            ):
+                return False
             self._daily_cost_usdc += estimated_cost_usdc
-            daily_cost = self._daily_cost_usdc
+            return True
+
+    def _refund_budget(self, estimated_cost_usdc: Decimal) -> None:
+        with self._cost_lock:
+            self._daily_cost_usdc = max(
+                Decimal("0"),
+                self._daily_cost_usdc - estimated_cost_usdc,
+            )
+
+    def _record_cost(self, estimated_cost_usdc: Decimal, signal: MarketSignal) -> None:
+        assert self.config is not None
+        daily_cost = self._daily_cost_usdc_float()
         logger.info(
             "llm_forecaster_cost_recorded",
             extra={
                 "market_id": signal.market_id,
                 "provider": self.config.provider,
                 "model": self.config.model,
-                "estimated_cost_usdc": estimated_cost_usdc,
+                "estimated_cost_usdc": float(estimated_cost_usdc),
                 "daily_cost_usdc": daily_cost,
                 "max_daily_llm_cost_usdc": self.config.max_daily_llm_cost_usdc,
             },
         )
+
+    def _daily_cost_usdc_float(self) -> float:
+        with self._cost_lock:
+            return float(self._daily_cost_usdc)
 
 
 def _safe_import(name: str) -> object | None:

--- a/src/pms/controller/forecasters/llm.py
+++ b/src/pms/controller/forecasters/llm.py
@@ -1,21 +1,43 @@
 from __future__ import annotations
 
 import json
+import logging
+import threading
+import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
 from importlib import import_module
 from typing import Protocol, Self, cast
 
 from pms.config import LLMSettings
 from pms.core.models import MarketSignal
 
+logger = logging.getLogger(__name__)
 
-class _MessagesClient(Protocol):
-    def create(self, **kwargs: object) -> object: ...
+_SYSTEM_PROMPT = (
+    "You are a calibrated prediction-market forecaster. Estimate the true "
+    "resolution probability, not the current market price. Use the market, "
+    "orderbook, and external signals as evidence. Return valid JSON only with "
+    "prob_estimate, confidence, and rationale."
+)
+_ESTIMATED_CALL_COST_USDC = 0.002
 
 
-class _ClaudeClient(Protocol):
-    messages: _MessagesClient
+class _LLMClient(Protocol):
+    """Marker protocol; concrete SDK shapes are provider-specific."""
+
+
+class LLMTimeoutError(RuntimeError):
+    """Wraps SDK timeout errors. predict() downgrades these to None."""
+
+
+class LLMTransientError(RuntimeError):
+    """Wraps SDK transient errors such as rate limit, 5xx, and network errors."""
+
+
+class LLMParseError(RuntimeError):
+    """Raised when a provider response cannot satisfy the forecast contract."""
 
 
 class LLMForecastResult(tuple[float, float, str]):
@@ -37,6 +59,11 @@ class LLMForecastResult(tuple[float, float, str]):
 class LLMForecaster:
     config: LLMSettings | None = None
     client: object | None = None
+    _cache: dict[str, tuple[float, LLMForecastResult]] = field(default_factory=dict)
+    _cache_lock: threading.Lock = field(default_factory=threading.Lock)
+    _cost_lock: threading.Lock = field(default_factory=threading.Lock)
+    _cost_day: date | None = None
+    _daily_cost_usdc: float = 0.0
 
     def __post_init__(self) -> None:
         if self.config is None:
@@ -45,20 +72,54 @@ class LLMForecaster:
     def predict(self, signal: MarketSignal) -> LLMForecastResult | None:
         if self.config is None or not self.config.enabled:
             return None
-        return LLMForecastResult(
-            prob_estimate=signal.yes_price,
-            confidence=0.0,
-            rationale="pre-s5-neutral",
-            model_id="neutral",
-        )
+        cached = self._cache_get(signal.market_id)
+        if cached is not None:
+            return cached
+        estimated_cost = self._estimated_call_cost_usdc()
+        if not self._check_budget(estimated_cost):
+            logger.info(
+                "llm_forecaster_budget_exhausted",
+                extra={
+                    "market_id": signal.market_id,
+                    "provider": self.config.provider,
+                    "model": self.config.model,
+                    "estimated_cost_usdc": estimated_cost,
+                    "daily_cost_usdc": self._daily_cost_usdc,
+                    "max_daily_llm_cost_usdc": self.config.max_daily_llm_cost_usdc,
+                },
+            )
+            return None
+        client = self._client()
+        if client is None:
+            return None
+        try:
+            raw = self._call(client, signal)
+            result = self._parse(raw)
+        except (LLMTimeoutError, LLMTransientError, LLMParseError):
+            return None
+        self._record_cost(estimated_cost, signal)
+        self._cache_put(signal.market_id, result)
+        return result
 
     async def forecast(self, signal: MarketSignal) -> float:
-        result = self.predict(signal)
+        import asyncio
+
+        result = await asyncio.to_thread(self.predict, signal)
         return signal.yes_price if result is None else result[0]
 
-    def _client(self, api_key: str) -> _ClaudeClient | None:
+    def _client(self) -> object | None:
         if self.client is not None:
-            return cast(_ClaudeClient, self.client)
+            return self.client
+        if self.config is None or self.config.provider is None:
+            return None
+        if self.config.provider == "anthropic":
+            self.client = self._anthropic_client()
+        else:
+            self.client = self._openai_client()
+        return self.client
+
+    def _anthropic_client(self) -> object | None:
+        assert self.config is not None
         try:
             anthropic_module = import_module("anthropic")
         except ImportError:
@@ -66,10 +127,181 @@ class LLMForecaster:
         client_factory = getattr(anthropic_module, "Anthropic", None)
         if not callable(client_factory):
             return None
-        factory = cast(Callable[..., _ClaudeClient], client_factory)
-        created_client = factory(api_key=api_key)
-        self.client = created_client
-        return created_client
+        factory = cast(Callable[..., object], client_factory)
+        kwargs: dict[str, object] = {
+            "api_key": self.config.api_key,
+            "timeout": self.config.timeout_s,
+        }
+        if self.config.base_url:
+            kwargs["base_url"] = self.config.base_url
+        return factory(**kwargs)
+
+    def _openai_client(self) -> object | None:
+        assert self.config is not None
+        try:
+            openai_module = import_module("openai")
+        except ImportError:
+            return None
+        client_factory = getattr(openai_module, "OpenAI", None)
+        if not callable(client_factory):
+            return None
+        factory = cast(Callable[..., object], client_factory)
+        return factory(
+            api_key=self.config.api_key,
+            base_url=self.config.base_url,
+            timeout=self.config.timeout_s,
+        )
+
+    def _call(self, client: object, signal: MarketSignal) -> str:
+        assert self.config is not None
+        if self.config.provider == "anthropic":
+            return self._call_anthropic(client, signal)
+        if self.config.provider == "openai":
+            return self._call_openai(client, signal)
+        raise LLMTransientError(f"unknown provider: {self.config.provider}")
+
+    def _call_anthropic(self, client: object, signal: MarketSignal) -> str:
+        assert self.config is not None
+        try:
+            response = getattr(client, "messages").create(
+                model=self.config.model,
+                max_tokens=self.config.max_tokens,
+                system=_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": _prompt(signal)}],
+            )
+        except (LLMTimeoutError, LLMTransientError, LLMParseError):
+            raise
+        except Exception as exc:
+            anthropic_module = _safe_import("anthropic")
+            if anthropic_module is not None:
+                if isinstance(exc, getattr(anthropic_module, "APITimeoutError", ())):
+                    raise LLMTimeoutError(str(exc)) from exc
+                if isinstance(
+                    exc,
+                    (
+                        getattr(anthropic_module, "RateLimitError", ()),
+                        getattr(anthropic_module, "APIConnectionError", ()),
+                        getattr(anthropic_module, "InternalServerError", ()),
+                    ),
+                ):
+                    raise LLMTransientError(str(exc)) from exc
+            raise
+        return _response_text_anthropic(response)
+
+    def _call_openai(self, client: object, signal: MarketSignal) -> str:
+        assert self.config is not None
+        try:
+            response = getattr(client, "chat").completions.create(
+                model=self.config.model,
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": _prompt(signal)},
+                ],
+                max_tokens=self.config.max_tokens,
+                response_format={"type": "json_object"},
+            )
+        except (LLMTimeoutError, LLMTransientError, LLMParseError):
+            raise
+        except Exception as exc:
+            openai_module = _safe_import("openai")
+            if openai_module is not None:
+                if isinstance(exc, getattr(openai_module, "APITimeoutError", ())):
+                    raise LLMTimeoutError(str(exc)) from exc
+                if isinstance(
+                    exc,
+                    (
+                        getattr(openai_module, "RateLimitError", ()),
+                        getattr(openai_module, "APIConnectionError", ()),
+                        getattr(openai_module, "InternalServerError", ()),
+                    ),
+                ):
+                    raise LLMTransientError(str(exc)) from exc
+            raise
+        return _response_text_openai(response)
+
+    def _parse(self, raw: str) -> LLMForecastResult:
+        try:
+            loaded = _load_json(raw)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise LLMParseError(f"unparseable LLM response: {exc}") from exc
+        for key in ("prob_estimate", "confidence", "rationale"):
+            if key not in loaded:
+                raise LLMParseError(f"LLM response missing required key: {key}")
+        try:
+            probability = _clamp_probability(_as_float(loaded["prob_estimate"]))
+            confidence = _clamp(_as_float(loaded["confidence"]))
+        except (TypeError, ValueError) as exc:
+            raise LLMParseError(f"non-numeric LLM field: {exc}") from exc
+        assert self.config is not None
+        return LLMForecastResult(
+            prob_estimate=probability,
+            confidence=confidence,
+            rationale=str(loaded["rationale"]),
+            model_id=self.config.model,
+        )
+
+    def _cache_get(self, market_id: str) -> LLMForecastResult | None:
+        if self.config is None or self.config.cache_ttl_s <= 0:
+            return None
+        with self._cache_lock:
+            entry = self._cache.get(market_id)
+            if entry is None:
+                return None
+            ts, result = entry
+            if time.monotonic() - ts > self.config.cache_ttl_s:
+                del self._cache[market_id]
+                return None
+            return result
+
+    def _cache_put(self, market_id: str, result: LLMForecastResult) -> None:
+        if self.config is None or self.config.cache_ttl_s <= 0:
+            return
+        with self._cache_lock:
+            self._cache[market_id] = (time.monotonic(), result)
+            if len(self._cache) > 1000:
+                oldest = min(self._cache, key=lambda k: self._cache[k][0])
+                del self._cache[oldest]
+
+    def _estimated_call_cost_usdc(self) -> float:
+        return _ESTIMATED_CALL_COST_USDC
+
+    def _check_budget(self, estimated_cost_usdc: float) -> bool:
+        assert self.config is not None
+        with self._cost_lock:
+            today = _today_utc()
+            if self._cost_day != today:
+                self._cost_day = today
+                self._daily_cost_usdc = 0.0
+            max_daily = self.config.max_daily_llm_cost_usdc
+            if max_daily is None:
+                return True
+            return self._daily_cost_usdc + estimated_cost_usdc <= max_daily
+
+    def _record_cost(self, estimated_cost_usdc: float, signal: MarketSignal) -> None:
+        assert self.config is not None
+        with self._cost_lock:
+            if self._cost_day is None:
+                self._cost_day = _today_utc()
+            self._daily_cost_usdc += estimated_cost_usdc
+            daily_cost = self._daily_cost_usdc
+        logger.info(
+            "llm_forecaster_cost_recorded",
+            extra={
+                "market_id": signal.market_id,
+                "provider": self.config.provider,
+                "model": self.config.model,
+                "estimated_cost_usdc": estimated_cost_usdc,
+                "daily_cost_usdc": daily_cost,
+                "max_daily_llm_cost_usdc": self.config.max_daily_llm_cost_usdc,
+            },
+        )
+
+
+def _safe_import(name: str) -> object | None:
+    try:
+        return import_module(name)
+    except ImportError:
+        return None
 
 
 def _prompt(signal: MarketSignal) -> str:
@@ -79,14 +311,20 @@ def _prompt(signal: MarketSignal) -> str:
     }
     return "\n".join(
         [
-            f"market_title: {signal.title}",
+            "# Market",
+            f"title: {signal.title}",
             f"market_id: {signal.market_id}",
             f"venue: {signal.venue}",
             f"yes_price: {signal.yes_price}",
-            "orderbook_top_5: "
-            + json.dumps(orderbook, sort_keys=True, separators=(",", ":")),
-            "external_signal: "
-            + json.dumps(signal.external_signal, sort_keys=True, default=str),
+            "",
+            "# Orderbook",
+            json.dumps(orderbook, sort_keys=True, separators=(",", ":")),
+            "",
+            "# External Signals",
+            json.dumps(signal.external_signal, sort_keys=True, default=str),
+            "",
+            "# Output",
+            "Return JSON only with prob_estimate, confidence, and rationale.",
         ]
     )
 
@@ -97,8 +335,7 @@ def _top_five(levels: object) -> object:
     return []
 
 
-def _parse_response(response: object) -> dict[str, object]:
-    text = _response_text(response)
+def _load_json(text: str) -> dict[str, object]:
     try:
         loaded = json.loads(text)
     except json.JSONDecodeError:
@@ -108,14 +345,11 @@ def _parse_response(response: object) -> dict[str, object]:
             raise
         loaded = json.loads(text[start : end + 1])
     if not isinstance(loaded, dict):
-        raise ValueError("Expected Claude forecast response to be a JSON object")
-    for key in ("prob_estimate", "confidence", "rationale"):
-        if key not in loaded:
-            raise ValueError(f"Claude forecast response missing {key}")
+        raise ValueError("expected JSON object")
     return loaded
 
 
-def _response_text(response: object) -> str:
+def _response_text_anthropic(response: object) -> str:
     content = getattr(response, "content", "")
     if isinstance(content, str):
         return content
@@ -131,6 +365,15 @@ def _response_text(response: object) -> str:
     return str(content)
 
 
+def _response_text_openai(response: object) -> str:
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return ""
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", "") if message is not None else ""
+    return content if isinstance(content, str) else str(content)
+
+
 def _as_float(value: object) -> float:
     if isinstance(value, str | int | float):
         return float(value)
@@ -139,3 +382,11 @@ def _as_float(value: object) -> float:
 
 def _clamp(value: float) -> float:
     return min(max(value, 0.0), 1.0)
+
+
+def _clamp_probability(value: float) -> float:
+    return min(max(value, 0.01), 0.99)
+
+
+def _today_utc() -> date:
+    return datetime.now(tz=UTC).date()

--- a/src/pms/controller/forecasters/llm.py
+++ b/src/pms/controller/forecasters/llm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import threading
 import time
 from collections.abc import Callable
@@ -94,10 +95,10 @@ class LLMForecaster:
             return None
         try:
             raw = self._call(client, signal)
+            self._record_cost(estimated_cost, signal)
             result = self._parse(raw)
         except (LLMTimeoutError, LLMTransientError, LLMParseError):
             return None
-        self._record_cost(estimated_cost, signal)
         self._cache_put(signal.market_id, result)
         return result
 
@@ -376,7 +377,10 @@ def _response_text_openai(response: object) -> str:
 
 def _as_float(value: object) -> float:
     if isinstance(value, str | int | float):
-        return float(value)
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            raise ValueError("Expected finite numeric value")
+        return numeric
     raise ValueError(f"Expected numeric value, got {type(value).__name__}")
 
 

--- a/src/pms/controller/forecasters/llm.py
+++ b/src/pms/controller/forecasters/llm.py
@@ -169,11 +169,13 @@ class LLMForecaster:
         if not callable(client_factory):
             return None
         factory = cast(Callable[..., object], client_factory)
-        return factory(
-            api_key=self.config.api_key,
-            base_url=self.config.base_url,
-            timeout=self.config.timeout_s,
-        )
+        kwargs: dict[str, object] = {
+            "api_key": self.config.api_key,
+            "timeout": self.config.timeout_s,
+        }
+        if self.config.base_url:
+            kwargs["base_url"] = self.config.base_url
+        return factory(**kwargs)
 
     def _call(self, client: object, signal: MarketSignal) -> str:
         assert self.config is not None

--- a/src/pms/controller/forecasters/llm.py
+++ b/src/pms/controller/forecasters/llm.py
@@ -100,18 +100,26 @@ class LLMForecaster:
                 },
             )
             return None
-        client = self._client()
+        try:
+            client = self._client()
+        except Exception:
+            self._refund_budget(estimated_cost)
+            raise
         if client is None:
             self._refund_budget(estimated_cost)
             return None
         try:
             raw = self._call(client, signal)
-            self._record_cost(estimated_cost, signal)
-            result = self._parse(raw)
         except (LLMTimeoutError, LLMTransientError):
             self._refund_budget(estimated_cost)
             return None
-        except (LLMTimeoutError, LLMTransientError, LLMParseError):
+        except Exception:
+            self._refund_budget(estimated_cost)
+            raise
+        self._record_cost(estimated_cost, signal)
+        try:
+            result = self._parse(raw)
+        except LLMParseError:
             return None
         self._cache_put(signal.market_id, result)
         return result

--- a/tests/unit/test_controller_cp05.py
+++ b/tests/unit/test_controller_cp05.py
@@ -557,6 +557,63 @@ def test_llm_forecaster_refunds_transient_provider_failure_budget() -> None:
     assert len(client.messages.calls) == 2
 
 
+def test_llm_forecaster_refunds_unhandled_provider_exception_budget() -> None:
+    client = FakeClaudeClient()
+    failing_messages = FailingMessages(RuntimeError("auth rejected"))
+    client.messages = failing_messages
+    forecaster = LLMForecaster(
+        config=LLMSettings(
+            enabled=True,
+            provider="anthropic",
+            api_key="test-key",
+            cache_ttl_s=0.0,
+            max_daily_llm_cost_usdc=0.003,
+        ),
+        client=client,
+    )
+
+    with pytest.raises(RuntimeError, match="auth rejected"):
+        forecaster.predict(_signal(market_id="m-auth-fail"))
+
+    success_messages = FakeMessages()
+    client.messages = success_messages
+    assert forecaster.predict(_signal(market_id="m-after-auth-fail")) is not None
+    assert len(failing_messages.calls) == 1
+    assert len(success_messages.calls) == 1
+
+
+def test_llm_forecaster_refunds_client_initialization_exception_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    factory_calls: list[dict[str, Any]] = []
+
+    def create_client(**kwargs: Any) -> FakeClaudeClient:
+        factory_calls.append(kwargs)
+        if len(factory_calls) == 1:
+            raise RuntimeError("invalid client configuration")
+        return FakeClaudeClient()
+
+    monkeypatch.setattr(
+        "pms.controller.forecasters.llm.import_module",
+        lambda _: SimpleNamespace(Anthropic=create_client),
+    )
+    forecaster = LLMForecaster(
+        config=LLMSettings(
+            enabled=True,
+            provider="anthropic",
+            api_key="test-key",
+            cache_ttl_s=0.0,
+            max_daily_llm_cost_usdc=0.003,
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="invalid client configuration"):
+        forecaster.predict(_signal(market_id="m-client-fail"))
+
+    assert forecaster.predict(_signal(market_id="m-after-client-fail")) is not None
+    assert len(factory_calls) == 2
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/tests/unit/test_controller_cp05.py
+++ b/tests/unit/test_controller_cp05.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, date, datetime
 from math import inf, nan
 from types import SimpleNamespace
@@ -11,6 +13,7 @@ import pytest
 from pms.config import ControllerSettings, LLMSettings, RiskSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.forecasters.llm import (
+    LLMTransientError,
     LLMForecaster,
     _as_float,
     _clamp,
@@ -123,6 +126,34 @@ class FakeSequenceMessages:
         self.calls.append(kwargs)
         payload = self._payloads.pop(0)
         return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+
+class BlockingMessages:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def create(self, **kwargs: Any) -> object:
+        self.calls.append(kwargs)
+        self.entered.set()
+        assert self.release.wait(timeout=2.0)
+        payload = {
+            "prob_estimate": 0.8,
+            "confidence": 0.6,
+            "rationale": "blocked race winner",
+        }
+        return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+
+class FailingMessages:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> object:
+        self.calls.append(kwargs)
+        raise self._exc
 
 
 class FakeClaudeClient:
@@ -387,6 +418,40 @@ def test_llm_forecaster_budget_exhaustion_and_midnight_utc_reset(
     assert len(client.messages.calls) == 2
 
 
+def test_llm_forecaster_reserves_budget_atomically_for_concurrent_calls() -> None:
+    client = FakeClaudeClient()
+    messages = BlockingMessages()
+    client.messages = messages
+    forecaster = LLMForecaster(
+        config=LLMSettings(
+            enabled=True,
+            provider="anthropic",
+            api_key="test-key",
+            cache_ttl_s=0.0,
+            max_daily_llm_cost_usdc=0.003,
+        ),
+        client=client,
+    )
+    start = threading.Barrier(3)
+
+    def predict_after_barrier(market_id: str) -> object:
+        start.wait(timeout=2.0)
+        return forecaster.predict(_signal(market_id=market_id))
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(predict_after_barrier, "m-race-1"),
+            executor.submit(predict_after_barrier, "m-race-2"),
+        ]
+        start.wait(timeout=2.0)
+        assert messages.entered.wait(timeout=2.0)
+        messages.release.set()
+        results = [future.result(timeout=2.0) for future in futures]
+
+    assert len(messages.calls) == 1
+    assert sum(result is not None for result in results) == 1
+
+
 def test_llm_forecaster_clamps_probability_away_from_impossible_extremes() -> None:
     client = FakeClaudeClient()
     client.messages = FakeMessages(prob_estimate=1.2, confidence=1.5)
@@ -452,6 +517,40 @@ def test_llm_forecaster_counts_malformed_provider_attempt_against_budget() -> No
     assert forecaster.predict(_signal(market_id="m-bad")) is None
     assert forecaster.predict(_signal(market_id="m-budget")) is None
     assert len(client.messages.calls) == 1
+
+
+def test_llm_forecaster_refunds_transient_provider_failure_budget() -> None:
+    client = FakeClaudeClient()
+    client.messages = FailingMessages(LLMTransientError("provider unavailable"))
+    forecaster = LLMForecaster(
+        config=LLMSettings(
+            enabled=True,
+            provider="anthropic",
+            api_key="test-key",
+            cache_ttl_s=0.0,
+            max_daily_llm_cost_usdc=0.003,
+        ),
+        client=client,
+    )
+
+    assert forecaster.predict(_signal(market_id="m-fail-1")) is None
+    assert forecaster.predict(_signal(market_id="m-fail-2")) is None
+    assert len(client.messages.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"timeout_s": 0.0},
+        {"cache_ttl_s": -1.0},
+        {"max_tokens": 0},
+        {"max_daily_llm_cost_usdc": 0.0},
+        {"max_daily_llm_cost_usdc": -0.01},
+    ],
+)
+def test_llm_settings_reject_invalid_numeric_controls(kwargs: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        LLMSettings.model_validate(kwargs)
 
 
 def test_llm_prompt_trims_orderbook_and_serializes_external_signal() -> None:

--- a/tests/unit/test_controller_cp05.py
+++ b/tests/unit/test_controller_cp05.py
@@ -4,7 +4,7 @@ import json
 from datetime import UTC, date, datetime
 from math import inf, nan
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Protocol
 
 import pytest
 
@@ -37,6 +37,12 @@ from pms.strategies.projections import (
     RiskParams,
     StrategyConfig,
 )
+
+
+class _MessagesDouble(Protocol):
+    calls: list[dict[str, Any]]
+
+    def create(self, **kwargs: Any) -> object: ...
 
 
 def _signal(
@@ -108,9 +114,20 @@ class FakeMessages:
         return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(self._payload))])
 
 
+class FakeSequenceMessages:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self._payloads = list(payloads)
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> object:
+        self.calls.append(kwargs)
+        payload = self._payloads.pop(0)
+        return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+
+
 class FakeClaudeClient:
     def __init__(self) -> None:
-        self.messages = FakeMessages()
+        self.messages: _MessagesDouble = FakeMessages()
 
 
 class FakeOpenAIChatCompletions:
@@ -392,6 +409,49 @@ def test_llm_forecaster_clamps_probability_away_from_impossible_extremes() -> No
     assert low is not None
     assert low[0] == pytest.approx(0.01)
     assert low[1] == pytest.approx(0.0)
+
+
+def test_llm_forecaster_rejects_non_finite_numeric_fields() -> None:
+    client = FakeClaudeClient()
+    client.messages = FakeMessages(prob_estimate=float("nan"), confidence=0.5)
+    forecaster = LLMForecaster(
+        config=LLMSettings(enabled=True, provider="anthropic", api_key="test-key"),
+        client=client,
+    )
+
+    assert forecaster.predict(_signal()) is None
+    assert len(client.messages.calls) == 1
+
+
+def test_llm_forecaster_counts_malformed_provider_attempt_against_budget() -> None:
+    client = FakeClaudeClient()
+    client.messages = FakeSequenceMessages(
+        [
+            {
+                "prob_estimate": 0.8,
+                "confidence": 0.6,
+            },
+            {
+                "prob_estimate": 0.7,
+                "confidence": 0.5,
+                "rationale": "would be valid if called",
+            },
+        ]
+    )
+    forecaster = LLMForecaster(
+        config=LLMSettings(
+            enabled=True,
+            provider="anthropic",
+            api_key="test-key",
+            cache_ttl_s=0.0,
+            max_daily_llm_cost_usdc=0.003,
+        ),
+        client=client,
+    )
+
+    assert forecaster.predict(_signal(market_id="m-bad")) is None
+    assert forecaster.predict(_signal(market_id="m-budget")) is None
+    assert len(client.messages.calls) == 1
 
 
 def test_llm_prompt_trims_orderbook_and_serializes_external_signal() -> None:

--- a/tests/unit/test_controller_cp05.py
+++ b/tests/unit/test_controller_cp05.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from math import inf, nan
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -14,9 +14,10 @@ from pms.controller.forecasters.llm import (
     LLMForecaster,
     _as_float,
     _clamp,
-    _parse_response,
+    _load_json,
     _prompt,
-    _response_text,
+    _response_text_anthropic,
+    _response_text_openai,
 )
 from pms.controller.forecasters.rules import RulesForecaster
 from pms.controller.forecasters.statistical import StatisticalForecaster
@@ -40,12 +41,13 @@ from pms.strategies.projections import (
 
 def _signal(
     *,
+    market_id: str = "m-cp05",
     yes_price: float = 0.4,
     volume_24h: float | None = 1000.0,
     external_signal: dict[str, Any] | None = None,
 ) -> MarketSignal:
     return MarketSignal(
-        market_id="m-cp05",
+        market_id=market_id,
         token_id="t-yes",
         venue="polymarket",
         title="Will CP05 pass?",
@@ -87,22 +89,59 @@ def _portfolio() -> Portfolio:
 
 
 class FakeMessages:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        prob_estimate: float = 0.8,
+        confidence: float = 0.6,
+        rationale: str = "orderbook and external context support yes",
+    ) -> None:
+        self._payload = {
+            "prob_estimate": prob_estimate,
+            "confidence": confidence,
+            "rationale": rationale,
+        }
         self.calls: list[dict[str, Any]] = []
 
     def create(self, **kwargs: Any) -> object:
         self.calls.append(kwargs)
-        payload = {
-            "prob_estimate": 0.8,
-            "confidence": 0.6,
-            "rationale": "orderbook and external context support yes",
-        }
-        return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])
+        return SimpleNamespace(content=[SimpleNamespace(text=json.dumps(self._payload))])
 
 
 class FakeClaudeClient:
     def __init__(self) -> None:
         self.messages = FakeMessages()
+
+
+class FakeOpenAIChatCompletions:
+    def __init__(
+        self,
+        *,
+        prob_estimate: float = 0.72,
+        confidence: float = 0.55,
+        rationale: str = "openai-fake",
+    ) -> None:
+        self._payload = {
+            "prob_estimate": prob_estimate,
+            "confidence": confidence,
+            "rationale": rationale,
+        }
+        self.calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs: Any) -> object:
+        self.calls.append(kwargs)
+        message = SimpleNamespace(content=json.dumps(self._payload))
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class FakeOpenAIChat:
+    def __init__(self) -> None:
+        self.completions = FakeOpenAIChatCompletions()
+
+
+class FakeOpenAIClient:
+    def __init__(self) -> None:
+        self.chat = FakeOpenAIChat()
 
 
 class FailingForecaster:
@@ -157,22 +196,65 @@ class FixedSizer:
         return self._size
 
 
-def test_llm_forecaster_returns_neutral_tuple_without_calling_client() -> None:
+def test_llm_forecaster_predict_uses_anthropic_system_prompt_and_caches() -> None:
     client = FakeClaudeClient()
     forecaster = LLMForecaster(
-        config=LLMSettings(enabled=True, api_key="test-key", model="claude-test"),
+        config=LLMSettings(
+            enabled=True,
+            provider="anthropic",
+            api_key="test-key",
+            model="claude-test",
+            cache_ttl_s=30.0,
+        ),
         client=client,
     )
 
     result = forecaster.predict(_signal())
 
     assert result is not None
-    assert result == pytest.approx((0.4, 0.0, "pre-s5-neutral"))
-    assert result.model_id == "neutral"
-    assert client.messages.calls == []
+    assert result == pytest.approx(
+        (0.8, 0.6, "orderbook and external context support yes")
+    )
+    assert result.model_id == "claude-test"
+    assert len(client.messages.calls) == 1
+    call = client.messages.calls[0]
+    assert call["system"].startswith("You are a calibrated prediction-market forecaster")
+    assert call["messages"][0]["role"] == "user"
+    assert "# Market" in call["messages"][0]["content"]
+
+    assert forecaster.predict(_signal()) is result
+    assert len(client.messages.calls) == 1
 
 
-def test_llm_forecaster_returns_none_when_disabled_and_neutral_when_enabled(
+def test_llm_forecaster_predict_uses_openai_system_message() -> None:
+    client = FakeOpenAIClient()
+    forecaster = LLMForecaster(
+        config=LLMSettings(
+            enabled=True,
+            provider="openai",
+            api_key="test-key",
+            base_url="https://llm-gateway.example/v1",
+            model="openai-test",
+        ),
+        client=client,
+    )
+
+    result = forecaster.predict(_signal())
+
+    assert result is not None
+    assert result == pytest.approx((0.72, 0.55, "openai-fake"))
+    assert result.model_id == "openai-test"
+    call = client.chat.completions.calls[0]
+    assert call["response_format"] == {"type": "json_object"}
+    assert call["messages"][0]["role"] == "system"
+    assert call["messages"][0]["content"].startswith(
+        "You are a calibrated prediction-market forecaster"
+    )
+    assert call["messages"][1]["role"] == "user"
+    assert "# Market" in call["messages"][1]["content"]
+
+
+def test_llm_forecaster_returns_none_when_disabled_and_real_result_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -184,10 +266,14 @@ def test_llm_forecaster_returns_none_when_disabled_and_neutral_when_enabled(
         ).predict(_signal())
         is None
     )
-    assert LLMForecaster(
-        config=LLMSettings(enabled=True),
+    result = LLMForecaster(
+        config=LLMSettings(enabled=True, provider="anthropic", api_key="test-key"),
         client=FakeClaudeClient(),
-    ).predict(_signal()) == pytest.approx((0.4, 0.0, "pre-s5-neutral"))
+    ).predict(_signal())
+    assert result is not None
+    assert result == pytest.approx(
+        (0.8, 0.6, "orderbook and external context support yes")
+    )
 
 
 @pytest.mark.asyncio
@@ -204,67 +290,138 @@ def test_llm_forecaster_client_paths_cover_injected_missing_and_cached_factory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     injected_client = FakeClaudeClient()
-    injected_result = LLMForecaster(client=injected_client)._client("ignored")
+    injected_result = LLMForecaster(
+        config=LLMSettings(enabled=True, provider="anthropic", api_key="ignored"),
+        client=injected_client,
+    )._client()
     assert injected_result is not None
-    assert cast(object, injected_result) is injected_client
+    assert injected_result is injected_client
 
     def raise_import_error(module_name: str) -> object:
         raise ImportError(module_name)
 
     monkeypatch.setattr("pms.controller.forecasters.llm.import_module", raise_import_error)
-    assert LLMForecaster()._client("missing") is None
+    assert (
+        LLMForecaster(
+            config=LLMSettings(enabled=True, provider="anthropic", api_key="missing")
+        )._client()
+        is None
+    )
 
     monkeypatch.setattr(
         "pms.controller.forecasters.llm.import_module",
         lambda _: SimpleNamespace(Anthropic="not-callable"),
     )
-    assert LLMForecaster()._client("bad-factory") is None
+    assert (
+        LLMForecaster(
+            config=LLMSettings(enabled=True, provider="anthropic", api_key="bad")
+        )._client()
+        is None
+    )
 
     created_calls: list[str] = []
 
-    def create_client(*, api_key: str) -> FakeClaudeClient:
-        created_calls.append(api_key)
+    def create_client(**kwargs: Any) -> FakeClaudeClient:
+        created_calls.append(str(kwargs["api_key"]))
         return FakeClaudeClient()
 
     monkeypatch.setattr(
         "pms.controller.forecasters.llm.import_module",
         lambda _: SimpleNamespace(Anthropic=create_client),
     )
-    forecaster = LLMForecaster()
-    created_client = forecaster._client("cache-key")
+    forecaster = LLMForecaster(
+        config=LLMSettings(enabled=True, provider="anthropic", api_key="cache-key")
+    )
+    created_client = forecaster._client()
 
     assert created_client is not None
     assert hasattr(created_client, "messages")
     assert forecaster.client is not None
-    cached_client = forecaster._client("ignored-after-cache")
+    cached_client = forecaster._client()
     assert cached_client is not None
-    assert cast(object, cached_client) is cast(object, created_client)
+    assert cached_client is created_client
     assert created_calls == ["cache-key"]
+
+
+def test_llm_forecaster_budget_exhaustion_and_midnight_utc_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClaudeClient()
+    forecaster = LLMForecaster(
+        config=LLMSettings(
+            enabled=True,
+            provider="anthropic",
+            api_key="test-key",
+            model="claude-test",
+            cache_ttl_s=0.0,
+            max_daily_llm_cost_usdc=0.003,
+        ),
+        client=client,
+    )
+    days = iter([date(2026, 5, 3), date(2026, 5, 3), date(2026, 5, 4)])
+    monkeypatch.setattr(
+        "pms.controller.forecasters.llm._today_utc",
+        lambda: next(days),
+    )
+
+    assert forecaster.predict(_signal(market_id="m-1")) is not None
+    assert forecaster.predict(_signal(market_id="m-2")) is None
+    assert forecaster.predict(_signal(market_id="m-3")) is not None
+    assert len(client.messages.calls) == 2
+
+
+def test_llm_forecaster_clamps_probability_away_from_impossible_extremes() -> None:
+    client = FakeClaudeClient()
+    client.messages = FakeMessages(prob_estimate=1.2, confidence=1.5)
+    high = LLMForecaster(
+        config=LLMSettings(enabled=True, provider="anthropic", api_key="test-key"),
+        client=client,
+    ).predict(_signal())
+
+    assert high is not None
+    assert high[0] == pytest.approx(0.99)
+    assert high[1] == pytest.approx(1.0)
+
+    low_client = FakeClaudeClient()
+    low_client.messages = FakeMessages(prob_estimate=-0.3, confidence=-0.2)
+    low = LLMForecaster(
+        config=LLMSettings(enabled=True, provider="anthropic", api_key="test-key"),
+        client=low_client,
+    ).predict(_signal())
+
+    assert low is not None
+    assert low[0] == pytest.approx(0.01)
+    assert low[1] == pytest.approx(0.0)
 
 
 def test_llm_prompt_trims_orderbook_and_serializes_external_signal() -> None:
     prompt = _prompt(_signal())
 
-    assert "market_title: Will CP05 pass?" in prompt
+    assert "# Market" in prompt
+    assert "title: Will CP05 pass?" in prompt
     assert "yes_price: 0.4" in prompt
     assert '"price":0.35' in prompt
     assert '"price":0.34' not in prompt
     assert '"fair_value": 0.65' in prompt
     assert '"no_count": 3' in prompt
+    assert "Return JSON only" in prompt
 
 
 def test_llm_response_parsing_helpers_cover_json_text_and_errors() -> None:
-    direct_response = SimpleNamespace(
-        content='{"prob_estimate":0.6,"confidence":0.2,"rationale":"direct"}'
-    )
-    embedded_response = SimpleNamespace(
-        content=[SimpleNamespace(text='prefix {"prob_estimate":0.7,"confidence":0.1,"rationale":"embedded"} suffix')]
+    direct_json = '{"prob_estimate":0.6,"confidence":0.2,"rationale":"direct"}'
+    embedded_json = 'prefix {"prob_estimate":0.7,"confidence":0.1,"rationale":"embedded"} suffix'
+    openai_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=direct_json))]
     )
 
-    assert _response_text(SimpleNamespace(content="plain-text")) == "plain-text"
-    assert _response_text(SimpleNamespace(content={"content": "ignored"})) == "{'content': 'ignored'}"
-    assert _parse_response(direct_response)["prob_estimate"] == pytest.approx(0.6)
-    assert _parse_response(embedded_response)["rationale"] == "embedded"
+    assert _response_text_anthropic(SimpleNamespace(content="plain-text")) == "plain-text"
+    assert (
+        _response_text_anthropic(SimpleNamespace(content={"content": "ignored"}))
+        == "{'content': 'ignored'}"
+    )
+    assert _response_text_openai(openai_response) == direct_json
+    assert _load_json(direct_json)["prob_estimate"] == pytest.approx(0.6)
+    assert _load_json(embedded_json)["rationale"] == "embedded"
     assert _as_float("0.5") == pytest.approx(0.5)
     assert _as_float(2) == pytest.approx(2.0)
     assert _clamp(-0.2) == 0.0
@@ -273,19 +430,29 @@ def test_llm_response_parsing_helpers_cover_json_text_and_errors() -> None:
     with pytest.raises(ValueError, match="Expected numeric value"):
         _as_float(object())
 
-    with pytest.raises(ValueError, match="missing rationale"):
-        _parse_response(SimpleNamespace(content='{"prob_estimate":0.6,"confidence":0.2}'))
+    with pytest.raises(ValueError, match="expected JSON object"):
+        _load_json("[1, 2, 3]")
 
 
 @pytest.mark.asyncio
 async def test_controller_pipeline_suppresses_zero_size_decision_and_tracks_metric() -> None:
     llm_client = FakeClaudeClient()
+    llm_client.messages = FakeMessages(
+        prob_estimate=0.4,
+        confidence=0.0,
+        rationale="neutral mocked LLM branch",
+    )
     pipeline = ControllerPipeline(
         forecasters=[
             RulesForecaster(min_edge=0.01),
             StatisticalForecaster(),
             LLMForecaster(
-                config=LLMSettings(enabled=True, api_key="test-key", model="claude-test"),
+                config=LLMSettings(
+                    enabled=True,
+                    provider="anthropic",
+                    api_key="test-key",
+                    model="claude-test",
+                ),
                 client=llm_client,
             ),
         ],

--- a/tests/unit/test_controller_cp05.py
+++ b/tests/unit/test_controller_cp05.py
@@ -302,6 +302,47 @@ def test_llm_forecaster_predict_uses_openai_system_message() -> None:
     assert "# Market" in call["messages"][1]["content"]
 
 
+def test_llm_settings_allow_openai_default_and_custom_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_calls: list[dict[str, Any]] = []
+
+    def create_client(**kwargs: Any) -> FakeOpenAIClient:
+        created_calls.append(kwargs)
+        return FakeOpenAIClient()
+
+    monkeypatch.setattr(
+        "pms.controller.forecasters.llm.import_module",
+        lambda _: SimpleNamespace(OpenAI=create_client),
+    )
+    default_endpoint = LLMSettings(
+        enabled=True,
+        provider="openai",
+        api_key="test-key",
+        model="openai-test",
+    )
+    custom_endpoint = LLMSettings(
+        enabled=True,
+        provider="openai",
+        api_key="test-key",
+        base_url="https://llm-gateway.example/v1",
+        model="openai-test",
+    )
+
+    assert (
+        LLMForecaster(config=default_endpoint).predict(_signal(market_id="m-openai"))
+        is not None
+    )
+    assert (
+        LLMForecaster(config=custom_endpoint).predict(
+            _signal(market_id="m-openai-custom")
+        )
+        is not None
+    )
+    assert "base_url" not in created_calls[0]
+    assert created_calls[1]["base_url"] == "https://llm-gateway.example/v1"
+
+
 def test_llm_forecaster_returns_none_when_disabled_and_real_result_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_controller_cp05.py
+++ b/tests/unit/test_controller_cp05.py
@@ -452,6 +452,25 @@ def test_llm_forecaster_reserves_budget_atomically_for_concurrent_calls() -> Non
     assert sum(result is not None for result in results) == 1
 
 
+def test_llm_forecaster_shares_daily_budget_across_strategy_instances() -> None:
+    first_client = FakeClaudeClient()
+    second_client = FakeClaudeClient()
+    config = LLMSettings(
+        enabled=True,
+        provider="anthropic",
+        api_key="test-key",
+        cache_ttl_s=0.0,
+        max_daily_llm_cost_usdc=0.003,
+    )
+    first = LLMForecaster(config=config, client=first_client)
+    second = LLMForecaster(config=config, client=second_client)
+
+    assert first.predict(_signal(market_id="m-strategy-1")) is not None
+    assert second.predict(_signal(market_id="m-strategy-2")) is None
+    assert len(first_client.messages.calls) == 1
+    assert len(second_client.messages.calls) == 0
+
+
 def test_llm_forecaster_clamps_probability_away_from_impossible_extremes() -> None:
     client = FakeClaudeClient()
     client.messages = FakeMessages(prob_estimate=1.2, confidence=1.5)

--- a/uv.lock
+++ b/uv.lock
@@ -696,6 +696,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -757,6 +776,7 @@ live = [
 ]
 llm = [
     { name = "anthropic" },
+    { name = "openai" },
 ]
 
 [package.dev-dependencies]
@@ -776,6 +796,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "openai", marker = "extra == 'llm'", specifier = ">=1.50.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "py-clob-client-v2", marker = "extra == 'live'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pydantic", specifier = ">=2.12.0" },
@@ -1157,6 +1178,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replaces the neutral LLM forecaster stub with a config-gated real provider path for Anthropic and OpenAI-compatible gateways.
- Adds provider-specific prompt wiring: Anthropic uses the `system=` kwarg; OpenAI uses a `role=system` message plus JSON response format.
- Adds TTL caching, JSON parsing, probability clamping to `[0.01, 0.99]`, graceful timeout/transient/parse degradation, and a midnight-UTC shared daily cost budget gate.
- Hardens budget accounting as a reservation lifecycle: reserve before client/call, refund before raw provider text exists, retain budget once raw provider text returns even if parse/validation fails.
- Extends `LLMSettings` with provider/base_url/timeout/cache/max_tokens/max_daily_llm_cost_usdc and updates the optional `llm` extra to include OpenAI.

## Scope hygiene
```text
git diff --name-only origin/main...HEAD
pyproject.toml
src/pms/config.py
src/pms/controller/forecasters/llm.py
tests/unit/test_controller_cp05.py
uv.lock
```

Strategy-boundary impact: no. This stays inside LLM forecaster/config/tests/dependency metadata and does not change controller, strategy, signal, or forecaster interface shapes.

## Real-provider / CI behavior
- Real SDK calls remain config-gated behind `LLMSettings(enabled=True, provider=..., api_key=...)`.
- CI/unit tests use injected fake Anthropic/OpenAI clients only; no real provider or network call is made.
- OpenAI can use the SDK default endpoint with `base_url=None`, or an explicit custom gateway endpoint when configured.
- If the SDK is missing, provider creation returns `None` and the forecaster gracefully returns `None`.
- No UI surface exists for screenshots; this PR is backend/controller infrastructure, so validation evidence is command output and review-thread evidence.

## Review fixes included
- `01f2aef`: rejects non-finite LLM numeric fields and counts malformed paid responses against the daily budget.
- `24f5469`: validates invalid numeric LLM settings and makes reservation accounting atomic / `Decimal`-backed.
- `85dea5c`: shares the daily budget tracker across forecaster instances created from the same `LLMSettings` object.
- `417e8ff`: refunds reservations for client initialization and SDK-call exceptions before raw provider text is available; keeps no-refund semantics for parse failure after raw provider text.
- `94156be`: allows OpenAI default endpoint by making `base_url` optional and passing it to the SDK only when explicitly configured.

## Verification

RED check for latest OpenAI endpoint fix:
```text
uv run pytest tests/unit/test_controller_cp05.py::test_llm_settings_allow_openai_default_and_custom_endpoint -q
1 failed
E Value error, base_url is required when provider is openai
```

Previous RED check for reservation lifecycle fix:
```text
uv run pytest tests/unit/test_controller_cp05.py::test_llm_forecaster_refunds_unhandled_provider_exception_budget tests/unit/test_controller_cp05.py::test_llm_forecaster_refunds_client_initialization_exception_budget tests/unit/test_controller_cp05.py::test_llm_forecaster_counts_malformed_provider_attempt_against_budget -q
2 failed, 1 passed
```

Focused LLM/controller tests:
```text
uv run pytest tests/unit/test_controller_cp05.py -q
44 passed in 0.20s
```

Relevant regression slice:
```text
uv run pytest tests/unit/test_controller_cp05.py tests/unit/test_live_trading_blockers.py tests/unit/test_controller_cp01.py tests/unit/test_runner_cp01.py tests/unit/test_controller_runtime_selection_contract_cp01.py -q
66 passed in 0.27s
```

Full unit suite:
```text
uv run pytest tests/unit -q
876 passed in 9.14s
```

Scoped lint/type/import contracts:
```text
uv run ruff check src/pms/controller/forecasters/llm.py src/pms/config.py tests/unit/test_controller_cp05.py
All checks passed!

uv run mypy src/pms/controller/forecasters/llm.py src/pms/config.py tests/unit/test_controller_cp05.py
Success: no issues found in 3 source files

uv run lint-imports
Contracts: 8 kept, 0 broken.
```

Whitespace:
```text
git diff --check
# no output
```

## GitHub CI note
Current GitHub CI is expected to keep failing on two unrelated PostgreSQL integration tests:
```text
tests/integration/test_market_selector_user_subscriptions.py::test_subscription_survives_runner_restart
tests/integration/test_market_selector_user_subscriptions.py::test_live_reselection_reads_user_subscriptions_without_restart
```

This is documented as base/merge-ref drift because PR #39, an independent clean Ripple branch with no LLM/config changes, failed the same two tests with the same warning/signature: `no active_version_id rows found; data sensor will idle until a strategy is activated`.
