### PR TITLE
fix(tests): keep subscription fixtures selectable

### DIFF
--- a/tests/integration/test_market_selector_user_subscriptions.py
+++ b/tests/integration/test_market_selector_user_subscriptions.py
@@ -5,7 +5,7 @@ import os
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import Any, cast
+from typing import cast
 
 import asyncpg
 import httpx
@@ -169,6 +169,7 @@ def _settings() -> PMSSettings:
 
 
 def _signal() -> MarketSignal:
+    now = datetime.now(tz=UTC)
     return MarketSignal(
         market_id="cp07-user-subscription",
         token_id="cp07-user-token",
@@ -176,10 +177,10 @@ def _signal() -> MarketSignal:
         title="Will CP07 user subscriptions select?",
         yes_price=0.55,
         volume_24h=1_000.0,
-        resolves_at=datetime(2026, 5, 1, tzinfo=UTC),
+        resolves_at=now + timedelta(days=7),
         orderbook={"bids": [], "asks": []},
         external_signal={},
-        fetched_at=datetime(2026, 4, 24, 9, 0, tzinfo=UTC),
+        fetched_at=now,
         market_status="open",
     )
 
@@ -191,7 +192,8 @@ async def _seed_market_with_token(
     token_id: str,
 ) -> None:
     store = PostgresMarketDataStore(pg_pool)
-    now = datetime(2026, 4, 24, 9, 0, tzinfo=UTC)
+    # Keep subscription-route fixtures selectable regardless of wall-clock date.
+    now = datetime.now(tz=UTC)
     await store.write_market(
         Market(
             condition_id=market_id,


### PR DESCRIPTION
## Summary
- Fixes the base-main CI drift that blocked otherwise clean PMS PRs #39 and #40.
- Updates the subscription integration fixture to use runtime-relative timestamps instead of hard-coded April/May 2026 dates.
- Keeps the fix test-only and scoped to `tests/integration/test_market_selector_user_subscriptions.py`.

## Root Cause
The failing tests seeded a market with a fixed timestamp path:

```text
created_at/fetched_at: 2026-04-24 09:00 UTC
resolves_at: 2026-05-01 09:00 UTC
```

As of 2026-05-03, `2026-05-01` is in the past. `PostgresMarketDataStore.read_markets()` correctly filters out expired markets with:

```sql
WHERE (markets.resolves_at IS NULL OR markets.resolves_at > $1)
```

So `/markets` returned an empty list and the tests failed with `IndexError`. The captured `no active_version_id rows found` warning was real but incidental here: `MarketSelector` still appends user subscriptions when no active strategies exist, and the subscription sensor update was already happening. The row disappeared only at the `/markets` catalog filter due to wall-clock date drift.

## Scope Hygiene
```text
git diff --name-only origin/main...HEAD
tests/integration/test_market_selector_user_subscriptions.py
```

No product code changes. No UI surface or screenshots apply; this PR is a backend/integration-test drift fix, so validation is command output.

## Failing Before
Run on clean `origin/main` (`7c03bfa`) before this patch:

```text
PMS_RUN_INTEGRATION=1 PMS_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/pms_test uv run pytest tests/integration/test_market_selector_user_subscriptions.py::test_subscription_survives_runner_restart tests/integration/test_market_selector_user_subscriptions.py::test_live_reselection_reads_user_subscriptions_without_restart -q
FF                                                                       [100%]
FAILED tests/integration/test_market_selector_user_subscriptions.py::test_subscription_survives_runner_restart - IndexError: list index out of range
FAILED tests/integration/test_market_selector_user_subscriptions.py::test_live_reselection_reads_user_subscriptions_without_restart - IndexError: list index out of range
WARNING  pms.market_selection.selector:selector.py:42 no active_version_id rows found; data sensor will idle until a strategy is activated
2 failed in 5.67s
```

## Passing After
```text
PMS_RUN_INTEGRATION=1 PMS_TEST_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/pms_test uv run pytest tests/integration/test_market_selector_user_subscriptions.py -q
..                                                                       [100%]
2 passed in 1.13s
```

Related unit regression slice:
```text
uv run pytest tests/unit/test_market_selector_user_subscriptions.py tests/unit/test_market_data_store_markets.py -q
...................                                                      [100%]
19 passed in 0.19s
```

Lint/type/whitespace:
```text
uv run ruff check tests/integration/test_market_selector_user_subscriptions.py
All checks passed!

uv run mypy tests/integration/test_market_selector_user_subscriptions.py
Success: no issues found in 1 source file

git diff --check
# no output
```

## Unblocks
- PR #39 CI should no longer fail this unrelated subscription integration drift.
- PR #40 CI should no longer fail this unrelated subscription integration drift.
