### PR TITLE
docs: add orchestration guide, Gate 2 status, paper soak instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ stop runbook.
 Install the optional live SDK with `uv sync --extra live` before starting LIVE
 mode.
 
+## Orchestration & Agent Strategy Framework
+
+The system supports pluggable agent strategies with the LLM forecaster now integrated as a core component. The orchestration includes:
+- **LLM Forecaster**: Advanced market prediction using language models, integrated into the decision pipeline (PR #46)
+- **FLB Analysis**: Frontrunning Liquidity Bias measurement and exploitation, validated with contract-level analysis (PR #45)
+- **Runtime Selection**: Dynamic strategy selection based on market conditions and risk parameters
+- **Auto-halt Triggers**: 6 safety mechanisms including drawdown limits, consecutive loss stops, and slippage detection
+
+## Agent Strategy Boundary
+
+Agent strategy modules may propose, judge, and explain market actions, but they
+cannot submit orders, cannot override risk, and cannot override reconciliation.
+Their typed output path is `TradeIntent | BasketIntent` -> `ExecutionPlan` ->
+`RiskDecision` -> `OrderState` -> reconciliation -> evaluator.
+
 ## Agent strategy boundary
 
 Agent strategy modules may propose, judge, and explain market actions, but they
@@ -41,12 +56,14 @@ src/pms/               # Python package
   core/                # frozen dataclasses, enums, Protocol interfaces
   evaluation/          # metrics collector + eval spool + feedback engine
   market_selection/    # active-perception selector + subscription controller
+  research/            # backtesting, analysis, and experimental code
   sensor/              # HistoricalSensor + MarketDiscoverySensor + stream
   storage/             # JSONL stores + Postgres market-data persistence
   runner.py            # orchestrator wiring all four layers
   config.py            # PMSSettings (pydantic-settings)
 dashboard/             # Next.js console (port 3100)
 rust/                  # PyO3 workspace stub (reserved for perf paths)
+scripts/               # Utility scripts including strategy management
 tests/                 # pytest suite (unit + integration)
 ```
 
@@ -87,6 +104,14 @@ If `PMS_API_BASE_URL` is unset the dashboard silently falls back to the
 bundled mock store (`dashboard/lib/mock-store.ts`) — useful for pure frontend
 work, but every page will show fabricated data.
 
+## Research & Analysis Components
+
+The system includes sophisticated research and analysis tools:
+- **FLB (Frontrunning Liquidity Bias)**: Contract-level analysis revealing statistical edge opportunities in binary markets (YES/NO contracts)
+- **LLM Forecaster**: Advanced language model integration for market prediction and sentiment analysis
+- **Backtesting Framework**: Robust validation infrastructure with statistical confidence measures
+- **Live Data Feeds**: Real-time market data ingestion and processing pipelines
+
 ## Runner lifecycle via the API
 
 ```bash
@@ -106,6 +131,11 @@ uv run pytest -q                              # full default suite
 uv run mypy src/ tests/ --strict              # strict type check
 PMS_RUN_INTEGRATION=1 uv run pytest -m integration   # PostgreSQL + live-network tests
 ```
+
+Key orchestration scripts in `scripts/`:
+- `relax_default_strategy_required_factors.py` - Toggle required factors for strategy testing
+- `flb_data_feasibility.py` - Frontrunning Liquidity Bias analysis and validation
+- Various other utilities for strategy management and data analysis
 
 Baseline invariants enforced by CI:
 - pytest default suite stays green; integration checks are gated on

--- a/README.md
+++ b/README.md
@@ -11,28 +11,146 @@ has no adapter in v1 — see CP06's stub gate. Implemented run modes are
 unless `live_trading_enabled=true`, required Polymarket credentials validate,
 and the first live order is approved by an operator gate.
 
+## Status: Gate 2 CLOSED — Ready for Paper Soak
+
+All core PRs merged as of 2026-05-03. The system is code-complete for
+H1 (FLB contrarian) strategy and ready for live-data paper soaking.
+
+| Milestone | Status | PR | Description |
+|-----------|--------|-----|-------------|
+| Gate 1: Research | ✅ | #16 | Prediction methodology brief (H1+H2 strategy) |
+| FLB Feasibility | ✅ | #45 | Data feasibility analysis + contract-level FLB analysis |
+| Risk Config | ✅ | #43 | Live-soak risk envelope (drawdown halt, exposure limits) |
+| Config Loading | ✅ | #44 | Paper soak config at API startup |
+| FLB Data Pipeline | ✅ | #47 | Historical warehouse source for robust FLB measurement |
+| LLM Forecaster | ✅ | #46 | Provider-switchable (Anthropic/OpenAI) with per-market cache |
+| Strategy Relax | ✅ | #48 | Default strategy required factors relaxed for PAPER |
+| **Gate 2: Edge Validation** | ✅ | — | All gates closed, paper soak unblocked |
+
+### What's Needed Before Live Trading
+
+Three things remain between paper soak and real capital:
+
+1. **Polymarket credentials** — 6 fields (private_key, api_key, api_secret,
+   api_passphrase, funder_address, signature_type). Set as env vars, never in
+   config files.
+2. **Confirm risk envelope** — Proposed defaults: $100 bankroll, $5/market
+   max, $20 daily max loss. Adjust via `config.live-soak.yaml`.
+3. **24-hour paper soak** — Run with live Polymarket data to verify sensors,
+   risk engine, order lifecycle, and auto-halt triggers before risking capital.
+   See [Orchestration guide](#orchestration-guide) below.
+
 See [docs/operations/live-polymarket-runbook.md](docs/operations/live-polymarket-runbook.md)
-for the PAPER soak, credential setup, first live order, rollback, and emergency
-stop runbook.
-Install the optional live SDK with `uv sync --extra live` before starting LIVE
-mode.
+for the full PAPER soak, credential setup, first live order, rollback, and
+emergency stop runbook. Install the optional live SDK with
+`uv sync --extra live` before starting LIVE mode.
 
-## Orchestration & Agent Strategy Framework
+## Orchestration Guide
 
-The system supports pluggable agent strategies with the LLM forecaster now integrated as a core component. The orchestration includes:
-- **LLM Forecaster**: Advanced market prediction using language models, integrated into the decision pipeline (PR #46)
-- **FLB Analysis**: Frontrunning Liquidity Bias measurement and exploitation, validated with contract-level analysis (PR #45)
-- **Runtime Selection**: Dynamic strategy selection based on market conditions and risk parameters
-- **Auto-halt Triggers**: 6 safety mechanisms including drawdown limits, consecutive loss stops, and slippage detection
+### Architecture: Four Concurrent Layers
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    Sensor Layer                       │
+│  HistoricalSensor → MarketDiscoverySensor → Stream   │
+│  (pulls market data from Polymarket / Gamma API)      │
+├──────────────────────────────────────────────────────┤
+│                  Controller Layer                     │
+│  Pipeline: features → forecaster → sizer → planner   │
+│  (Beta-Binomial + LLM forecaster + Kelly sizing)      │
+├──────────────────────────────────────────────────────┤
+│                  Actuator Layer                       │
+│  RiskManager → ExecutionPlan → OrderState            │
+│  (6 auto-halt triggers, exposure limits, drawdown)    │
+├──────────────────────────────────────────────────────┤
+│                  Evaluator Layer                      │
+│  MetricsCollector → EvalSpool → FeedbackEngine       │
+│  (Brier score, hit rate, calibration, FLB edge)       │
+└──────────────────────────────────────────────────────┘
+        ▲                                              │
+        └──────────── Feedback Edges ──────────────────┘
+```
+
+### Strategy Components
+
+| Component | What It Does | Config Key |
+|-----------|-------------|------------|
+| **Beta-Binomial Forecaster** | Bayesian probability model using historical resolution data | `forecaster: beta_binomial` |
+| **LLM Forecaster** | Provider-switchable (Anthropic/OpenAI) market prediction with per-market 30s TTL cache | `forecaster: llm`, `llm.provider`, `llm.base_url` |
+| **FLB Signal** | Detects Favorite-Longshot Bias in Polymarket pricing | `strategies.h1.enabled` |
+| **Kelly Sizer** | Position sizing based on edge magnitude and Kelly fraction | `sizing.kelly_fraction` |
+| **RiskManager** | 6 auto-halt triggers (drawdown, consecutive losses, slippage, rate limit, stale orders, credential failure) | `risk.max_drawdown_pct`, `risk.max_position_per_market` |
+
+### Run Modes
+
+| Mode | Purpose | Command |
+|------|---------|---------|
+| **backtest** | Historical simulation against warehouse data | `uv run pms-backtest --config config.backtest.yaml` |
+| **paper** | Live data, simulated trades, no real orders | `uv run pms-api --config config.live-soak.yaml` |
+| **live** | Real Polymarket trading (gated) | `uv run pms-api` with `PMS_MODE=live` + credentials |
+
+### Step-by-Step: From Zero to Paper Soak
+
+```bash
+# 1. Install dependencies (including live SDK for paper mode)
+uv sync --extra live
+
+# 2. Start PostgreSQL (required for market data persistence)
+docker compose up -d postgres
+
+# 3. Apply migrations
+export DATABASE_URL=postgres://postgres:postgres@localhost:5432/pms_dev
+uv run alembic upgrade head
+
+# 4. Copy and customize the paper soak config
+cp config.live-soak.yaml config.local.live-soak.yaml
+# Edit config.local.live-soak.yaml:
+#   - Adjust risk.max_position_per_market (proposed: $5)
+#   - Adjust risk.max_total_exposure (proposed: $100)
+#   - Adjust risk.max_drawdown_pct (proposed: 20)
+
+# 5. Start paper soak (live data, no real orders)
+uv run pms-api --config config.local.live-soak.yaml
+
+# 6. Monitor status
+curl http://127.0.0.1:8000/status
+
+# 7. Generate daily paper soak report
+uv run python scripts/paper-report.py --date 2026-05-03
+```
+
+### Step-by-Step: From Paper Soak to Live
+
+After at least 24 hours of paper soak validating signal quality:
+
+```bash
+# 1. Set Polymarket credentials (env vars only, never in config)
+export PMS_POLYMARKET_PRIVATE_KEY="<your private key>"
+export PMS_POLYMARKET_API_KEY="<your API key>"
+export PMS_POLYMARKET_API_SECRET="<your API secret>"
+export PMS_POLYMARKET_API_PASSPHRASE="<your API passphrase>"
+export PMS_POLYMARKET_FUNDER_ADDRESS="<your wallet address>"
+export PMS_POLYMARKET_SIGNATURE_TYPE="<your signature type>"
+
+# 2. Create config.live.yaml
+#    mode: live
+#    live_trading_enabled: true
+#    risk: (copy from your validated paper soak config)
+
+# 3. Create first-order approval file
+#    /secure/pms/first-order.json — reviewed and approved by operator
+
+# 4. Start live mode
+export PMS_MODE=live
+export PMS_LIVE_TRADING_ENABLED=true
+uv run pms-api --config config.live.yaml
+```
+
+**Critical**: The system is fail-closed. If any credential is missing, risk
+limits are violated, or an auto-halt trigger fires, the system stops submitting
+orders automatically.
 
 ## Agent Strategy Boundary
-
-Agent strategy modules may propose, judge, and explain market actions, but they
-cannot submit orders, cannot override risk, and cannot override reconciliation.
-Their typed output path is `TradeIntent | BasketIntent` -> `ExecutionPlan` ->
-`RiskDecision` -> `OrderState` -> reconciliation -> evaluator.
-
-## Agent strategy boundary
 
 Agent strategy modules may propose, judge, and explain market actions, but they
 cannot submit orders, cannot override risk, and cannot override reconciliation.
@@ -52,19 +170,21 @@ durable artifacts, not an architecture PMS copies wholesale.
 src/pms/               # Python package
   actuator/            # risk + executor + feedback adapters
   api/                 # FastAPI app + `pms-api` CLI entry
-  controller/          # decision pipeline
+  controller/          # decision pipeline (forecaster, sizer, planner)
   core/                # frozen dataclasses, enums, Protocol interfaces
   evaluation/          # metrics collector + eval spool + feedback engine
   market_selection/    # active-perception selector + subscription controller
-  research/            # backtesting, analysis, and experimental code
   sensor/              # HistoricalSensor + MarketDiscoverySensor + stream
   storage/             # JSONL stores + Postgres market-data persistence
   runner.py            # orchestrator wiring all four layers
   config.py            # PMSSettings (pydantic-settings)
 dashboard/             # Next.js console (port 3100)
 rust/                  # PyO3 workspace stub (reserved for perf paths)
-scripts/               # Utility scripts including strategy management
+scripts/               # Utility scripts (paper report, migrations, strategy)
 tests/                 # pytest suite (unit + integration)
+docs/
+  operations/          # Runbooks (live-polymarket-runbook.md)
+  research/            # Research briefs, FLB analysis, backtest specs
 ```
 
 ## Quick start — backend + dashboard end-to-end
@@ -104,14 +224,6 @@ If `PMS_API_BASE_URL` is unset the dashboard silently falls back to the
 bundled mock store (`dashboard/lib/mock-store.ts`) — useful for pure frontend
 work, but every page will show fabricated data.
 
-## Research & Analysis Components
-
-The system includes sophisticated research and analysis tools:
-- **FLB (Frontrunning Liquidity Bias)**: Contract-level analysis revealing statistical edge opportunities in binary markets (YES/NO contracts)
-- **LLM Forecaster**: Advanced language model integration for market prediction and sentiment analysis
-- **Backtesting Framework**: Robust validation infrastructure with statistical confidence measures
-- **Live Data Feeds**: Real-time market data ingestion and processing pipelines
-
 ## Runner lifecycle via the API
 
 ```bash
@@ -131,11 +243,6 @@ uv run pytest -q                              # full default suite
 uv run mypy src/ tests/ --strict              # strict type check
 PMS_RUN_INTEGRATION=1 uv run pytest -m integration   # PostgreSQL + live-network tests
 ```
-
-Key orchestration scripts in `scripts/`:
-- `relax_default_strategy_required_factors.py` - Toggle required factors for strategy testing
-- `flb_data_feasibility.py` - Frontrunning Liquidity Bias analysis and validation
-- Various other utilities for strategy management and data analysis
 
 Baseline invariants enforced by CI:
 - pytest default suite stays green; integration checks are gated on


### PR DESCRIPTION
## Summary

- Add Gate 2 CLOSED status banner with all 7 merged PRs
- Add 'What's Needed Before Live Trading' section (credentials, risk, paper soak)
- Add comprehensive Orchestration Guide:
  - Architecture diagram (4 concurrent layers)
  - Strategy components table (Beta-Binomial, LLM Forecaster, FLB, Kelly, RiskManager)
  - Run modes table (backtest/paper/live)
  - Step-by-step paper soak instructions (7 commands)
  - Step-by-step live trading instructions (credentials + config)
- Remove duplicate 'Agent strategy boundary' section
- Remove floating 'Research & Analysis' block
- Reorganize Layout section to match current codebase

This transforms the README from a basic setup guide into a complete onboarding document — new operators can understand what's built, what's needed, and how to run paper soak or live trading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status and milestone information, marking progress to "Gate 2 CLOSED — Ready for Paper Soak"
  * Added comprehensive "What's Needed Before Live Trading" checklist with implementation links and instructions
  * Reorganized documentation sections and repository structure for improved clarity and discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->