### PR TITLE
Add FLB warehouse source path

### DIFF
--- a/docs/research/flb-historical-warehouse-source.md
+++ b/docs/research/flb-historical-warehouse-source.md
@@ -1,0 +1,66 @@
+# H1 FLB Historical Warehouse Source
+
+Task #22 keeps the H1 feasibility work data-source focused. It does not add
+H2 anchoring lag or LLM/news replay.
+
+## Goal
+
+Produce resolved Polymarket binary contract observations that can be replayed
+through `scripts/flb_data_feasibility.py` and compared against PR #45's
+contract-level `ContractObservation` semantics:
+
+- YES contract at entry YES price `p`.
+- NO contract at entry price `1 - p`.
+- `pays_out` must come from explicit final settlement data.
+
+The H1 data source is viable only when both extreme contract buckets meet the
+sample gate:
+
+- `[0%,10%)`: at least 100 contract observations.
+- `[90%,100%]`: at least 100 contract observations.
+
+## Warehouse CSV Contract
+
+Export a CSV from Dune, a data warehouse, or a checked-in research fixture with
+one row per resolved binary market and these required columns:
+
+| Column | Meaning |
+| --- | --- |
+| `market_id` | Stable Polymarket condition/market id. |
+| `question` | Human-readable market question. |
+| `entry_yes_price` | YES price at the selected entry timestamp. Must be `0 < p < 1`. |
+| `yes_payout` | Final YES payout. Must be exactly `1` or `0`. |
+| `no_payout` | Final NO payout. Must be exactly `1` or `0`. |
+| `volume` | Historical volume for liquidity filtering/reporting. |
+| `liquidity` | Liquidity measure at or near the entry timestamp. |
+| `entry_timestamp` | ISO-8601 timestamp for the entry price snapshot. |
+| `resolved_at` | ISO-8601 settlement/resolution timestamp. |
+| `category` | Market category used for reporting. |
+
+Settlement correctness is strict: only `(yes_payout,no_payout)=(1,0)` or
+`(0,1)` is accepted. Price-like or ambiguous vectors such as `0.995,0.005` and
+`0.5,0.5` are rejected because they are not explicit binary settlement labels.
+
+## Reproducible Run
+
+```bash
+uv run python scripts/flb_data_feasibility.py \
+  --source warehouse-csv \
+  --input exports/polymarket_resolved_binary.csv \
+  --output docs/research/flb-report.md \
+  --csv docs/research/flb-deciles.csv
+```
+
+The script returns:
+
+- exit `0` when H1 data is viable and both extreme buckets have at least 100
+  contract observations.
+- exit `1` when H1 is not viable yet because the sample gate fails.
+- exit `2` when no markets were loaded.
+
+## Next Data Gap
+
+If the warehouse export fails the sample gate, H1 is not rejected. The next gap
+is historical source coverage: add a broader Dune query or warehouse table with
+more resolved binary contracts and explicit payout vectors before building H2
+LLM/news replay.

--- a/docs/research/flb-historical-warehouse-source.md
+++ b/docs/research/flb-historical-warehouse-source.md
@@ -22,7 +22,11 @@ sample gate:
 ## Warehouse CSV Contract
 
 Export a CSV from Dune, a data warehouse, or a checked-in research fixture with
-one row per resolved binary market and these required columns:
+one row per resolved binary market. `market_id` must be unique; trade-level or
+token-level exports must be aggregated to one entry snapshot per market before
+running the gate.
+
+The CSV requires these columns:
 
 | Column | Meaning |
 | --- | --- |
@@ -40,6 +44,10 @@ one row per resolved binary market and these required columns:
 Settlement correctness is strict: only `(yes_payout,no_payout)=(1,0)` or
 `(0,1)` is accepted. Price-like or ambiguous vectors such as `0.995,0.005` and
 `0.5,0.5` are rejected because they are not explicit binary settlement labels.
+
+Timing correctness is also strict: `entry_timestamp` must be before
+`resolved_at`. Same-time or post-resolution entry snapshots are rejected because
+they can leak settlement truth into the FLB sample.
 
 ## Reproducible Run
 

--- a/scripts/flb_data_feasibility.py
+++ b/scripts/flb_data_feasibility.py
@@ -10,6 +10,8 @@ reflects the full tradable contract set.
 
 Usage:
     uv run python scripts/flb_data_feasibility.py [--limit N] [--output PATH]
