### PR TITLE
feat(pms): add Ripple Beta-Binomial evaluator and Kelly sizing

### DIFF
--- a/src/pms/strategies/ripple/controller.py
+++ b/src/pms/strategies/ripple/controller.py
@@ -26,6 +26,33 @@ class RippleController:
 
 def _candidate_from_observation(observation: StrategyObservation) -> StrategyCandidate:
     payload = observation.payload
+    payload_metadata = _mapping(payload.get("metadata", {}))
+    metadata: dict[str, Any] = {
+        "observation_id": observation.observation_id,
+        "source": observation.source,
+        "confidence": _required_float(payload, "confidence"),
+        "token_id": _required_str(payload, "token_id"),
+        "venue": _required_str(payload, "venue"),
+        "side": _required_str(payload, "side"),
+        "outcome": _required_str(payload, "outcome"),
+        "limit_price": _required_float(payload, "limit_price"),
+        "notional_usdc": _required_float(payload, "notional_usdc"),
+        "expected_price": _required_float(payload, "expected_price"),
+        "max_slippage_bps": _required_int(payload, "max_slippage_bps"),
+        "time_in_force": _required_str(payload, "time_in_force"),
+        "contradiction_refs": _string_tuple(payload.get("contradiction_refs", ())),
+        "fixture_metadata": payload_metadata,
+    }
+    for field_name in (
+        "entry_edge_threshold",
+        "metaculus_prior",
+        "no_count",
+        "posterior_probability",
+        "prior_strength",
+        "yes_count",
+    ):
+        if field_name in payload_metadata:
+            metadata[field_name] = payload_metadata[field_name]
     return StrategyCandidate(
         candidate_id=f"candidate-{observation.observation_id}",
         strategy_id=observation.strategy_id,
@@ -37,22 +64,7 @@ def _candidate_from_observation(observation: StrategyObservation) -> StrategyCan
         expected_edge=_required_float(payload, "expected_edge"),
         evidence_refs=observation.evidence_refs,
         created_at=observation.observed_at,
-        metadata={
-            "observation_id": observation.observation_id,
-            "source": observation.source,
-            "confidence": _required_float(payload, "confidence"),
-            "token_id": _required_str(payload, "token_id"),
-            "venue": _required_str(payload, "venue"),
-            "side": _required_str(payload, "side"),
-            "outcome": _required_str(payload, "outcome"),
-            "limit_price": _required_float(payload, "limit_price"),
-            "notional_usdc": _required_float(payload, "notional_usdc"),
-            "expected_price": _required_float(payload, "expected_price"),
-            "max_slippage_bps": _required_int(payload, "max_slippage_bps"),
-            "time_in_force": _required_str(payload, "time_in_force"),
-            "contradiction_refs": _string_tuple(payload.get("contradiction_refs", ())),
-            "fixture_metadata": _mapping(payload.get("metadata", {})),
-        },
+        metadata=metadata,
     )
 
 

--- a/src/pms/strategies/ripple/evaluator.py
+++ b/src/pms/strategies/ripple/evaluator.py
@@ -4,15 +4,25 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime
+from math import isfinite, sqrt
 from typing import Any, cast
 
 from pms.strategies.intents import StrategyCandidate
 
 
+DEFAULT_PRIOR_STRENGTH = 2.0
+DEFAULT_MIN_EXPECTED_EDGE = 0.02
+NEAR_RESOLUTION_MIN_DAYS = 1.0
+
+
 @dataclass(frozen=True, slots=True)
 class RippleEvidenceAssessment:
     approved: bool
+    posterior_probability: float
+    expected_edge: float
     confidence: float
+    entry_edge_threshold: float
     rationale: str
     evidence_refs: tuple[str, ...]
     failure_reasons: tuple[str, ...]
@@ -22,41 +32,133 @@ class RippleEvidenceAssessment:
 class RippleEvidenceEvaluator:
     min_evidence_refs: int = 2
     min_confidence: float = 0.6
+    min_expected_edge: float = DEFAULT_MIN_EXPECTED_EDGE
 
     def assess(self, candidate: StrategyCandidate) -> RippleEvidenceAssessment:
-        confidence = _metadata_float(candidate.metadata, "confidence")
+        posterior = _posterior_from_candidate(
+            candidate,
+            min_expected_edge=self.min_expected_edge,
+        )
         contradiction_refs = _metadata_tuple(candidate.metadata, "contradiction_refs")
         if len(candidate.evidence_refs) < self.min_evidence_refs:
             return RippleEvidenceAssessment(
                 approved=False,
-                confidence=min(confidence, self.min_confidence - 0.01),
-                rationale="rejected: insufficient fixture evidence",
+                posterior_probability=posterior.posterior_probability,
+                expected_edge=posterior.expected_edge,
+                confidence=min(posterior.confidence, self.min_confidence - 0.01),
+                entry_edge_threshold=posterior.entry_edge_threshold,
+                rationale="rejected: insufficient ripple evidence",
                 evidence_refs=candidate.evidence_refs,
                 failure_reasons=("insufficient_evidence",),
             )
         if contradiction_refs:
             return RippleEvidenceAssessment(
                 approved=False,
-                confidence=min(confidence, self.min_confidence - 0.01),
-                rationale="rejected: fixture evidence contains a contradiction",
+                posterior_probability=posterior.posterior_probability,
+                expected_edge=posterior.expected_edge,
+                confidence=min(posterior.confidence, self.min_confidence - 0.01),
+                entry_edge_threshold=posterior.entry_edge_threshold,
+                rationale="rejected: ripple evidence contains a contradiction",
                 evidence_refs=(*candidate.evidence_refs, *contradiction_refs),
                 failure_reasons=("contradiction",),
             )
