### PR TITLE
fix(pms): load paper-soak config at API startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ uv run alembic downgrade base
 uv run pms-api                       # → http://127.0.0.1:8000
 # Optional: auto-start the runner at boot
 PMS_AUTO_START=1 uv run pms-api
+# First-live paper soak: load the tight risk envelope explicitly
+uv run pms-api --config config.live-soak.yaml
 
 # 5. In another shell, start the dashboard (port 3100)
 cd dashboard

--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -12,7 +12,9 @@ passphrases into chat, issues, PRs, logs, or config files.
    `max_drawdown_pct=20%`, `max_open_positions=5`,
    `max_quantity_shares=500`, and `slippage_threshold_bps=50`.
 3. Run PAPER mode against live market data with the soak config:
-   `PMS_MODE=paper uv run pms-api`.
+   `uv run pms-api --config config.live-soak.yaml`.
+   For process managers that cannot pass CLI args, set
+   `PMS_CONFIG_PATH=config.live-soak.yaml`.
 4. Confirm `/status`, `/trades`, `/positions`, and evaluator metrics update.
 5. Review order notional, slippage, rejected orders, and portfolio exposure.
 6. Keep `live_trading_enabled=false` until the 30-day soak and compliance

--- a/src/pms/api/__main__.py
+++ b/src/pms/api/__main__.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from collections.abc import Sequence
 
 import uvicorn
 
-from pms.config import PMSSettings
+from pms.config import load_settings
 
 
 LOOPBACK_API_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
@@ -22,6 +23,11 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--log-level", default="info")
     parser.add_argument("--reload", action="store_true", help="Enable hot-reload for development.")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="YAML config path. Also available as PMS_CONFIG_PATH.",
+    )
     return parser
 
 
@@ -34,7 +40,9 @@ def _startup_gate_message(host: str) -> str:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(list(argv) if argv is not None else None)
-    settings = PMSSettings()
+    if args.config is not None:
+        os.environ["PMS_CONFIG_PATH"] = args.config
+    settings = load_settings(args.config)
     host = settings.api_host
 
     if not settings.api_token and host not in LOOPBACK_API_HOSTS:

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -60,7 +60,12 @@ from pms.api.routes.signals import SignalDepthNotFoundError, get_signal_depth
 from pms.api.routes.strategies import list_strategy_metrics as list_strategy_metrics_items
 from pms.api.routes.strategies import list_strategies as list_strategies_items
 from pms.api.routes.trades import list_trades as list_trades_items
-from pms.config import MissingPolymarketCredentialsError, PMSSettings, validate_live_mode_ready
+from pms.config import (
+    MissingPolymarketCredentialsError,
+    PMSSettings,
+    load_settings,
+    validate_live_mode_ready,
+)
 from pms.core.enums import RunMode
 from pms.core.models import EvalRecord, LiveTradingDisabledError, MarketSignal, TradeDecision
 from pms.evaluation.metrics import MetricsCollector, MetricsSnapshot
@@ -104,8 +109,9 @@ def create_app(
     runner: Runner | None = None,
     *,
     auto_start: bool | None = None,
+    config_path: str | None = None,
 ) -> FastAPI:
-    active_runner = runner or Runner()
+    active_runner = runner or Runner(config=load_settings(config_path))
     if auto_start is None:
         auto_start = os.environ.get("PMS_AUTO_START", "").lower() in {"1", "true", "yes"}
 

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -161,6 +161,13 @@ class PMSSettings(BaseSettings):
         return cls(**config_data)
 
 
+def load_settings(config_path: str | Path | None = None) -> PMSSettings:
+    configured_path = config_path
+    if configured_path is None:
+        configured_path = os.environ.get("PMS_CONFIG_PATH") or "config.yaml"
+    return PMSSettings.load(configured_path)
+
+
 def validate_live_mode_ready(settings: PMSSettings) -> VenueCredentials:
     if not settings.live_trading_enabled:
         msg = "Live trading is disabled. Set live_trading_enabled=true in config."

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any
 
+from pms.api.app import create_app
 import pms.api.__main__ as api_main