+    uv run python scripts/flb_data_feasibility.py \
+        --source warehouse-csv --input exports/polymarket_resolved_binary.csv
 
 Exit codes:
     0 — H1 viable (sample gate passed)
@@ -52,6 +54,18 @@ SAMPLE_GATE_MIN = 100  # minimum resolved contracts per target bucket
 DECILE_BOUNDARIES = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 TARGET_BUCKETS = [0, 9]  # decile 0 = [0%, 10%), decile 9 = [90%, 100%]
 WILSON_Z = 1.96  # 95% confidence
+WAREHOUSE_REQUIRED_COLUMNS = frozenset({
+    "market_id",
+    "question",
+    "entry_yes_price",
+    "yes_payout",
+    "no_payout",
+    "volume",
+    "liquidity",
+    "entry_timestamp",
+    "resolved_at",
+    "category",
+})
 
 
 # ── Data Structures ─────────────────────────────────────────────────────────
@@ -283,6 +297,125 @@ def _extract_category(slug: str, question: str) -> str:
     return "other"
 
 
+# ── Historical Warehouse Loading ─────────────────────────────────────────────
+
+
+def load_warehouse_markets(path: Path) -> list[ResolvedMarket]:
+    """Load resolved binary markets from an explicit warehouse/Dune CSV export.
+
+    The warehouse path is intentionally stricter than the Gamma fallback:
+    settlement must come from an explicit final payout vector
+    (``yes_payout,no_payout`` equal to ``1,0`` or ``0,1``).  Near-settled
+    prices such as ``0.995,0.005`` are rejected because they are trade prices,
+    not oracle settlement labels.
+    """
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = set(reader.fieldnames or [])
+        missing = WAREHOUSE_REQUIRED_COLUMNS - fieldnames
+        if missing:
+            missing_display = ", ".join(sorted(missing))
+            raise ValueError(f"warehouse CSV missing required columns: {missing_display}")
+
+        markets: list[ResolvedMarket] = []
+        for row_number, row in enumerate(reader, start=2):
+            markets.append(_parse_warehouse_row(row, row_number=row_number))
+
+    return markets
+
+
+def _parse_warehouse_row(
+    row: dict[str, str | None],
+    *,
+    row_number: int,
+) -> ResolvedMarket:
+    """Parse one strict warehouse CSV row into a resolved binary market."""
+    entry_yes_price = _required_float(row, "entry_yes_price", row_number=row_number)
+    if entry_yes_price <= 0.0 or entry_yes_price >= 1.0:
+        raise ValueError(
+            f"warehouse row {row_number}: entry_yes_price must be between 0 and 1"
+        )
+
+    resolved_yes = _resolved_yes_from_exact_payout(row, row_number=row_number)
+
+    entry_timestamp = _required_text(row, "entry_timestamp", row_number=row_number)
+    resolved_at = _required_text(row, "resolved_at", row_number=row_number)
+    _validate_iso_datetime(entry_timestamp, column="entry_timestamp", row_number=row_number)
+    _validate_iso_datetime(resolved_at, column="resolved_at", row_number=row_number)
+
+    return ResolvedMarket(
+        market_id=_required_text(row, "market_id", row_number=row_number),
+        question=_required_text(row, "question", row_number=row_number),
+        yes_price=entry_yes_price,
+        resolved_yes=resolved_yes,
+        volume=_required_float(row, "volume", row_number=row_number),
+        liquidity=_required_float(row, "liquidity", row_number=row_number),
+        end_date=resolved_at,
+        category=_required_text(row, "category", row_number=row_number),
+    )
+
+
+def _resolved_yes_from_exact_payout(
+    row: dict[str, str | None],
+    *,
+    row_number: int,
+) -> bool:
+    """Return resolution from an exact final payout vector."""
+    yes_payout = _required_float(row, "yes_payout", row_number=row_number)
+    no_payout = _required_float(row, "no_payout", row_number=row_number)
+
+    if yes_payout == 1.0 and no_payout == 0.0:
+        return True
+    if yes_payout == 0.0 and no_payout == 1.0:
+        return False
+
+    raise ValueError(
+        f"warehouse row {row_number}: expected exact final payout vector "
+        "(yes_payout,no_payout) of (1,0) or (0,1)"
+    )
+
+
+def _required_text(
+    row: dict[str, str | None],
+    column: str,
+    *,
+    row_number: int,
+) -> str:
+    value = row.get(column)
+    if value is None or value.strip() == "":
+        raise ValueError(f"warehouse row {row_number}: missing {column}")
+    return value.strip()
+
+
+def _required_float(
+    row: dict[str, str | None],
+    column: str,
+    *,
+    row_number: int,
+) -> float:
+    raw_value = _required_text(row, column, row_number=row_number)
+    try:
+        value = float(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"warehouse row {row_number}: {column} must be a finite number"
+        ) from exc
+    if not math.isfinite(value):
+        raise ValueError(
+            f"warehouse row {row_number}: {column} must be a finite number"
+        )
+    return value
+
+
+def _validate_iso_datetime(value: str, *, column: str, row_number: int) -> None:
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"warehouse row {row_number}: {column} must be ISO-8601"
+        ) from exc
+
+
 # ── Contract-Level Conversion ────────────────────────────────────────────────
 
 