-        if confidence < self.min_confidence:
+        if posterior.confidence < self.min_confidence:
             return RippleEvidenceAssessment(
                 approved=False,
-                confidence=confidence,
-                rationale="rejected: confidence below deterministic threshold",
+                posterior_probability=posterior.posterior_probability,
+                expected_edge=posterior.expected_edge,
+                confidence=posterior.confidence,
+                entry_edge_threshold=posterior.entry_edge_threshold,
+                rationale="rejected: confidence below posterior threshold",
                 evidence_refs=candidate.evidence_refs,
                 failure_reasons=("low_confidence",),
             )
+        if posterior.expected_edge < posterior.entry_edge_threshold:
+            return RippleEvidenceAssessment(
+                approved=False,
+                posterior_probability=posterior.posterior_probability,
+                expected_edge=posterior.expected_edge,
+                confidence=posterior.confidence,
+                entry_edge_threshold=posterior.entry_edge_threshold,
+                rationale=(
+                    "rejected: posterior edge below entry threshold "
+                    f"{posterior.entry_edge_threshold:.4f}"
+                ),
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("insufficient_expected_edge",),
+            )
         return RippleEvidenceAssessment(
             approved=True,
-            confidence=confidence,
-            rationale="approved: fixture evidence is sufficient and non-contradictory",
+            posterior_probability=posterior.posterior_probability,
+            expected_edge=posterior.expected_edge,
+            confidence=posterior.confidence,
+            entry_edge_threshold=posterior.entry_edge_threshold,
+            rationale=(
+                "approved: beta-binomial posterior edge is sufficient "
+                f"({posterior.expected_edge:.4f})"
+            ),
             evidence_refs=candidate.evidence_refs,
             failure_reasons=(),
         )
+
+
+@dataclass(frozen=True, slots=True)
+class RipplePosterior:
+    posterior_probability: float
+    expected_edge: float
+    confidence: float
+    entry_edge_threshold: float
+
+
+def beta_binomial_posterior_probability(
+    *,
+    prior_probability: float,
+    prior_strength: float = DEFAULT_PRIOR_STRENGTH,
+    yes_count: float = 0.0,
+    no_count: float = 0.0,
+) -> float:
+    _require_probability(prior_probability, "prior_probability")
+    _require_positive(prior_strength, "prior_strength")
+    _require_non_negative(yes_count, "yes_count")
+    _require_non_negative(no_count, "no_count")
+    posterior_alpha = prior_probability * prior_strength + yes_count
+    posterior_beta = (1.0 - prior_probability) * prior_strength + no_count
+    return posterior_alpha / (posterior_alpha + posterior_beta)
+
+
+def posterior_confidence(
+    *,
+    prior_strength: float,
+    yes_count: float,
+    no_count: float,
+    degraded: bool = False,
+) -> float:
+    _require_positive(prior_strength, "prior_strength")
+    _require_non_negative(yes_count, "yes_count")
+    _require_non_negative(no_count, "no_count")
+    evidence_mass = yes_count + no_count
+    confidence = 0.5 + (0.4 * evidence_mass / (prior_strength + evidence_mass))
+    if degraded:
+        confidence = min(confidence, 0.55)
+    return min(confidence, 0.95)
+
+
+def entry_edge_threshold(
+    *,
+    as_of: datetime,
+    resolves_at: datetime | None,
+    min_expected_edge: float = DEFAULT_MIN_EXPECTED_EDGE,
+) -> float:
+    _require_positive(min_expected_edge, "min_expected_edge")
+    if resolves_at is None:
+        return min_expected_edge
+    remaining_s = (resolves_at - as_of).total_seconds()
+    if remaining_s <= 0.0:
+        return 1.0
+    remaining_days = remaining_s / 86_400.0
+    if remaining_days >= NEAR_RESOLUTION_MIN_DAYS:
+        return min_expected_edge
+    return min_expected_edge / sqrt(max(remaining_days, 1.0 / 24.0))
 
 
 def _metadata_float(metadata: Mapping[str, Any], field_name: str) -> float:
@@ -76,3 +178,81 @@ def _metadata_tuple(metadata: Mapping[str, Any], field_name: str) -> tuple[str, 
         msg = f"{field_name} must contain strings"
         raise TypeError(msg)
     return cast(tuple[str, ...], value)
+
+
+def _posterior_from_candidate(
+    candidate: StrategyCandidate,
+    *,
+    min_expected_edge: float,
+) -> RipplePosterior:
+    prior_probability = _optional_metadata_float(
+        candidate.metadata,
+        "metaculus_prior",
+    )
+    prior_strength = _optional_metadata_float(
+        candidate.metadata,
+        "prior_strength",
+    )
+    yes_count = _optional_metadata_float(candidate.metadata, "yes_count")
+    no_count = _optional_metadata_float(candidate.metadata, "no_count")
+    limit_price = _optional_metadata_float(candidate.metadata, "limit_price")
+    threshold = _optional_metadata_float(candidate.metadata, "entry_edge_threshold")
+    if prior_probability is None:
+        prior_probability = candidate.probability_estimate
+    if prior_strength is None:
+        prior_strength = DEFAULT_PRIOR_STRENGTH
+    if yes_count is None:
+        yes_count = 0.0
+    if no_count is None:
+        no_count = 0.0
+    if limit_price is None:
+        limit_price = candidate.probability_estimate - candidate.expected_edge
+    if threshold is None:
+        threshold = min_expected_edge
+    if yes_count == 0.0 and no_count == 0.0 and "metaculus_prior" not in candidate.metadata:
+        posterior_probability = candidate.probability_estimate
+    else:
+        posterior_probability = beta_binomial_posterior_probability(
+            prior_probability=prior_probability,
+            prior_strength=prior_strength,
+            yes_count=yes_count,
+            no_count=no_count,
+        )
+    confidence = _metadata_float(candidate.metadata, "confidence")
+    return RipplePosterior(
+        posterior_probability=posterior_probability,
+        expected_edge=posterior_probability - limit_price,
+        confidence=confidence,
+        entry_edge_threshold=threshold,
+    )
+
+
+def _optional_metadata_float(
+    metadata: Mapping[str, Any],
+    field_name: str,
+) -> float | None:
+    value = metadata.get(field_name)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    return float(value)
+
+
+def _require_probability(value: float, field_name: str) -> None:
+    if not isfinite(value) or value < 0.0 or value > 1.0:
+        msg = f"{field_name} must satisfy 0.0 <= value <= 1.0"
+        raise ValueError(msg)
+
+
+def _require_positive(value: float, field_name: str) -> None:
+    if not isfinite(value) or value <= 0.0:
+        msg = f"{field_name} must be positive"
+        raise ValueError(msg)
+
+
+def _require_non_negative(value: float, field_name: str) -> None:
+    if not isfinite(value) or value < 0.0:
+        msg = f"{field_name} must be non-negative"
+        raise ValueError(msg)

--- a/src/pms/strategies/ripple/source.py
+++ b/src/pms/strategies/ripple/source.py
@@ -9,9 +9,16 @@ from typing import Any
 from typing import Protocol
 
 from pms.core.enums import TimeInForce
-from pms.core.models import BookSide, Outcome, Venue
+from pms.core.models import BookSide, Outcome, Portfolio, Venue
 from pms.strategies.intents import StrategyContext, StrategyObservation
 from pms.strategies.projections import FactorCompositionStep
+from pms.strategies.ripple.evaluator import (
+    DEFAULT_MIN_EXPECTED_EDGE,
+    DEFAULT_PRIOR_STRENGTH,
+    beta_binomial_posterior_probability,
+    entry_edge_threshold,
+    posterior_confidence,
+)
 
 
 LIVE_RIPPLE_SOURCE = "live_factor_service"
@@ -41,6 +48,24 @@ RIPPLE_FACTOR_REQUIREMENTS: tuple[FactorCompositionStep, ...] = (
         weight=1.0,
         threshold=0.0,
         required=True,
+        freshness_sla_s=3600.0,
+    ),
+    FactorCompositionStep(
+        factor_id="yes_count",
+        role="posterior_success",
+        param="",
+        weight=1.0,
+        threshold=None,
+        required=False,
+        freshness_sla_s=3600.0,
+    ),
+    FactorCompositionStep(
+        factor_id="no_count",
+        role="posterior_failure",
+        param="",
+        weight=1.0,
+        threshold=None,
+        required=False,
         freshness_sla_s=3600.0,
     ),
 )
@@ -77,6 +102,16 @@ class RippleMarketSnapshotReader(Protocol):
     ) -> RippleMarketSnapshot | None: ...
 
 
+class RipplePositionSizer(Protocol):
+    def size(
+        self,
+        *,
+        prob: float,
+        market_price: float,
+        portfolio: Portfolio,
+    ) -> float: ...
+
+
 @dataclass(frozen=True, slots=True)
 class RippleMarketSnapshot:
     market_id: str
@@ -86,6 +121,7 @@ class RippleMarketSnapshot:
     observed_at: datetime
     best_bid: float | None = None
     best_ask: float | None = None
+    resolves_at: datetime | None = None
     venue: Venue = "polymarket"
 
     def __post_init__(self) -> None:
@@ -195,7 +231,10 @@ class LiveRippleSource:
     market_ids: Sequence[str]
     factor_reader: RippleFactorSnapshotReader
     market_reader: RippleMarketSnapshotReader
-    notional_usdc: float = 25.0
+    position_sizer: RipplePositionSizer
+    portfolio: Portfolio
+    prior_strength: float = DEFAULT_PRIOR_STRENGTH
+    min_expected_edge: float = DEFAULT_MIN_EXPECTED_EDGE
     max_slippage_bps: int = 50
     time_in_force: TimeInForce = TimeInForce.GTC
 
@@ -205,8 +244,11 @@ class LiveRippleSource:
             raise ValueError(msg)
         for market_id in self.market_ids:
             _require_non_empty(market_id, "market_id")
-        if self.notional_usdc <= 0.0:
-            msg = "notional_usdc must be > 0.0"
+        if self.prior_strength <= 0.0:
+            msg = "prior_strength must be > 0.0"
+            raise ValueError(msg)
+        if self.min_expected_edge <= 0.0:
+            msg = "min_expected_edge must be > 0.0"
             raise ValueError(msg)
         if self.max_slippage_bps < 0:
             msg = "max_slippage_bps must be >= 0"
@@ -233,7 +275,10 @@ class LiveRippleSource:
                     context=context,
                     market=market,
                     snapshot=snapshot,
-                    notional_usdc=self.notional_usdc,
+                    position_sizer=self.position_sizer,
+                    portfolio=self.portfolio,
+                    prior_strength=self.prior_strength,
+                    min_expected_edge=self.min_expected_edge,
                     max_slippage_bps=self.max_slippage_bps,
                     time_in_force=self.time_in_force,
                 )