+from pms.core.enums import RunMode
 
 
 def test_main_invokes_uvicorn_with_settings_host_and_cli_defaults(
@@ -73,3 +77,61 @@ def test_main_uses_settings_host_even_when_host_flag_is_passed(
     assert exit_code == 0
     assert calls["host"] == "0.0.0.0"
     assert calls["port"] == 9000
+
+
+def test_main_loads_config_file_and_exports_path_for_app_factory(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    calls: dict[str, Any] = {}
+    config_path = tmp_path / "live-soak.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "api_host: 127.0.0.1",
+                "mode: paper",
+                "risk:",
+                "  max_total_exposure: 50.0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(app: str, **kwargs: Any) -> None:
+        calls["app"] = app
+        calls.update(kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    monkeypatch.delenv("PMS_CONFIG_PATH", raising=False)
+
+    exit_code = api_main.main(["--config", str(config_path)])
+
+    assert exit_code == 0
+    assert calls["host"] == "127.0.0.1"
+    assert calls["app"] == "pms.api.app:create_app"
+    assert calls["factory"] is True
+    assert calls["reload"] is False
+    assert calls["log_level"] == "info"
+    assert calls["port"] == 8000
+    assert os.environ["PMS_CONFIG_PATH"] == str(config_path)
+
+
+def test_create_app_uses_config_path_for_default_runner(tmp_path: Path) -> None:
+    config_path = tmp_path / "live-soak.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "mode: paper",
+                "risk:",
+                "  max_position_per_market: 5.0",
+                "  max_total_exposure: 50.0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    app = create_app(auto_start=False, config_path=str(config_path))
+
+    assert app.state.runner.config.mode is RunMode.PAPER
+    assert app.state.runner.config.risk.max_position_per_market == 5.0
+    assert app.state.runner.config.risk.max_total_exposure == 50.0


### PR DESCRIPTION
## Summary
- Adds a shared `load_settings()` helper that honors `--config` and `PMS_CONFIG_PATH`.
- Makes `pms-api --config config.live-soak.yaml` load the same settings used by the actual FastAPI runner factory.
- Updates the runbook/README paper-soak command so ops can start the runner with the tight PR #43 risk envelope, not just `PMS_MODE=paper`.

## Why
PR #43 added `config.live-soak.yaml`, but `pms-api` still built `PMSSettings()` from env/defaults only. The paper report loaded the soak config, but the actual runner did not. That meant Day 0 report verification was valid, but real paper-soak execution could silently use default risk caps.

## Verification
```text
uv run pytest tests/unit/test_api_main.py tests/unit/test_core_foundation.py tests/unit/test_live_soak_config.py -q
....................                                                     [100%]
20 passed in 0.43s
```

```text
uv run pytest tests/unit -q
........................................................................ [  7%]
........................................................................ [ 15%]
........................................................................ [ 23%]
........................................................................ [ 31%]
........................................................................ [ 39%]
........................................................................ [ 47%]
........................................................................ [ 55%]
........................................................................ [ 63%]
........................................................................ [ 71%]
........................................................................ [ 79%]
........................................................................ [ 87%]
........................................................................ [ 95%]
.....................................                                    [100%]
901 passed in 11.23s
```

```text
uv run ruff check src/pms/api/__main__.py src/pms/api/app.py src/pms/config.py tests/unit/test_api_main.py tests/unit/test_core_foundation.py tests/unit/test_live_soak_config.py
All checks passed!
```

```text
uv run mypy src/pms/api/__main__.py src/pms/api/app.py src/pms/config.py tests/unit/test_api_main.py
Success: no issues found in 4 source files
```

```text
uv run python - <<'PY'
from pms.api.app import create_app
app = create_app(auto_start=False, config_path='config.live-soak.yaml')
settings = app.state.runner.config
print(settings.mode.value)
print(settings.risk.max_position_per_market)
print(settings.risk.max_total_exposure)
print(settings.risk.max_drawdown_pct)
print(settings.risk.max_open_positions)
print(settings.risk.max_quantity_shares)
print(settings.live_trading_enabled)
PY
paper
5.0
50.0
20.0
5
500.0
False
```

```text
git diff --check
# no output
```

No screenshots apply: this is CLI/config startup plumbing.