@@ -481,12 +614,14 @@ def generate_report(
     decile_stats: list[DecileStats],
     gate: SampleGateResult,
     fetched_at: datetime,
+    source_label: str = "Gamma API closed markets",
 ) -> str:
     """Generate a Markdown report of the FLB feasibility analysis."""
     lines: list[str] = []
     lines.append("# H1 FLB Data Feasibility Report")
     lines.append("")
     lines.append(f"**Generated:** {fetched_at.isoformat()}")
+    lines.append(f"**Data source:** {source_label}")
     lines.append(f"**Total resolved markets analyzed:** {len(markets)}")
     lines.append(f"**Total contract observations:** {len(contracts)} "
                  "(2 per binary market: YES + NO)")
@@ -496,8 +631,8 @@ def generate_report(
     gate_emoji = "✅" if gate.passed else "❌"
     lines.append(f"## Sample Gate: {gate_emoji}")
     lines.append("")
-    lines.append(f"| Bucket | Contract Count | Required | Status |")
-    lines.append(f"|--------|---------------|----------|--------|")
+    lines.append("| Bucket | Contract Count | Required | Status |")
+    lines.append("|--------|---------------|----------|--------|")
     ls = "✅" if gate.longshot_passed else "❌"
     fs = "✅" if gate.favorite_passed else "❌"
     lines.append(
@@ -508,10 +643,18 @@ def generate_report(
     )
     lines.append("")
 
-    if not gate.passed:
+    if gate.passed:
+        lines.append(
+            "**H1 DATA VIABLE.** Extreme buckets meet the sample gate. "
+            "Proceed to the next backtest slice with fees, slippage, and "
+            "timestamped entry rules."
+        )
+        lines.append("")
+    else:
         lines.append(
             "**H1 NOT VIABLE YET.** Insufficient resolved contracts in target "
-            "buckets. Collect more data before proceeding with FLB strategy."
+            "buckets. Next data-source gap: collect a broader Dune or "
+            "warehouse export before proceeding with FLB strategy."
         )
         lines.append("")
 
@@ -606,9 +749,9 @@ def generate_report(
         "backtesting, we need price snapshots at a defined entry horizon."
     )
     lines.append(
-        "3. **Data source:** Gamma API `closed=true` returns a small window "
-        "of recently resolved markets. For ≥100 contracts per target bucket, "
-        "Dune Analytics on-chain data or a historical warehouse is required."
+        "3. **Data source coverage:** Gamma API `closed=true` is only a "
+        "small-window fallback. Robust H1 viability requires a Dune Analytics "
+        "or historical warehouse export with explicit final payout vectors."
     )
     lines.append(
         "4. **Feasibility only:** This is a bias-detection script, not a "
@@ -647,6 +790,18 @@ def save_decile_csv(
 def main() -> int:
     parser = argparse.ArgumentParser(description="H1 FLB Data Feasibility Analysis")
     parser.add_argument(
+        "--source",
+        choices=["gamma", "warehouse-csv"],
+        default="gamma",
+        help="Historical data source (default: gamma)",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=None,
+        help="Input CSV path when --source=warehouse-csv",
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=500,
@@ -674,14 +829,26 @@ def main() -> int:
 
     fetched_at = datetime.now(tz=UTC)
 
-    # Step 1: Fetch resolved markets.
-    print(f"Fetching resolved Polymarket markets (limit={args.limit}, max_pages={args.max_pages})...",
-          file=sys.stderr)
-    markets = fetch_resolved_markets(limit=args.limit, max_pages=args.max_pages)
-    print(f"Fetched {len(markets)} resolved binary markets.", file=sys.stderr)
+    # Step 1: Fetch/load resolved markets.
+    if args.source == "gamma":
+        source_label = "Gamma API closed markets"
+        print(
+            "Fetching resolved Polymarket markets "
+            f"(limit={args.limit}, max_pages={args.max_pages})...",
+            file=sys.stderr,
+        )
+        markets = fetch_resolved_markets(limit=args.limit, max_pages=args.max_pages)
+        print(f"Fetched {len(markets)} resolved binary markets.", file=sys.stderr)
+    else:
+        if args.input is None:
+            parser.error("--input is required when --source=warehouse-csv")
+        source_label = f"warehouse CSV: {args.input}"
+        print(f"Loading resolved binary markets from {args.input}...", file=sys.stderr)
+        markets = load_warehouse_markets(args.input)
+        print(f"Loaded {len(markets)} resolved binary markets.", file=sys.stderr)
 
     if not markets:
-        print("ERROR: No resolved markets found. Check API connectivity.", file=sys.stderr)
+        print("ERROR: No resolved markets found.", file=sys.stderr)
         return 2
 
     # Step 2: Convert to contract-level observations.
@@ -702,6 +869,7 @@ def main() -> int:
         decile_stats=decile_stats,
         gate=gate,
         fetched_at=fetched_at,
+        source_label=source_label,
     )
 
     if args.output:

--- a/scripts/flb_data_feasibility.py
+++ b/scripts/flb_data_feasibility.py
@@ -429,11 +429,14 @@ def _required_float(
 
 def _parse_iso_datetime(value: str, *, column: str, row_number: int) -> datetime:
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
         raise ValueError(
             f"warehouse row {row_number}: {column} must be ISO-8601"
         ) from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 # ── Contract-Level Conversion ────────────────────────────────────────────────

--- a/scripts/flb_data_feasibility.py
+++ b/scripts/flb_data_feasibility.py
@@ -318,8 +318,16 @@ def load_warehouse_markets(path: Path) -> list[ResolvedMarket]:
             raise ValueError(f"warehouse CSV missing required columns: {missing_display}")
 
         markets: list[ResolvedMarket] = []
+        market_ids: set[str] = set()
         for row_number, row in enumerate(reader, start=2):
-            markets.append(_parse_warehouse_row(row, row_number=row_number))
+            market = _parse_warehouse_row(row, row_number=row_number)
+            if market.market_id in market_ids:
+                raise ValueError(
+                    f"warehouse row {row_number}: duplicate market_id "
+                    f"{market.market_id!r}; expected one row per resolved binary market"
+                )
+            market_ids.add(market.market_id)
+            markets.append(market)
 
     return markets
 
@@ -340,8 +348,20 @@ def _parse_warehouse_row(
 
     entry_timestamp = _required_text(row, "entry_timestamp", row_number=row_number)
     resolved_at = _required_text(row, "resolved_at", row_number=row_number)
-    _validate_iso_datetime(entry_timestamp, column="entry_timestamp", row_number=row_number)
-    _validate_iso_datetime(resolved_at, column="resolved_at", row_number=row_number)
+    entry_dt = _parse_iso_datetime(
+        entry_timestamp,
+        column="entry_timestamp",
+        row_number=row_number,
+    )
+    resolved_dt = _parse_iso_datetime(
+        resolved_at,
+        column="resolved_at",
+        row_number=row_number,
+    )
+    if entry_dt >= resolved_dt:
+        raise ValueError(
+            f"warehouse row {row_number}: entry_timestamp must be before resolved_at"
+        )
 
     return ResolvedMarket(
         market_id=_required_text(row, "market_id", row_number=row_number),
@@ -407,9 +427,9 @@ def _required_float(
     return value
 
 
-def _validate_iso_datetime(value: str, *, column: str, row_number: int) -> None:
+def _parse_iso_datetime(value: str, *, column: str, row_number: int) -> datetime:
     try:
-        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
         raise ValueError(
             f"warehouse row {row_number}: {column} must be ISO-8601"

--- a/tests/test_flb_data_feasibility.py
+++ b/tests/test_flb_data_feasibility.py
@@ -6,12 +6,13 @@ sample gate, report generation) without hitting the Gamma API.
 
 from __future__ import annotations
 
+import csv
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
 from scripts.flb_data_feasibility import (
-    ContractObservation,
     DecileStats,
     ResolvedMarket,
     _assign_decile,
@@ -20,6 +21,7 @@ from scripts.flb_data_feasibility import (
     check_sample_gate,
     compute_decile_stats,
     generate_report,
+    load_warehouse_markets,
     markets_to_contracts,
 )
 
@@ -46,6 +48,141 @@ def _market(
         end_date="2026-05-01",
         category=category,
     )
+
+
+WAREHOUSE_COLUMNS = [
+    "market_id",
+    "question",
+    "entry_yes_price",
+    "yes_payout",
+    "no_payout",
+    "volume",
+    "liquidity",
+    "entry_timestamp",
+    "resolved_at",
+    "category",
+]
+
+
+def _write_warehouse_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=WAREHOUSE_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _warehouse_row(
+    *,
+    market_id: str = "m-1",
+    entry_yes_price: str = "0.05",
+    yes_payout: str = "0",
+    no_payout: str = "1",
+) -> dict[str, str]:
+    return {
+        "market_id": market_id,
+        "question": f"Warehouse market {market_id}?",
+        "entry_yes_price": entry_yes_price,
+        "yes_payout": yes_payout,
+        "no_payout": no_payout,
+        "volume": "10000",
+        "liquidity": "500",
+        "entry_timestamp": "2025-12-01T00:00:00Z",
+        "resolved_at": "2026-01-01T00:00:00Z",
+        "category": "politics",
+    }
+
+
+# ── Warehouse CSV Loading ───────────────────────────────────────────────────
+
+
+class TestWarehouseCsvLoading:
+    def test_loads_explicit_settlement_vectors(self, tmp_path: Path) -> None:
+        """Warehouse source uses explicit final payout vectors, not price heuristics."""
+        path = tmp_path / "resolved_binary.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(
+                market_id="yes-wins",
+                entry_yes_price="0.92",
+                yes_payout="1",
+                no_payout="0",
+            ),
+            _warehouse_row(
+                market_id="no-wins",
+                entry_yes_price="0.08",
+                yes_payout="0",
+                no_payout="1",
+            ),
+        ])
+
+        markets = load_warehouse_markets(path)
+
+        assert len(markets) == 2
+        assert markets[0].resolved_yes is True
+        assert markets[0].yes_price == pytest.approx(0.92)
+        assert markets[1].resolved_yes is False
+        assert len(markets_to_contracts(markets)) == 4
+
+    def test_rejects_near_settled_payout_vector(self, tmp_path: Path) -> None:
+        """0.995/0.005 is a price-like vector, not explicit settlement truth."""
+        path = tmp_path / "near_settled.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(yes_payout="0.995", no_payout="0.005")
+        ])
+
+        with pytest.raises(ValueError, match="exact final payout vector"):
+            load_warehouse_markets(path)
+
+    def test_rejects_ambiguous_fifty_fifty_payout_vector(self, tmp_path: Path) -> None:
+        """Ambiguous 50/50 resolutions are not safe labels for H1 FLB."""
+        path = tmp_path / "fifty_fifty.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(yes_payout="0.5", no_payout="0.5")
+        ])
+
+        with pytest.raises(ValueError, match="exact final payout vector"):
+            load_warehouse_markets(path)
+
+    def test_rejects_missing_required_column(self, tmp_path: Path) -> None:
+        path = tmp_path / "missing_column.csv"
+        with path.open("w", newline="", encoding="utf-8") as f:
+            fieldnames = [c for c in WAREHOUSE_COLUMNS if c != "liquidity"]
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            row = _warehouse_row()
+            row.pop("liquidity")
+            writer.writerow(row)
+
+        with pytest.raises(ValueError, match="missing required columns: liquidity"):
+            load_warehouse_markets(path)
+
+    def test_warehouse_contracts_can_pass_extreme_sample_gate(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "sample_gate.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(market_id=f"m-{i}", entry_yes_price="0.05")
+            for i in range(120)
+        ])
+
+        markets = load_warehouse_markets(path)
+        contracts = markets_to_contracts(markets)
+        stats = compute_decile_stats(contracts)
+        gate = check_sample_gate(stats)
+        report = generate_report(
+            markets=markets,
+            contracts=contracts,
+            decile_stats=stats,
+            gate=gate,
+            fetched_at=datetime(2026, 5, 3, tzinfo=UTC),
+            source_label=f"warehouse CSV: {path}",
+        )
+
+        assert len(markets) == 120
+        assert gate.longshot_count == 120
+        assert gate.favorite_count == 120
+        assert gate.passed is True
+        assert "H1 DATA VIABLE" in report
+        assert "warehouse CSV:" in report
 
 
 # ── Decile Assignment ───────────────────────────────────────────────────────
@@ -829,8 +966,6 @@ class TestContractLevelAnalysis:
         ]
 
         contracts = markets_to_contracts(markets)