@@ -258,23 +303,46 @@ def _live_observation(
     context: StrategyContext,
     market: RippleMarketSnapshot,
     snapshot: RippleFactorSnapshot,
-    notional_usdc: float,
+    position_sizer: RipplePositionSizer,
+    portfolio: Portfolio,
+    prior_strength: float,
+    min_expected_edge: float,
     max_slippage_bps: int,
     time_in_force: TimeInForce,
 ) -> StrategyObservation:
-    probability_estimate = _bounded_probability(
+    prior_probability = _bounded_probability(
         _factor_value(snapshot, "metaculus_prior", fallback=market.yes_price),
-        "probability_estimate",
+        "metaculus_prior",
     )
-    expected_edge = _factor_value(
-        snapshot,
-        "fair_value_spread",
-        fallback=probability_estimate - market.yes_price,
+    yes_count = _non_negative_count(snapshot, "yes_count")
+    no_count = _non_negative_count(snapshot, "no_count")
+    probability_estimate = beta_binomial_posterior_probability(
+        prior_probability=prior_probability,
+        prior_strength=prior_strength,
+        yes_count=yes_count,
+        no_count=no_count,
     )
     orderbook_imbalance = _factor_value(snapshot, "orderbook_imbalance", fallback=0.0)
     limit_price = _bounded_probability(
         market.best_ask if market.best_ask is not None else market.yes_price,
         "limit_price",
+    )
+    expected_edge = probability_estimate - limit_price
+    dynamic_entry_threshold = entry_edge_threshold(
+        as_of=context.as_of,
+        resolves_at=market.resolves_at,
+        min_expected_edge=min_expected_edge,
+    )
+    confidence = _live_confidence(
+        snapshot,
+        prior_strength=prior_strength,
+        yes_count=yes_count,
+        no_count=no_count,
+    )
+    notional_usdc = position_sizer.size(
+        prob=probability_estimate,
+        market_price=limit_price,
+        portfolio=portfolio,
     )
     evidence_refs = _live_evidence_refs(market, snapshot)
     payload_metadata = {
@@ -287,7 +355,14 @@ def _live_observation(
         "best_bid": market.best_bid,
         "best_ask": market.best_ask,
         "observed_at": market.observed_at.isoformat(),
+        "resolves_at": market.resolves_at.isoformat() if market.resolves_at else None,
         "orderbook_imbalance": orderbook_imbalance,
+        "metaculus_prior": prior_probability,
+        "prior_strength": prior_strength,
+        "yes_count": yes_count,
+        "no_count": no_count,
+        "posterior_probability": probability_estimate,
+        "entry_edge_threshold": dynamic_entry_threshold,
     }
     payload = {
         "market_id": market.market_id,
@@ -298,7 +373,7 @@ def _live_observation(
         ),
         "probability_estimate": probability_estimate,
         "expected_edge": expected_edge,
-        "confidence": _live_confidence(snapshot),
+        "confidence": confidence,
         "token_id": market.token_id,
         "venue": market.venue,
         "side": "BUY",
@@ -337,6 +412,14 @@ def _factor_value(
     return float(value)
 
 
+def _non_negative_count(snapshot: RippleFactorSnapshot, factor_id: str) -> float:
+    value = _factor_value(snapshot, factor_id, fallback=0.0)
+    if value < 0.0:
+        msg = f"{factor_id} must be >= 0.0"
+        raise ValueError(msg)
+    return value
+
+
 def _bounded_probability(value: float, field_name: str) -> float:
     if value <= 0.0:
         return 0.0001
@@ -348,10 +431,19 @@ def _bounded_probability(value: float, field_name: str) -> float:
     return float(value)
 
 
-def _live_confidence(snapshot: RippleFactorSnapshot) -> float:
-    if snapshot.missing_factors or snapshot.stale_factors:
-        return 0.55
-    return 0.75
+def _live_confidence(
+    snapshot: RippleFactorSnapshot,
+    *,
+    prior_strength: float,
+    yes_count: float,
+    no_count: float,
+) -> float:
+    return posterior_confidence(
+        prior_strength=prior_strength,
+        yes_count=yes_count,
+        no_count=no_count,
+        degraded=bool(snapshot.missing_factors or snapshot.stale_factors),
+    )
 
 
 def _live_evidence_refs(

--- a/src/pms/strategies/ripple/source.py
+++ b/src/pms/strategies/ripple/source.py
@@ -56,7 +56,7 @@ RIPPLE_FACTOR_REQUIREMENTS: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=1.0,
         threshold=None,
-        required=False,
+        required=True,
         freshness_sla_s=3600.0,
     ),
     FactorCompositionStep(
@@ -65,7 +65,7 @@ RIPPLE_FACTOR_REQUIREMENTS: tuple[FactorCompositionStep, ...] = (
         param="",
         weight=1.0,
         threshold=None,
-        required=False,
+        required=True,
         freshness_sla_s=3600.0,
     ),
 )
@@ -270,19 +270,19 @@ class LiveRippleSource:
                 strategy_id=context.strategy_id,
                 strategy_version_id=context.strategy_version_id,
             )
-            observations.append(
-                _live_observation(
-                    context=context,
-                    market=market,
-                    snapshot=snapshot,
-                    position_sizer=self.position_sizer,
-                    portfolio=self.portfolio,
-                    prior_strength=self.prior_strength,
-                    min_expected_edge=self.min_expected_edge,
-                    max_slippage_bps=self.max_slippage_bps,
-                    time_in_force=self.time_in_force,
-                )
+            observation = _live_observation(
+                context=context,
+                market=market,
+                snapshot=snapshot,
+                position_sizer=self.position_sizer,
+                portfolio=self.portfolio,
+                prior_strength=self.prior_strength,
+                min_expected_edge=self.min_expected_edge,
+                max_slippage_bps=self.max_slippage_bps,
+                time_in_force=self.time_in_force,
             )
+            if observation is not None:
+                observations.append(observation)
         return tuple(observations)
 
 
@@ -309,7 +309,7 @@ def _live_observation(
     min_expected_edge: float,
     max_slippage_bps: int,
     time_in_force: TimeInForce,
-) -> StrategyObservation:
+) -> StrategyObservation | None:
     prior_probability = _bounded_probability(
         _factor_value(snapshot, "metaculus_prior", fallback=market.yes_price),
         "metaculus_prior",
@@ -344,6 +344,8 @@ def _live_observation(
         market_price=limit_price,
         portfolio=portfolio,
     )
+    if notional_usdc <= 0.0:
+        return None
     evidence_refs = _live_evidence_refs(market, snapshot)
     payload_metadata = {
         "source": LIVE_RIPPLE_SOURCE,

--- a/tests/unit/test_ripple_strategy_plugin.py
+++ b/tests/unit/test_ripple_strategy_plugin.py
@@ -401,7 +401,7 @@ async def test_live_ripple_raises_entry_threshold_near_resolution() -> None:
                 values={
                     ("metaculus_prior", ""): 0.58,
                     ("yes_count", ""): 9.0,
-                    ("no_count", ""): 7.0,
+                    ("no_count", ""): 6.0,
                 }
             )
         ),
@@ -419,7 +419,10 @@ async def test_live_ripple_raises_entry_threshold_near_resolution() -> None:
 
     judgement = await agent.judge(_context(), candidates[0])
 
-    assert candidates[0].expected_edge == pytest.approx(0.018888888888888844)
+    assert candidates[0].expected_edge == pytest.approx(
+        ((0.58 * 2.0 + 9.0) / (2.0 + 9.0 + 6.0)) - 0.56
+    )
+    assert candidates[0].expected_edge > 0.02
     assert candidates[0].metadata["entry_edge_threshold"] > 0.02
     assert judgement.approved is False
     assert judgement.failure_reasons == ("insufficient_expected_edge",)

--- a/tests/unit/test_ripple_strategy_plugin.py
+++ b/tests/unit/test_ripple_strategy_plugin.py
@@ -30,6 +30,7 @@ from pms.strategies.ripple.controller import RippleController
 from pms.strategies.ripple.evaluator import RippleEvidenceEvaluator
 from pms.strategies.ripple.source import (
     LiveRippleSource,
+    RIPPLE_FACTOR_REQUIREMENTS,
     RippleMarketSnapshot,
     RippleObservationFixture,
     RippleObservationSource,
@@ -176,6 +177,33 @@ class _StaticMarketReader:
         )
 
 
+class _ZeroSizer:
+    def size(
+        self,
+        *,
+        prob: float,
+        market_price: float,
+        portfolio: Portfolio,
+    ) -> float:
+        del prob, market_price, portfolio
+        return 0.0
+
+
+class _FixedSizer:
+    def __init__(self, notional_usdc: float) -> None:
+        self.notional_usdc = notional_usdc
+
+    def size(
+        self,
+        *,
+        prob: float,
+        market_price: float,
+        portfolio: Portfolio,
+    ) -> float:
+        del prob, market_price, portfolio
+        return self.notional_usdc
+
+
 async def _candidate_from_fixture(
     fixture: RippleObservationFixture,
 ) -> StrategyCandidate:
@@ -297,6 +325,16 @@ async def test_live_ripple_source_reads_factor_snapshot_and_market_price() -> No
     )
 
 
+def test_live_ripple_requires_beta_binomial_count_factors() -> None:
+    required_flags = {
+        step.factor_id: step.required
+        for step in RIPPLE_FACTOR_REQUIREMENTS
+    }
+
+    assert required_flags["yes_count"] is True
+    assert required_flags["no_count"] is True
+
+
 def test_ripple_evaluator_emits_beta_binomial_posterior_edge_and_confidence() -> None:
     candidate = StrategyCandidate(
         candidate_id="candidate-ripple-live",
@@ -364,6 +402,27 @@ async def test_live_ripple_uses_fractional_kelly_sizing_instead_of_fixture_notio
 
 
 @pytest.mark.asyncio
+async def test_live_ripple_zero_kelly_size_is_clean_no_trade() -> None:
+    source = LiveRippleSource(
+        market_ids=("market-ripple-1",),
+        factor_reader=_RecordingFactorReader(),
+        market_reader=_StaticMarketReader(best_ask=0.60),
+        position_sizer=_ZeroSizer(),
+        portfolio=_portfolio(),
+    )
+    module = RippleStrategyModule(
+        source=source,
+        controller=RippleController(),
+        agent=RippleAgent(),
+        strategy_id="ripple",
+        strategy_version_id="ripple-v1",
+    )
+
+    assert await source.observe(_context()) == ()
+    assert await module.run(_context()) == ()
+
+
+@pytest.mark.asyncio
 async def test_live_ripple_rejects_zero_or_negative_edge_before_building_intent() -> None:
     source = LiveRippleSource(
         market_ids=("market-ripple-1",),
@@ -377,7 +436,7 @@ async def test_live_ripple_rejects_zero_or_negative_edge_before_building_intent(
             )
         ),
         market_reader=_StaticMarketReader(yes_price=0.55, best_ask=0.56),
-        position_sizer=KellySizer(risk=RiskSettings(max_position_per_market=100.0)),
+        position_sizer=_FixedSizer(2.0),
         portfolio=_portfolio(),
     )
     observations = await source.observe(_context())

--- a/tests/unit/test_ripple_strategy_plugin.py
+++ b/tests/unit/test_ripple_strategy_plugin.py
@@ -8,7 +8,10 @@ import tomllib
 
 import pytest
 
+from pms.config import RiskSettings
 from pms.core.enums import TimeInForce
+from pms.core.models import Portfolio
+from pms.controller.sizers.kelly import KellySizer
 from pms.strategies.base import (
     StrategyAgent,
     StrategyController,
@@ -24,6 +27,7 @@ from pms.strategies.intents import (
 )
 from pms.strategies.ripple.agent import RippleAgent
 from pms.strategies.ripple.controller import RippleController
+from pms.strategies.ripple.evaluator import RippleEvidenceEvaluator
 from pms.strategies.ripple.source import (
     LiveRippleSource,
     RippleMarketSnapshot,
@@ -68,17 +72,53 @@ def _fixture(**overrides: object) -> RippleObservationFixture:
 
 
 class _FakeFactorSnapshot:
-    values: Mapping[tuple[str, str], float] = {
-        ("metaculus_prior", ""): 0.67,
-        ("orderbook_imbalance", ""): 0.21,
-        ("fair_value_spread", ""): 0.08,
-    }
-    missing_factors: tuple[tuple[str, str], ...] = ()
-    stale_factors: tuple[tuple[str, str], ...] = ()
-    snapshot_hash: str | None = "factor-hash-1"
+    def __init__(
+        self,
+        *,
+        values: Mapping[tuple[str, str], float] | None = None,
+        missing_factors: tuple[tuple[str, str], ...] = (),
+        stale_factors: tuple[tuple[str, str], ...] = (),
+        snapshot_hash: str | None = "factor-hash-1",
+    ) -> None:
+        self.values = values or {
+            ("metaculus_prior", ""): 0.67,
+            ("orderbook_imbalance", ""): 0.21,
+            ("fair_value_spread", ""): 0.08,
+            ("yes_count", ""): 4.0,
+            ("no_count", ""): 1.0,
+        }
+        self.missing_factors = missing_factors
+        self.stale_factors = stale_factors
+        self.snapshot_hash = snapshot_hash
 
 
 class _RecordingFactorReader:
+    def __init__(self, snapshot: _FakeFactorSnapshot | None = None) -> None:
+        self.snapshot_result = snapshot or _FakeFactorSnapshot()
+        self.calls: list[dict[str, object]] = []
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> _FakeFactorSnapshot:
+        self.calls.append(
+            {
+                "market_id": market_id,
+                "as_of": as_of,
+                "required": required,
+                "strategy_id": strategy_id,
+                "strategy_version_id": strategy_version_id,
+            }
+        )
+        return self.snapshot_result
+
+
+class _LegacyRecordingFactorReader:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
@@ -104,6 +144,19 @@ class _RecordingFactorReader:
 
 
 class _StaticMarketReader:
+    def __init__(
+        self,
+        *,
+        yes_price: float = 0.59,
+        best_bid: float | None = 0.58,
+        best_ask: float | None = 0.60,
+        resolves_at: datetime | None = None,
+    ) -> None:
+        self.yes_price = yes_price
+        self.best_bid = best_bid
+        self.best_ask = best_ask
+        self.resolves_at = resolves_at
+
     async def latest(
         self,
         market_id: str,
@@ -115,10 +168,11 @@ class _StaticMarketReader:
             market_id=market_id,
             title="Will the live factor source resolve YES?",
             token_id="token-ripple-yes",
-            yes_price=0.59,
-            best_bid=0.58,
-            best_ask=0.60,
+            yes_price=self.yes_price,
+            best_bid=self.best_bid,
+            best_ask=self.best_ask,
             observed_at=NOW,
+            resolves_at=self.resolves_at,
         )
 
 
@@ -130,6 +184,15 @@ async def _candidate_from_fixture(
     candidates = await RippleController().propose(context, observations)
     assert len(candidates) == 1
     return candidates[0]
+
+
+def _portfolio(free_usdc: float = 100.0) -> Portfolio:
+    return Portfolio(
+        total_usdc=free_usdc,
+        free_usdc=free_usdc,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
 
 
 def test_ripple_components_satisfy_strategy_protocols() -> None:
@@ -172,11 +235,13 @@ async def test_ripple_strategy_approves_fixture_candidate_and_emits_trade_intent
 
 @pytest.mark.asyncio
 async def test_live_ripple_source_reads_factor_snapshot_and_market_price() -> None:
-    factor_reader = _RecordingFactorReader()
+    factor_reader = _LegacyRecordingFactorReader()
     source = LiveRippleSource(
         market_ids=("market-ripple-1",),
         factor_reader=factor_reader,
         market_reader=_StaticMarketReader(),
+        position_sizer=KellySizer(risk=RiskSettings(max_position_per_market=100.0)),
+        portfolio=_portfolio(),
     )
 
     observations = await source.observe(_context())
@@ -185,16 +250,26 @@ async def test_live_ripple_source_reads_factor_snapshot_and_market_price() -> No
     assert len(observations) == 1
     observation = observations[0]
     assert observation.source == "live_factor_service"
-    assert observation.payload["probability_estimate"] == 0.67
-    assert observation.payload["expected_edge"] == 0.08
+    assert observation.payload["probability_estimate"] == pytest.approx(
+        (0.67 * 2.0 + 4.0) / (2.0 + 4.0 + 1.0)
+    )
+    assert observation.payload["expected_edge"] == pytest.approx(
+        observation.payload["probability_estimate"] - 0.60
+    )
     assert observation.payload["limit_price"] == 0.60
-    assert observation.payload["expected_price"] == 0.67
+    assert observation.payload["expected_price"] == observation.payload["probability_estimate"]
     assert observation.payload["metadata"]["yes_price"] == 0.59
     assert observation.payload["metadata"]["factor_values"] == {
         "fair_value_spread": 0.08,
         "metaculus_prior": 0.67,
         "orderbook_imbalance": 0.21,
+        "yes_count": 4.0,
+        "no_count": 1.0,
     }
+    assert observation.payload["metadata"]["posterior_probability"] == pytest.approx(
+        observation.payload["probability_estimate"]
+    )
+    assert observation.payload["metadata"]["entry_edge_threshold"] == pytest.approx(0.02)
     assert observation.evidence_refs == (
         "factor_snapshot:factor-hash-1",
         "market_snapshot:market-ripple-1:2026-04-28T12:00:00+00:00",
@@ -213,11 +288,141 @@ async def test_live_ripple_source_reads_factor_snapshot_and_market_price() -> No
         "fair_value_spread",
         "metaculus_prior",
         "orderbook_imbalance",
+        "yes_count",
+        "no_count",
     }
     assert candidates[0].metadata["source"] == "live_factor_service"
     assert candidates[0].metadata["fixture_metadata"]["factor_snapshot_hash"] == (
         "factor-hash-1"
     )
+
+
+def test_ripple_evaluator_emits_beta_binomial_posterior_edge_and_confidence() -> None:
+    candidate = StrategyCandidate(
+        candidate_id="candidate-ripple-live",
+        strategy_id="ripple",
+        strategy_version_id="ripple-v1",
+        market_id="market-ripple-1",
+        title="Will posterior math stay deterministic?",
+        thesis="Live evidence supports a posterior edge.",
+        probability_estimate=0.76,
+        expected_edge=0.26,
+        evidence_refs=("factor_snapshot:hash", "market_snapshot:market-ripple-1"),
+        created_at=NOW,
+        metadata={
+            "source": "live_factor_service",
+            "metaculus_prior": 0.6,
+            "prior_strength": 2.0,
+            "yes_count": 8.0,
+            "no_count": 2.0,
+            "limit_price": 0.5,
+            "confidence": 0.8,
+            "contradiction_refs": (),
+        },
+    )
+
+    assessment = RippleEvidenceEvaluator(min_confidence=0.6).assess(candidate)
+
+    assert assessment.approved is True
+    assert assessment.posterior_probability == pytest.approx((0.6 * 2.0 + 8.0) / 12.0)
+    assert assessment.expected_edge == pytest.approx(assessment.posterior_probability - 0.5)
+    assert assessment.confidence == pytest.approx(0.8)
+    assert assessment.entry_edge_threshold == pytest.approx(0.02)
+
+
+@pytest.mark.asyncio
+async def test_live_ripple_uses_fractional_kelly_sizing_instead_of_fixture_notional() -> None:
+    sizer = KellySizer(risk=RiskSettings(max_position_per_market=100.0))
+    portfolio = _portfolio(free_usdc=100.0)
+    source = LiveRippleSource(
+        market_ids=("market-ripple-1",),
+        factor_reader=_RecordingFactorReader(),
+        market_reader=_StaticMarketReader(best_ask=0.60),
+        position_sizer=sizer,
+        portfolio=portfolio,
+    )
+    module = RippleStrategyModule(
+        source=source,
+        controller=RippleController(),
+        agent=RippleAgent(),
+        strategy_id="ripple",
+        strategy_version_id="ripple-v1",
+    )
+
+    intents = await module.run(_context())
+
+    assert len(intents) == 1
+    intent = intents[0]
+    assert isinstance(intent, TradeIntent)
+    expected_probability = (0.67 * 2.0 + 4.0) / (2.0 + 4.0 + 1.0)
+    assert intent.expected_price == pytest.approx(expected_probability)
+    assert intent.expected_edge == pytest.approx(expected_probability - 0.60)
+    assert intent.notional_usdc == pytest.approx(
+        sizer.size(prob=expected_probability, market_price=0.60, portfolio=portfolio)
+    )
+    assert intent.notional_usdc != 25.0
+
+
+@pytest.mark.asyncio
+async def test_live_ripple_rejects_zero_or_negative_edge_before_building_intent() -> None:
+    source = LiveRippleSource(
+        market_ids=("market-ripple-1",),
+        factor_reader=_RecordingFactorReader(
+            _FakeFactorSnapshot(
+                values={
+                    ("metaculus_prior", ""): 0.4,
+                    ("yes_count", ""): 1.0,
+                    ("no_count", ""): 9.0,
+                }
+            )
+        ),
+        market_reader=_StaticMarketReader(yes_price=0.55, best_ask=0.56),
+        position_sizer=KellySizer(risk=RiskSettings(max_position_per_market=100.0)),
+        portfolio=_portfolio(),
+    )
+    observations = await source.observe(_context())
+    candidates = await RippleController().propose(_context(), observations)
+    agent = RippleAgent(min_confidence=0.6)
+
+    judgement = await agent.judge(_context(), candidates[0])
+    intents = await agent.build_intents(_context(), candidates[0], judgement)
+
+    assert judgement.approved is False
+    assert judgement.failure_reasons == ("insufficient_expected_edge",)
+    assert intents == ()
+
+
+@pytest.mark.asyncio
+async def test_live_ripple_raises_entry_threshold_near_resolution() -> None:
+    source = LiveRippleSource(
+        market_ids=("market-ripple-1",),
+        factor_reader=_RecordingFactorReader(
+            _FakeFactorSnapshot(
+                values={
+                    ("metaculus_prior", ""): 0.58,
+                    ("yes_count", ""): 9.0,
+                    ("no_count", ""): 7.0,
+                }
+            )
+        ),
+        market_reader=_StaticMarketReader(
+            yes_price=0.55,
+            best_ask=0.56,
+            resolves_at=datetime(2026, 4, 28, 16, 0, tzinfo=UTC),
+        ),
+        position_sizer=KellySizer(risk=RiskSettings(max_position_per_market=100.0)),
+        portfolio=_portfolio(),
+    )
+    observations = await source.observe(_context())
+    candidates = await RippleController().propose(_context(), observations)
+    agent = RippleAgent(min_confidence=0.6)
+
+    judgement = await agent.judge(_context(), candidates[0])
+
+    assert candidates[0].expected_edge == pytest.approx(0.018888888888888844)
+    assert candidates[0].metadata["entry_edge_threshold"] > 0.02
+    assert judgement.approved is False
+    assert judgement.failure_reasons == ("insufficient_expected_edge",)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Replaces Ripple's threshold-only live evaluation with a Beta-Binomial posterior path that emits `posterior_probability`, `expected_edge`, `confidence`, and `entry_edge_threshold`.
- Adds the explicit entry gate: expected edge must clear the configured base threshold (`0.02`) or the near-resolution dynamic threshold, and confidence must clear `min_confidence`.
- Wires live Ripple sizing through an injected sizer protocol compatible with the existing `KellySizer`, so the production live source does not rely on fixture `notional_usdc`.

## Scope hygiene
```text
git log --oneline origin/main..HEAD
c913b1e feat(strategies): add ripple posterior kelly sizing
18a8720 test(strategies): define ripple posterior kelly contract

git diff --name-only origin/main...HEAD
src/pms/strategies/ripple/controller.py
src/pms/strategies/ripple/evaluator.py
src/pms/strategies/ripple/source.py
tests/unit/test_ripple_strategy_plugin.py
```

Strategy-boundary impact: yes, but contained to `pms.strategies.ripple`. The Ripple plugin still has no `pms.controller`, actuator, or venue-adapter imports; `KellySizer` is injected from the assembly/test side and verified by import-linter.

## RED evidence
```text
uv run pytest tests/unit/test_ripple_strategy_plugin.py -q
..FFFFF......                                                            [100%]
FAILED tests/unit/test_ripple_strategy_plugin.py::test_live_ripple_source_reads_factor_snapshot_and_market_price - TypeError: LiveRippleSource.__init__() got an unexpected keyword argument 'position_sizer'
FAILED tests/unit/test_ripple_strategy_plugin.py::test_ripple_evaluator_emits_beta_binomial_posterior_edge_and_confidence - AttributeError: 'RippleEvidenceAssessment' object has no attribute 'posterior_probability'
FAILED tests/unit/test_ripple_strategy_plugin.py::test_live_ripple_uses_fractional_kelly_sizing_instead_of_fixture_notional - TypeError: LiveRippleSource.__init__() got an unexpected keyword argument 'position_sizer'
FAILED tests/unit/test_ripple_strategy_plugin.py::test_live_ripple_rejects_zero_or_negative_edge_before_building_intent - TypeError: LiveRippleSource.__init__() got an unexpected keyword argument 'position_sizer'
FAILED tests/unit/test_ripple_strategy_plugin.py::test_live_ripple_raises_entry_threshold_near_resolution - TypeError: LiveRippleSource.__init__() got an unexpected keyword argument 'position_sizer'
5 failed, 8 passed in 1.15s
```

## Verification
```text
uv run pytest tests/unit/test_ripple_strategy_plugin.py -q
13 passed in 0.21s

uv run pytest tests/unit/test_ripple_strategy_plugin.py tests/unit/test_strategy_plugin_intents.py tests/unit/test_agent_strategy_runtime_bridge.py -q
31 passed in 0.23s

uv run pytest tests/unit -q
881 passed in 12.31s

uv run ruff check src/pms/strategies/ripple tests/unit/test_ripple_strategy_plugin.py
All checks passed!

uv run mypy src/pms/strategies/ripple tests/unit/test_ripple_strategy_plugin.py
Success: no issues found in 8 source files

uv run lint-imports
Contracts: 8 kept, 0 broken.

git diff --check
# no output
```

## Reviewer packet
- @Researcher-Ciga: please review Beta-Binomial posterior math, confidence, and Kelly sizing semantics.
- @PM-Derik: please review risk acceptance: edge threshold, near-resolution threshold behavior, and no fixture notional in live path.
- @claude: please review Ripple integration / strategy-boundary impact. The import-linter contract remains green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Bayesian posterior-based evaluation for trading decisions, replacing deterministic confidence calculations.
  * Added dynamic position sizing based on portfolio state instead of fixed notional amounts.
  * Enhanced confidence measurement to account for missing or stale market data.

* **Tests**
  * Expanded test coverage for posterior probability calculations and edge-based rejection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->