-        stats = compute_decile_stats(contracts)
-
         # Find the specific contracts to verify the relationship
         yes_contract = next(c for c in contracts if c.contract_side == "YES")
         no_contract = next(c for c in contracts if c.contract_side == "NO")

--- a/tests/test_flb_data_feasibility.py
+++ b/tests/test_flb_data_feasibility.py
@@ -77,6 +77,8 @@ def _warehouse_row(
     entry_yes_price: str = "0.05",
     yes_payout: str = "0",
     no_payout: str = "1",
+    entry_timestamp: str = "2025-12-01T00:00:00Z",
+    resolved_at: str = "2026-01-01T00:00:00Z",
 ) -> dict[str, str]:
     return {
         "market_id": market_id,
@@ -86,8 +88,8 @@ def _warehouse_row(
         "no_payout": no_payout,
         "volume": "10000",
         "liquidity": "500",
-        "entry_timestamp": "2025-12-01T00:00:00Z",
-        "resolved_at": "2026-01-01T00:00:00Z",
+        "entry_timestamp": entry_timestamp,
+        "resolved_at": resolved_at,
         "category": "politics",
     }
 
@@ -153,6 +155,43 @@ class TestWarehouseCsvLoading:
             writer.writerow(row)
 
         with pytest.raises(ValueError, match="missing required columns: liquidity"):
+            load_warehouse_markets(path)
+
+    def test_rejects_duplicate_market_ids(self, tmp_path: Path) -> None:
+        """Duplicate markets would falsely inflate the contract sample gate."""
+        path = tmp_path / "duplicate_markets.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(market_id="duplicated-market"),
+            _warehouse_row(market_id="duplicated-market"),
+        ])
+
+        with pytest.raises(ValueError, match="duplicate market_id"):
+            load_warehouse_markets(path)
+
+    def test_rejects_entry_timestamp_after_resolution(self, tmp_path: Path) -> None:
+        """Post-resolution entry prices leak settlement truth into FLB samples."""
+        path = tmp_path / "post_resolution_entry.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(
+                entry_timestamp="2026-01-02T00:00:00Z",
+                resolved_at="2026-01-01T00:00:00Z",
+            )
+        ])
+
+        with pytest.raises(ValueError, match="entry_timestamp must be before resolved_at"):
+            load_warehouse_markets(path)
+
+    def test_rejects_entry_timestamp_equal_to_resolution(self, tmp_path: Path) -> None:
+        """Same-time entry snapshots are also unsafe for historical replay."""
+        path = tmp_path / "same_time_entry.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(
+                entry_timestamp="2026-01-01T00:00:00Z",
+                resolved_at="2026-01-01T00:00:00Z",
+            )
+        ])
+
+        with pytest.raises(ValueError, match="entry_timestamp must be before resolved_at"):
             load_warehouse_markets(path)
 
     def test_warehouse_contracts_can_pass_extreme_sample_gate(

--- a/tests/test_flb_data_feasibility.py
+++ b/tests/test_flb_data_feasibility.py
@@ -194,6 +194,35 @@ class TestWarehouseCsvLoading:
         with pytest.raises(ValueError, match="entry_timestamp must be before resolved_at"):
             load_warehouse_markets(path)
 
+    def test_mixed_timezone_timestamps_are_normalized(self, tmp_path: Path) -> None:
+        """Naive and Z-suffixed ISO fields should compare as UTC instants."""
+        path = tmp_path / "mixed_timezone.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(
+                entry_timestamp="2025-12-01T00:00:00",
+                resolved_at="2026-01-01T00:00:00Z",
+            )
+        ])
+
+        markets = load_warehouse_markets(path)
+
+        assert len(markets) == 1
+
+    def test_mixed_timezone_post_resolution_entry_is_validation_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Mixed timezone formats should not raise TypeError on unsafe rows."""
+        path = tmp_path / "mixed_timezone_bad_order.csv"
+        _write_warehouse_csv(path, [
+            _warehouse_row(
+                entry_timestamp="2026-01-02T00:00:00",
+                resolved_at="2026-01-01T00:00:00Z",
+            )
+        ])
+
+        with pytest.raises(ValueError, match="entry_timestamp must be before resolved_at"):
+            load_warehouse_markets(path)
+
     def test_warehouse_contracts_can_pass_extreme_sample_gate(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- Adds a strict `--source warehouse-csv --input ...` path to `scripts/flb_data_feasibility.py` for Dune / historical warehouse exports.
- Keeps PR #45 `ContractObservation` semantics: every resolved binary market becomes YES@p and NO@(1-p) contract observations.
- Requires explicit final payout vectors: only `(yes_payout,no_payout)=(1,0)` or `(0,1)` are accepted; near-settled price vectors like `0.995,0.005` and ambiguous `0.5,0.5` are rejected.
- Enforces one row per resolved binary market by rejecting duplicate `market_id` values, so trade/token-level exports cannot inflate the sample gate.
- Enforces `entry_timestamp < resolved_at`, normalizing naive and offset-aware ISO timestamps to UTC before comparison, so post-resolution or same-time entry snapshots cannot leak settlement truth into the FLB sample.
- Adds a reproducible warehouse CSV contract doc at `docs/research/flb-historical-warehouse-source.md`.
- Does not add H2 anchoring lag or LLM/news replay.

## Acceptance Mapping

- Reproducible historical source path: `uv run python scripts/flb_data_feasibility.py --source warehouse-csv --input exports/polymarket_resolved_binary.csv ...`
- Contract-level observations compatible with PR #45: unchanged `markets_to_contracts()` path converts warehouse rows into YES/NO observations.
- Settlement correctness: exact payout vector required; no near-settled heuristic for warehouse source.
- Dataset correctness: unique `market_id` and pre-resolution entry timestamp required.
- Decile counts and Wilson CI: existing decile report/CSV reused for warehouse input, including `[0%,10%)` and `[90%,100%]` buckets.
- Pass/fail recommendation: report emits `H1 DATA VIABLE` only when both extreme buckets meet the >=100 contract gate; otherwise it identifies broader Dune/warehouse coverage as the next data-source gap.

## Verification

```text
uv run pytest tests/test_flb_data_feasibility.py -q
72 passed in 0.33s

uv run ruff check scripts/flb_data_feasibility.py tests/test_flb_data_feasibility.py
All checks passed!

uv run mypy scripts/flb_data_feasibility.py --strict
pyproject.toml: note: unused section(s): module = ['asyncpg']
Success: no issues found in 1 source file

uv run pytest -q
981 passed, 159 skipped in 13.53s

NO_PROXY='*' no_proxy='*' PMS_RUN_INTEGRATION=1 PMS_TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/pms_test uv run pytest -q -m integration
160 passed, 977 deselected in 75.64s (0:01:15)

uv run mypy src/ tests/ --strict
Success: no issues found in 332 source files

uv run lint-imports
Contracts: 8 kept, 0 broken.

npm run test:ci --prefix dashboard
Test Files  23 passed (23)
Tests  60 passed (60)

# warehouse CSV smoke with 120 exact-settlement rows
uv run python scripts/flb_data_feasibility.py --source warehouse-csv --input "$csv" --output "$tmpdir/report.md" --csv "$tmpdir/deciles.csv"
Loaded 120 resolved binary markets.
Generated 240 contract observations (120 markets x 2).
Longshot [0%-10%) | 120 | >=100 | pass
Favorite [90%-100%] | 120 | >=100 | pass
H1 DATA VIABLE

git diff --check
# no output
```

Note: full `uv run ruff check` is not a CI gate in this repo and still reports pre-existing unused-import/f-string findings outside this diff. The changed Python files are ruff-clean.
