### PR TITLE
feat: add H1 FLB strategy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ and the first live order is approved by an operator gate.
 ## Status: Gate 2 CLOSED — Ready for Paper Soak
 
 All core PRs merged as of 2026-05-03. The system is code-complete for
-H1 (FLB contrarian) strategy and ready for live-data paper soaking.
+H1 (FLB contrarian) strategy and ready for live-data paper soaking. H2
+anchoring-lag / LLM-news replay remains research-only until the H1 historical
+data spine proves enough coverage and measurable edge.
 
 | Milestone | Status | PR | Description |
 |-----------|--------|-----|-------------|
@@ -77,7 +79,7 @@ emergency stop runbook. Install the optional live SDK with
 |-----------|-------------|------------|
 | **Beta-Binomial Forecaster** | Bayesian probability model using historical resolution data | `forecaster: beta_binomial` |
 | **LLM Forecaster** | Provider-switchable (Anthropic/OpenAI) market prediction with per-market 30s TTL cache | `forecaster: llm`, `llm.provider`, `llm.base_url` |
-| **FLB Signal** | Detects Favorite-Longshot Bias in Polymarket pricing | `strategies.h1.enabled` |
+| **FLB Signal** | Detects Favorite-Longshot Bias in Polymarket pricing | `pms.strategies.flb.FlbStrategyModule` |
 | **Kelly Sizer** | Position sizing based on edge magnitude and Kelly fraction | `sizing.kelly_fraction` |
 | **RiskManager** | 6 auto-halt triggers (drawdown, consecutive losses, slippage, rate limit, stale orders, credential failure) | `risk.max_drawdown_pct`, `risk.max_position_per_market` |
 
@@ -140,7 +142,7 @@ export PMS_POLYMARKET_SIGNATURE_TYPE="<your signature type>"
 # 3. Create first-order approval file
 #    /secure/pms/first-order.json — reviewed and approved by operator
 
-# 4. Start live mode
+# 4. Start live mode through the stub-gated operator path
 export PMS_MODE=live
 export PMS_LIVE_TRADING_ENABLED=true
 uv run pms-api --config config.live.yaml

--- a/docs/research/h1-flb-strategy.md
+++ b/docs/research/h1-flb-strategy.md
@@ -1,0 +1,32 @@
+# H1 FLB Strategy Implementation Contract
+
+This note converts the prediction-methodology research into the first
+implemented strategy slice. It intentionally implements H1 only.
+
+## H1 Semantics
+
+Favorite-longshot bias says low-probability YES contracts are often overpriced
+and high-probability YES contracts are often underpriced.
+
+For binary Polymarket contracts:
+
+- YES price below 10%: treat the YES longshot as overpriced and buy NO.
+- YES price above 90%: treat the YES favorite as underpriced and buy YES.
+- Middle deciles: no H1 trade.
+
+## Implemented Surface
+
+- Factor: `favorite_longshot_bias`
+  - negative value: low-YES longshot bucket, actionable side is buy NO
+  - positive value: high-YES favorite bucket, actionable side is buy YES
+- Strategy plugin: `pms.strategies.flb`
+  - source: `LiveFlbSource`
+  - controller: `FlbController`
+  - agent: `FlbAgent`
+  - module: `FlbStrategyModule`
+
+## Out Of Scope
+
+H2 anchoring lag and LLM/news replay are not implemented here. They should wait
+until the historical data spine proves H1 has enough resolved Polymarket
+coverage and measurable edge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ as_packages = false
 [[tool.importlinter.contracts]]
 name = "Strategy plugins: no actuator, controller, or venue adapter imports"
 type = "forbidden"
-source_modules = ["pms.strategies.ripple"]
+source_modules = ["pms.strategies.ripple", "pms.strategies.flb"]
 forbidden_modules = [
     "pms.actuator",
     "pms.actuator.adapters",

--- a/src/pms/factors/catalog.py
+++ b/src/pms/factors/catalog.py
@@ -22,6 +22,19 @@ class FactorCatalogEntry:
 
 FACTOR_CATALOG_ROWS: tuple[FactorCatalogEntry, ...] = (
     FactorCatalogEntry(
+        factor_id="favorite_longshot_bias",
+        name="Favorite-Longshot Bias",
+        description=(
+            "Signed H1 contrarian bucket signal: negative means buy NO in "
+            "overpriced low-YES longshots, positive means buy YES in underpriced "
+            "high-YES favorites."
+        ),
+        input_schema_hash="c4288b992546eb39e3a5e71f660d2a381a45e07f5a267349855f010c59785f6b",
+        output_type="scalar",
+        direction="signed",
+        owner="system",
+    ),
+    FactorCatalogEntry(
         factor_id="orderbook_imbalance",
         name="Orderbook Imbalance",
         description="Normalized bid-versus-ask depth imbalance from the current orderbook signal.",

--- a/src/pms/factors/definitions/__init__.py
+++ b/src/pms/factors/definitions/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pms.factors.base import FactorDefinition
 
+from .favorite_longshot_bias import FavoriteLongshotBias
 from .fair_value_spread import FairValueSpread
 from .metaculus_prior import MetaculusPrior
 from .no_count import NoCount
@@ -10,6 +11,7 @@ from .subset_pricing_violation import SubsetPricingViolation
 from .yes_count import YesCount
 
 REGISTERED: tuple[type[FactorDefinition], ...] = (
+    FavoriteLongshotBias,
     FairValueSpread,
     SubsetPricingViolation,
     MetaculusPrior,
@@ -20,6 +22,7 @@ REGISTERED: tuple[type[FactorDefinition], ...] = (
 
 __all__ = (
     "REGISTERED",
+    "FavoriteLongshotBias",
     "FairValueSpread",
     "MetaculusPrior",
     "NoCount",

--- a/src/pms/factors/definitions/favorite_longshot_bias.py
+++ b/src/pms/factors/definitions/favorite_longshot_bias.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pms.core.models import MarketSignal
+from pms.factors.base import FactorDefinition, FactorValueRow, OuterRingReader
+
+
+LONGSHOT_YES_THRESHOLD = Decimal("0.10")
+FAVORITE_YES_THRESHOLD = Decimal("0.90")
+
+
+class FavoriteLongshotBias(FactorDefinition):
+    """Signed H1 contrarian signal from the market YES price.
+
+    Negative values mean the YES longshot bucket is overpriced, so the
+    actionable contrarian side is buy NO. Positive values mean the YES favorite
+    bucket is underpriced, so the actionable side is buy YES.
+    """
+
+    factor_id = "favorite_longshot_bias"
+    required_inputs = ("yes_price",)
+
+    def compute(
+        self,
+        signal: MarketSignal,
+        outer_ring: OuterRingReader,
+    ) -> FactorValueRow | None:
+        del outer_ring
+
+        yes_price = Decimal(str(signal.yes_price))
+        if yes_price < LONGSHOT_YES_THRESHOLD:
+            value = yes_price - LONGSHOT_YES_THRESHOLD
+        elif yes_price > FAVORITE_YES_THRESHOLD:
+            value = yes_price - FAVORITE_YES_THRESHOLD
+        else:
+            return None
+
+        return FactorValueRow(
+            factor_id=self.factor_id,
+            param="",
+            market_id=signal.market_id,
+            ts=signal.timestamp,
+            value=float(value),
+        )

--- a/src/pms/strategies/flb/__init__.py
+++ b/src/pms/strategies/flb/__init__.py
@@ -1,0 +1,19 @@
+"""H1 favorite-longshot bias strategy plugin."""
+
+from pms.strategies.flb.agent import FlbAgent
+from pms.strategies.flb.controller import FlbController
+from pms.strategies.flb.source import (
+    FLB_RESEARCH_REF,
+    LiveFlbSource,
+    FlbMarketSnapshot,
+)
+from pms.strategies.flb.strategy import FlbStrategyModule
+
+__all__ = [
+    "FLB_RESEARCH_REF",
+    "FlbAgent",
+    "FlbController",
+    "FlbMarketSnapshot",
+    "FlbStrategyModule",
+    "LiveFlbSource",
+]

--- a/src/pms/strategies/flb/agent.py
+++ b/src/pms/strategies/flb/agent.py
@@ -1,0 +1,138 @@
+"""Deterministic H1 FLB agent that builds trade intents."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from pms.core.enums import TimeInForce
+from pms.core.models import BookSide, Outcome, Venue
+from pms.strategies.flb.evaluator import FlbEvidenceEvaluator
+from pms.strategies.intents import (
+    BasketIntent,
+    StrategyCandidate,
+    StrategyContext,
+    StrategyJudgement,
+    TradeIntent,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FlbAgent:
+    min_evidence_refs: int = 2
+    min_confidence: float = 0.6
+    min_expected_edge: float = 0.02
+    _evaluator: FlbEvidenceEvaluator = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "_evaluator",
+            FlbEvidenceEvaluator(
+                min_evidence_refs=self.min_evidence_refs,
+                min_confidence=self.min_confidence,
+                min_expected_edge=self.min_expected_edge,
+            ),
+        )
+
+    async def judge(
+        self,
+        context: StrategyContext,
+        candidate: StrategyCandidate,
+    ) -> StrategyJudgement:
+        _require_same_strategy(context, candidate)
+        assessment = self._evaluator.assess(candidate)
+        return StrategyJudgement(
+            judgement_id=f"judgement-{candidate.candidate_id}",
+            candidate_id=candidate.candidate_id,
+            strategy_id=context.strategy_id,
+            strategy_version_id=context.strategy_version_id,
+            approved=assessment.approved,
+            confidence=assessment.confidence,
+            rationale=assessment.rationale,
+            evidence_refs=assessment.evidence_refs,
+            failure_reasons=assessment.failure_reasons,
+            created_at=context.as_of,
+        )
+
+    async def build_intents(
+        self,
+        context: StrategyContext,
+        candidate: StrategyCandidate,
+        judgement: StrategyJudgement,
+    ) -> Sequence[TradeIntent | BasketIntent]:
+        _require_same_strategy(context, candidate)
+        if judgement.candidate_id != candidate.candidate_id:
+            msg = "judgement candidate_id must match candidate"
+            raise ValueError(msg)
+        if not judgement.approved:
+            return ()
+
+        metadata = candidate.metadata
+        intent = TradeIntent(
+            intent_id=f"intent-{candidate.candidate_id}",
+            strategy_id=context.strategy_id,
+            strategy_version_id=context.strategy_version_id,
+            candidate_id=candidate.candidate_id,
+            market_id=candidate.market_id,
+            token_id=_metadata_str(metadata, "token_id"),
+            venue=cast(Venue, _metadata_str(metadata, "venue")),
+            side=cast(BookSide, _metadata_str(metadata, "side")),
+            outcome=cast(Outcome, _metadata_str(metadata, "outcome")),
+            limit_price=_metadata_float(metadata, "limit_price"),
+            notional_usdc=_metadata_float(metadata, "notional_usdc"),
+            expected_price=_metadata_float(metadata, "expected_price"),
+            expected_edge=candidate.expected_edge,
+            max_slippage_bps=_metadata_int(metadata, "max_slippage_bps"),
+            time_in_force=_metadata_time_in_force(metadata),
+            evidence_refs=(judgement.judgement_id, *judgement.evidence_refs),
+            created_at=context.as_of,
+        )
+        return (intent,)
+
+
+def _require_same_strategy(
+    context: StrategyContext,
+    candidate: StrategyCandidate,
+) -> None:
+    if (
+        candidate.strategy_id != context.strategy_id
+        or candidate.strategy_version_id != context.strategy_version_id
+    ):
+        msg = "candidate strategy identity must match context"
+        raise ValueError(msg)
+
+
+def _metadata_str(metadata: Mapping[str, Any], field_name: str) -> str:
+    value = metadata[field_name]
+    if not isinstance(value, str):
+        msg = f"{field_name} must be a string"
+        raise TypeError(msg)
+    return value
+
+
+def _metadata_float(metadata: Mapping[str, Any], field_name: str) -> float:
+    value = metadata[field_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    return float(value)
+
+
+def _metadata_int(metadata: Mapping[str, Any], field_name: str) -> int:
+    value = metadata[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f"{field_name} must be an integer"
+        raise TypeError(msg)
+    return cast(int, value)
+
+
+def _metadata_time_in_force(metadata: Mapping[str, Any]) -> TimeInForce:
+    value = metadata["time_in_force"]
+    if isinstance(value, TimeInForce):
+        return value
+    if isinstance(value, str):
+        return TimeInForce(value)
+    msg = "time_in_force must be a TimeInForce or string"
+    raise TypeError(msg)

--- a/src/pms/strategies/flb/controller.py
+++ b/src/pms/strategies/flb/controller.py
@@ -1,0 +1,110 @@
+"""Candidate proposal for H1 FLB observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+from pms.strategies.intents import (
+    StrategyCandidate,
+    StrategyContext,
+    StrategyObservation,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FlbController:
+    async def propose(
+        self,
+        context: StrategyContext,
+        observations: Sequence[StrategyObservation],
+    ) -> Sequence[StrategyCandidate]:
+        del context
+        return tuple(_candidate_from_observation(observation) for observation in observations)
+
+
+def _candidate_from_observation(observation: StrategyObservation) -> StrategyCandidate:
+    payload = observation.payload
+    payload_metadata = _mapping(payload.get("metadata", {}))
+    metadata: dict[str, Any] = {
+        "observation_id": observation.observation_id,
+        "source": observation.source,
+        "confidence": _required_float(payload, "confidence"),
+        "token_id": _required_str(payload, "token_id"),
+        "venue": _required_str(payload, "venue"),
+        "side": _required_str(payload, "side"),
+        "outcome": _required_str(payload, "outcome"),
+        "limit_price": _required_float(payload, "limit_price"),
+        "notional_usdc": _required_float(payload, "notional_usdc"),
+        "expected_price": _required_float(payload, "expected_price"),
+        "max_slippage_bps": _required_int(payload, "max_slippage_bps"),
+        "time_in_force": _required_str(payload, "time_in_force"),
+        "contradiction_refs": _string_tuple(payload.get("contradiction_refs", ())),
+        "h1_metadata": payload_metadata,
+    }
+    for field_name in (
+        "favorite_yes_threshold",
+        "h1_signal",
+        "longshot_yes_threshold",
+        "min_expected_edge",
+        "no_best_ask",
+        "yes_best_ask",
+        "yes_price",
+    ):
+        if field_name in payload_metadata:
+            metadata[field_name] = payload_metadata[field_name]
+    return StrategyCandidate(
+        candidate_id=f"candidate-{observation.observation_id}",
+        strategy_id=observation.strategy_id,
+        strategy_version_id=observation.strategy_version_id,
+        market_id=_required_str(payload, "market_id"),
+        title=_required_str(payload, "title"),
+        thesis=_required_str(payload, "thesis"),
+        probability_estimate=_required_float(payload, "probability_estimate"),
+        expected_edge=_required_float(payload, "expected_edge"),
+        evidence_refs=observation.evidence_refs,
+        created_at=observation.observed_at,
+        metadata=metadata,
+    )
+
+
+def _required_str(payload: Mapping[str, Any], field_name: str) -> str:
+    value = payload[field_name]
+    if not isinstance(value, str):
+        msg = f"{field_name} must be a string"
+        raise TypeError(msg)
+    return value
+
+
+def _required_float(payload: Mapping[str, Any], field_name: str) -> float:
+    value = payload[field_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    return float(value)
+
+
+def _required_int(payload: Mapping[str, Any], field_name: str) -> int:
+    value = payload[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f"{field_name} must be an integer"
+        raise TypeError(msg)
+    return cast(int, value)
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, tuple):
+        msg = "contradiction_refs must be a tuple"
+        raise TypeError(msg)
+    if any(not isinstance(item, str) for item in value):
+        msg = "contradiction_refs must contain strings"
+        raise TypeError(msg)
+    return cast(tuple[str, ...], value)
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        msg = "metadata must be a mapping"
+        raise TypeError(msg)
+    return cast(Mapping[str, Any], value)

--- a/src/pms/strategies/flb/evaluator.py
+++ b/src/pms/strategies/flb/evaluator.py
@@ -1,0 +1,100 @@
+"""Deterministic evidence gate for the H1 FLB strategy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, cast
+
+from pms.strategies.intents import StrategyCandidate
+
+
+DEFAULT_MIN_EXPECTED_EDGE = 0.02
+DEFAULT_MIN_CONFIDENCE = 0.60
+
+
+@dataclass(frozen=True, slots=True)
+class FlbEvidenceAssessment:
+    approved: bool
+    expected_edge: float
+    confidence: float
+    rationale: str
+    evidence_refs: tuple[str, ...]
+    failure_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FlbEvidenceEvaluator:
+    min_evidence_refs: int = 2
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE
+    min_expected_edge: float = DEFAULT_MIN_EXPECTED_EDGE
+
+    def assess(self, candidate: StrategyCandidate) -> FlbEvidenceAssessment:
+        confidence = _metadata_float(candidate.metadata, "confidence")
+        contradiction_refs = _metadata_tuple(candidate.metadata, "contradiction_refs")
+        if len(candidate.evidence_refs) < self.min_evidence_refs:
+            return FlbEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=min(confidence, self.min_confidence - 0.01),
+                rationale="rejected: insufficient FLB evidence",
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("insufficient_evidence",),
+            )
+        if contradiction_refs:
+            return FlbEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=min(confidence, self.min_confidence - 0.01),
+                rationale="rejected: FLB evidence contains a contradiction",
+                evidence_refs=(*candidate.evidence_refs, *contradiction_refs),
+                failure_reasons=("contradiction",),
+            )
+        if confidence < self.min_confidence:
+            return FlbEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=confidence,
+                rationale="rejected: FLB confidence below threshold",
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("low_confidence",),
+            )
+        if candidate.expected_edge < self.min_expected_edge:
+            return FlbEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=confidence,
+                rationale="rejected: FLB expected edge below threshold",
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("insufficient_expected_edge",),
+            )
+        return FlbEvidenceAssessment(
+            approved=True,
+            expected_edge=candidate.expected_edge,
+            confidence=confidence,
+            rationale=(
+                "approved: H1 favorite-longshot bias bucket gives "
+                f"{candidate.expected_edge:.4f} expected edge"
+            ),
+            evidence_refs=candidate.evidence_refs,
+            failure_reasons=(),
+        )
+
+
+def _metadata_float(metadata: Mapping[str, Any], field_name: str) -> float:
+    value = metadata[field_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    return float(value)
+
+
+def _metadata_tuple(metadata: Mapping[str, Any], field_name: str) -> tuple[str, ...]:
+    value = metadata[field_name]
+    if not isinstance(value, tuple):
+        msg = f"{field_name} must be a tuple"
+        raise TypeError(msg)
+    if any(not isinstance(item, str) for item in value):
+        msg = f"{field_name} must contain strings"
+        raise TypeError(msg)
+    return cast(tuple[str, ...], value)

--- a/src/pms/strategies/flb/source.py
+++ b/src/pms/strategies/flb/source.py
@@ -1,0 +1,294 @@
+"""Observation source for the H1 favorite-longshot bias strategy."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from pms.core.enums import TimeInForce
+from pms.core.models import BookSide, Outcome, Portfolio, Venue
+from pms.strategies.flb.evaluator import DEFAULT_MIN_EXPECTED_EDGE
+from pms.strategies.intents import StrategyContext, StrategyObservation
+
+
+FLB_RESEARCH_REF = "research:h1-flb-strategy#h1"
+LIVE_FLB_SOURCE = "live_flb_market_source"
+LONGSHOT_YES_THRESHOLD = 0.10
+FAVORITE_YES_THRESHOLD = 0.90
+DEFAULT_FLB_CONFIDENCE = 0.65
+
+
+class FlbMarketSnapshotReader(Protocol):
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> FlbMarketSnapshot | None: ...
+
+
+class FlbPositionSizer(Protocol):
+    def size(
+        self,
+        *,
+        prob: float,
+        market_price: float,
+        portfolio: Portfolio,
+    ) -> float: ...
+
+
+@dataclass(frozen=True, slots=True)
+class FlbMarketSnapshot:
+    market_id: str
+    title: str
+    yes_token_id: str
+    no_token_id: str
+    yes_price: float
+    observed_at: datetime
+    yes_best_ask: float | None = None
+    no_best_ask: float | None = None
+    resolves_at: datetime | None = None
+    venue: Venue = "polymarket"
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.market_id, "market_id")
+        _require_non_empty(self.title, "title")
+        _require_non_empty(self.yes_token_id, "yes_token_id")
+        _require_non_empty(self.no_token_id, "no_token_id")
+        _require_open_probability(self.yes_price, "yes_price")
+        if self.yes_best_ask is not None:
+            _require_open_probability(self.yes_best_ask, "yes_best_ask")
+        if self.no_best_ask is not None:
+            _require_open_probability(self.no_best_ask, "no_best_ask")
+
+
+@dataclass(frozen=True, slots=True)
+class LiveFlbSource:
+    """Market-price source for H1 FLB signals.
+
+    This source implements only H1 bucket semantics from the research brief. H2
+    anchoring-lag/news replay remains out of scope until the H1 historical data
+    spine is proven viable.
+    """
+
+    market_ids: Sequence[str]
+    market_reader: FlbMarketSnapshotReader
+    position_sizer: FlbPositionSizer
+    portfolio: Portfolio
+    min_expected_edge: float = DEFAULT_MIN_EXPECTED_EDGE
+    longshot_yes_threshold: float = LONGSHOT_YES_THRESHOLD
+    favorite_yes_threshold: float = FAVORITE_YES_THRESHOLD
+    confidence: float = DEFAULT_FLB_CONFIDENCE
+    max_slippage_bps: int = 50
+    time_in_force: TimeInForce = TimeInForce.GTC
+
+    def __post_init__(self) -> None:
+        if not self.market_ids:
+            msg = "market_ids must not be empty"
+            raise ValueError(msg)
+        for market_id in self.market_ids:
+            _require_non_empty(market_id, "market_id")
+        if self.min_expected_edge <= 0.0:
+            msg = "min_expected_edge must be > 0.0"
+            raise ValueError(msg)
+        _require_open_probability(self.longshot_yes_threshold, "longshot_yes_threshold")
+        _require_open_probability(self.favorite_yes_threshold, "favorite_yes_threshold")
+        if self.longshot_yes_threshold >= self.favorite_yes_threshold:
+            msg = "longshot_yes_threshold must be below favorite_yes_threshold"
+            raise ValueError(msg)
+        if not 0.0 <= self.confidence <= 1.0:
+            msg = "confidence must satisfy 0.0 <= confidence <= 1.0"
+            raise ValueError(msg)
+        if self.max_slippage_bps < 0:
+            msg = "max_slippage_bps must be >= 0"
+            raise ValueError(msg)
+
+    async def observe(self, context: StrategyContext) -> Sequence[StrategyObservation]:
+        observations: list[StrategyObservation] = []
+        for market_id in self.market_ids:
+            market = await self.market_reader.latest(market_id, as_of=context.as_of)
+            if market is None or _is_resolved(context.as_of, market.resolves_at):
+                continue
+            observation = _observation_from_market(
+                context=context,
+                market=market,
+                position_sizer=self.position_sizer,
+                portfolio=self.portfolio,
+                min_expected_edge=self.min_expected_edge,
+                longshot_yes_threshold=self.longshot_yes_threshold,
+                favorite_yes_threshold=self.favorite_yes_threshold,
+                confidence=self.confidence,
+                max_slippage_bps=self.max_slippage_bps,
+                time_in_force=self.time_in_force,
+            )
+            if observation is not None:
+                observations.append(observation)
+        return tuple(observations)
+
+
+@dataclass(frozen=True, slots=True)
+class _FlbSignal:
+    signal_name: str
+    thesis: str
+    token_id: str
+    outcome: Outcome
+    side: BookSide
+    limit_price: float
+    probability_estimate: float
+
+
+def _observation_from_market(
+    *,
+    context: StrategyContext,
+    market: FlbMarketSnapshot,
+    position_sizer: FlbPositionSizer,
+    portfolio: Portfolio,
+    min_expected_edge: float,
+    longshot_yes_threshold: float,
+    favorite_yes_threshold: float,
+    confidence: float,
+    max_slippage_bps: int,
+    time_in_force: TimeInForce,
+) -> StrategyObservation | None:
+    signal = _classify_market(
+        market=market,
+        min_expected_edge=min_expected_edge,
+        longshot_yes_threshold=longshot_yes_threshold,
+        favorite_yes_threshold=favorite_yes_threshold,
+    )
+    if signal is None:
+        return None
+
+    expected_edge = signal.probability_estimate - signal.limit_price
+    notional_usdc = position_sizer.size(
+        prob=signal.probability_estimate,
+        market_price=signal.limit_price,
+        portfolio=portfolio,
+    )
+    if notional_usdc <= 0.0:
+        return None
+
+    evidence_refs = _evidence_refs(market)
+    metadata = {
+        "source": LIVE_FLB_SOURCE,
+        "h1_signal": signal.signal_name,
+        "yes_price": market.yes_price,
+        "yes_best_ask": market.yes_best_ask,
+        "no_best_ask": market.no_best_ask,
+        "observed_at": market.observed_at.isoformat(),
+        "resolves_at": market.resolves_at.isoformat() if market.resolves_at else None,
+        "longshot_yes_threshold": longshot_yes_threshold,
+        "favorite_yes_threshold": favorite_yes_threshold,
+        "min_expected_edge": min_expected_edge,
+    }
+    payload = {
+        "market_id": market.market_id,
+        "title": market.title,
+        "thesis": signal.thesis,
+        "probability_estimate": signal.probability_estimate,
+        "expected_edge": expected_edge,
+        "confidence": confidence,
+        "token_id": signal.token_id,
+        "venue": market.venue,
+        "side": signal.side,
+        "outcome": signal.outcome,
+        "limit_price": signal.limit_price,
+        "notional_usdc": notional_usdc,
+        "expected_price": signal.probability_estimate,
+        "max_slippage_bps": max_slippage_bps,
+        "time_in_force": time_in_force,
+        "contradiction_refs": (),
+        "metadata": metadata,
+    }
+    return StrategyObservation(
+        observation_id=f"live-flb-{market.market_id}-{context.as_of.isoformat()}",
+        strategy_id=context.strategy_id,
+        strategy_version_id=context.strategy_version_id,
+        source=LIVE_FLB_SOURCE,
+        observed_at=context.as_of,
+        summary=signal.thesis,
+        payload=payload,
+        evidence_refs=evidence_refs,
+    )
+
+
+def _classify_market(
+    *,
+    market: FlbMarketSnapshot,
+    min_expected_edge: float,
+    longshot_yes_threshold: float,
+    favorite_yes_threshold: float,
+) -> _FlbSignal | None:
+    if market.yes_price < longshot_yes_threshold:
+        limit_price = _bounded_probability(
+            market.no_best_ask if market.no_best_ask is not None else 1.0 - market.yes_price,
+            "no_limit_price",
+        )
+        probability_estimate = _bounded_probability(
+            limit_price + min_expected_edge,
+            "no_probability_estimate",
+        )
+        return _FlbSignal(
+            signal_name="longshot_yes_overpriced_buy_no",
+            thesis=(
+                "H1 FLB: low-YES longshot bucket is treated as overpriced; "
+                "buy NO exposure."
+            ),
+            token_id=market.no_token_id,
+            outcome="NO",
+            side="BUY",
+            limit_price=limit_price,
+            probability_estimate=probability_estimate,
+        )
+    if market.yes_price > favorite_yes_threshold:
+        limit_price = _bounded_probability(
+            market.yes_best_ask if market.yes_best_ask is not None else market.yes_price,
+            "yes_limit_price",
+        )
+        probability_estimate = _bounded_probability(
+            limit_price + min_expected_edge,
+            "yes_probability_estimate",
+        )
+        return _FlbSignal(
+            signal_name="favorite_yes_underpriced_buy_yes",
+            thesis=(
+                "H1 FLB: high-YES favorite bucket is treated as underpriced; "
+                "buy YES exposure."
+            ),
+            token_id=market.yes_token_id,
+            outcome="YES",
+            side="BUY",
+            limit_price=limit_price,
+            probability_estimate=probability_estimate,
+        )
+    return None
+
+
+def _is_resolved(as_of: datetime, resolves_at: datetime | None) -> bool:
+    return resolves_at is not None and resolves_at <= as_of
+
+
+def _evidence_refs(market: FlbMarketSnapshot) -> tuple[str, ...]:
+    market_ref = f"market_snapshot:{market.market_id}:{market.observed_at.isoformat()}"
+    return (FLB_RESEARCH_REF, market_ref)
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not value:
+        msg = f"{field_name} must be non-empty"
+        raise ValueError(msg)
+
+
+def _require_open_probability(value: float, field_name: str) -> None:
+    if value <= 0.0 or value >= 1.0 or value != value:
+        msg = f"{field_name} must satisfy 0.0 < value < 1.0"
+        raise ValueError(msg)
+
+
+def _bounded_probability(value: float, field_name: str) -> float:
+    if value != value:
+        msg = f"{field_name} must not be NaN"
+        raise ValueError(msg)
+    return min(max(float(value), 0.0001), 0.9999)

--- a/src/pms/strategies/flb/strategy.py
+++ b/src/pms/strategies/flb/strategy.py
@@ -1,0 +1,55 @@
+"""Composable H1 FLB strategy module."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from pms.strategies.base import (
+    StrategyAgent,
+    StrategyController,
+    StrategyObservationSource,
+)
+from pms.strategies.intents import BasketIntent, StrategyContext, TradeIntent
+from pms.strategies.runtime_bridge import StrategyRunResult
+
+
+@dataclass(frozen=True, slots=True)
+class FlbStrategyModule:
+    source: StrategyObservationSource
+    controller: StrategyController
+    agent: StrategyAgent
+    strategy_id: str
+    strategy_version_id: str
+
+    async def run(
+        self,
+        context: StrategyContext,
+    ) -> Sequence[TradeIntent | BasketIntent]:
+        results = await self.run_with_artifacts(context)
+        return tuple(intent for result in results for intent in result.intents)
+
+    async def run_with_artifacts(
+        self,
+        context: StrategyContext,
+    ) -> Sequence[StrategyRunResult]:
+        if (
+            context.strategy_id != self.strategy_id
+            or context.strategy_version_id != self.strategy_version_id
+        ):
+            msg = "context strategy identity must match H1 FLB module"
+            raise ValueError(msg)
+
+        observations = await self.source.observe(context)
+        candidates = await self.controller.propose(context, observations)
+        results: list[StrategyRunResult] = []
+        for candidate in candidates:
+            judgement = await self.agent.judge(context, candidate)
+            intents = await self.agent.build_intents(context, candidate, judgement)
+            results.append(
+                StrategyRunResult(
+                    judgement=judgement,
+                    intents=tuple(intents),
+                )
+            )
+        return tuple(results)

--- a/tests/unit/test_favorite_longshot_bias_factor.py
+++ b/tests/unit/test_favorite_longshot_bias_factor.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.core.enums import MarketStatus
+from pms.core.models import MarketSignal
+from pms.factors.base import EMPTY_OUTER_RING
+from pms.factors.catalog import FACTOR_CATALOG_ROWS
+from pms.factors.definitions import FavoriteLongshotBias, REGISTERED
+
+
+def _signal(*, yes_price: float) -> MarketSignal:
+    return MarketSignal(
+        market_id="market-flb",
+        token_id="token-flb-yes",
+        venue="polymarket",
+        title="Will FLB identify the contrarian side?",
+        yes_price=yes_price,
+        volume_24h=1000.0,
+        resolves_at=datetime(2026, 5, 30, tzinfo=UTC),
+        orderbook={"bids": [], "asks": []},
+        external_signal={},
+        fetched_at=datetime(2026, 5, 3, 12, 0, tzinfo=UTC),
+        market_status=MarketStatus.OPEN.value,
+    )
+
+
+def test_registered_includes_favorite_longshot_bias() -> None:
+    assert FavoriteLongshotBias in REGISTERED
+
+
+def test_catalog_includes_signed_flb_factor() -> None:
+    entry = next(row for row in FACTOR_CATALOG_ROWS if row.factor_id == "favorite_longshot_bias")
+
+    assert entry.output_type == "scalar"
+    assert entry.direction == "signed"
+
+
+def test_flb_factor_marks_low_yes_longshot_as_buy_no_signal() -> None:
+    factor = FavoriteLongshotBias()
+
+    row = factor.compute(_signal(yes_price=0.05), EMPTY_OUTER_RING)
+
+    assert row is not None
+    assert factor.required_inputs == ("yes_price",)
+    assert row.factor_id == "favorite_longshot_bias"
+    assert row.param == ""
+    assert row.value == pytest.approx(-0.05)
+
+
+def test_flb_factor_marks_high_yes_favorite_as_buy_yes_signal() -> None:
+    row = FavoriteLongshotBias().compute(_signal(yes_price=0.95), EMPTY_OUTER_RING)
+
+    assert row is not None
+    assert row.value == pytest.approx(0.05)
+
+
+def test_flb_factor_returns_none_for_middle_deciles() -> None:
+    assert FavoriteLongshotBias().compute(_signal(yes_price=0.50), EMPTY_OUTER_RING) is None

--- a/tests/unit/test_flb_strategy_plugin.py
+++ b/tests/unit/test_flb_strategy_plugin.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, cast
+import tomllib
+
+import pytest
+
+from pms.core.models import Portfolio
+from pms.strategies.base import (
+    StrategyAgent,
+    StrategyController,
+    StrategyModule,
+    StrategyObservationSource,
+)
+from pms.strategies.flb.agent import FlbAgent
+from pms.strategies.flb.controller import FlbController
+from pms.strategies.flb.source import (
+    FLB_RESEARCH_REF,
+    FlbPositionSizer,
+    LiveFlbSource,
+    FlbMarketSnapshot,
+)
+from pms.strategies.flb.strategy import FlbStrategyModule
+from pms.strategies.intents import StrategyContext, TradeIntent
+
+
+NOW = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _context() -> StrategyContext:
+    return StrategyContext(
+        strategy_id="h1_flb",
+        strategy_version_id="h1-flb-v1",
+        as_of=NOW,
+    )
+
+
+def _portfolio(free_usdc: float = 100.0) -> Portfolio:
+    return Portfolio(
+        total_usdc=free_usdc,
+        free_usdc=free_usdc,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+class _FixedSizer:
+    def __init__(self, notional_usdc: float = 5.0) -> None:
+        self.notional_usdc = notional_usdc
+        self.calls: list[tuple[float, float]] = []
+
+    def size(
+        self,
+        *,
+        prob: float,
+        market_price: float,
+        portfolio: Portfolio,
+    ) -> float:
+        del portfolio
+        self.calls.append((prob, market_price))
+        return self.notional_usdc
+
+
+class _ZeroSizer:
+    def size(
+        self,
+        *,
+        prob: float,
+        market_price: float,
+        portfolio: Portfolio,
+    ) -> float:
+        del prob, market_price, portfolio
+        return 0.0
+
+
+class _StaticMarketReader:
+    def __init__(self, market: FlbMarketSnapshot | None) -> None:
+        self.market = market
+        self.calls: list[tuple[str, datetime]] = []
+
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> FlbMarketSnapshot | None:
+        self.calls.append((market_id, as_of))
+        return self.market
+
+
+def _market(**overrides: object) -> FlbMarketSnapshot:
+    data: dict[str, object] = {
+        "market_id": "market-flb-1",
+        "title": "Will the H1 FLB strategy choose the contrarian side?",
+        "yes_token_id": "token-yes",
+        "no_token_id": "token-no",
+        "yes_price": 0.05,
+        "observed_at": NOW,
+        "yes_best_ask": 0.05,
+        "no_best_ask": 0.96,
+        "resolves_at": NOW + timedelta(days=7),
+    }
+    data.update(overrides)
+    return FlbMarketSnapshot(**cast(Any, data))
+
+
+def _module(
+    market: FlbMarketSnapshot | None,
+    *,
+    sizer: FlbPositionSizer | None = None,
+) -> FlbStrategyModule:
+    return FlbStrategyModule(
+        source=LiveFlbSource(
+            market_ids=("market-flb-1",),
+            market_reader=_StaticMarketReader(market),
+            position_sizer=sizer or _FixedSizer(),
+            portfolio=_portfolio(),
+        ),
+        controller=FlbController(),
+        agent=FlbAgent(),
+        strategy_id="h1_flb",
+        strategy_version_id="h1-flb-v1",
+    )
+
+
+def test_flb_components_satisfy_strategy_protocols() -> None:
+    module = _module(_market())
+
+    source: StrategyObservationSource = module.source
+    controller: StrategyController = module.controller
+    agent: StrategyAgent = module.agent
+    strategy_module: StrategyModule = module
+
+    assert source is module.source
+    assert controller is module.controller
+    assert agent is module.agent
+    assert strategy_module.strategy_id == "h1_flb"
+
+
+@pytest.mark.asyncio
+async def test_flb_longshot_signal_buys_no_contract() -> None:
+    sizer = _FixedSizer(5.0)
+    module = _module(_market(yes_price=0.05, no_best_ask=0.96), sizer=sizer)
+
+    intents = await module.run(_context())
+
+    assert len(intents) == 1
+    intent = intents[0]
+    assert isinstance(intent, TradeIntent)
+    assert intent.outcome == "NO"
+    assert intent.side == "BUY"
+    assert intent.token_id == "token-no"
+    assert intent.limit_price == pytest.approx(0.96)
+    assert intent.expected_price == pytest.approx(0.98)
+    assert intent.expected_edge == pytest.approx(0.02)
+    assert intent.notional_usdc == pytest.approx(5.0)
+    assert len(sizer.calls) == 1
+    assert sizer.calls[0][0] == pytest.approx(0.98)
+    assert sizer.calls[0][1] == pytest.approx(0.96)
+    assert FLB_RESEARCH_REF in intent.evidence_refs
+
+
+@pytest.mark.asyncio
+async def test_flb_favorite_signal_buys_yes_contract() -> None:
+    module = _module(_market(yes_price=0.95, yes_best_ask=0.94))
+
+    intents = await module.run(_context())
+
+    assert len(intents) == 1
+    intent = intents[0]
+    assert isinstance(intent, TradeIntent)
+    assert intent.outcome == "YES"
+    assert intent.side == "BUY"
+    assert intent.token_id == "token-yes"
+    assert intent.limit_price == pytest.approx(0.94)
+    assert intent.expected_price == pytest.approx(0.96)
+
+
+@pytest.mark.asyncio
+async def test_flb_source_ignores_middle_decile_markets() -> None:
+    module = _module(_market(yes_price=0.50, yes_best_ask=0.50, no_best_ask=0.50))
+
+    assert await module.run(_context()) == ()
+
+
+@pytest.mark.asyncio
+async def test_flb_source_suppresses_zero_sized_trades() -> None:
+    module = _module(_market(), sizer=_ZeroSizer())
+
+    assert await module.run(_context()) == ()
+
+
+@pytest.mark.asyncio
+async def test_flb_source_skips_resolved_markets() -> None:
+    module = _module(_market(resolves_at=NOW - timedelta(minutes=1)))
+
+    assert await module.run(_context()) == ()
+
+
+@pytest.mark.asyncio
+async def test_flb_module_rejects_context_strategy_mismatch() -> None:
+    module = _module(_market())
+    context = StrategyContext(
+        strategy_id="other",
+        strategy_version_id="h1-flb-v1",
+        as_of=NOW,
+    )
+
+    with pytest.raises(ValueError, match="context strategy identity must match"):
+        await module.run(context)
+
+
+def test_strategy_import_linter_contract_includes_flb_plugin() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    contracts: Sequence[dict[str, object]] = pyproject["tool"]["importlinter"][
+        "contracts"
+    ]
+    contract = next(
+        candidate
+        for candidate in contracts
+        if candidate["name"] == "Strategy plugins: no actuator, controller, or venue adapter imports"
+    )
+
+    assert contract["source_modules"] == [
+        "pms.strategies.ripple",
+        "pms.strategies.flb",
+    ]

--- a/tests/unit/test_ripple_strategy_plugin.py
+++ b/tests/unit/test_ripple_strategy_plugin.py
@@ -574,7 +574,10 @@ def test_ripple_import_linter_contract_is_declared() -> None:
     )
 
     assert contract["type"] == "forbidden"
-    assert contract["source_modules"] == ["pms.strategies.ripple"]
+    assert contract["source_modules"] == [
+        "pms.strategies.ripple",
+        "pms.strategies.flb",
+    ]
     assert contract["forbidden_modules"] == [
         "pms.actuator",
         "pms.actuator.adapters",


### PR DESCRIPTION
## Summary

Implements the first code slice from @Researcher-Ciga's methodology brief: H1 favorite-longshot bias only.

- Add `favorite_longshot_bias` factor with signed bucket semantics: negative means low-YES longshot -> buy NO, positive means high-YES favorite -> buy YES.
- Add `pms.strategies.flb` strategy plugin (`LiveFlbSource`, `FlbController`, `FlbAgent`, `FlbStrategyModule`) that emits typed `TradeIntent`s for the H1 buckets.
- Extend the strategy-plugin import-linter boundary to cover `pms.strategies.flb` alongside ripple.
- Add a short H1 implementation contract doc and update README to clarify H2 anchoring-lag / LLM-news replay is still research-only.

Out of scope: H2 anchoring lag, LLM/news replay, runtime auto-wiring, and live capital changes.

## TDD evidence

RED:

```text
uv run pytest tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_flb_strategy_plugin.py -q
ERROR tests/unit/test_favorite_longshot_bias_factor.py: cannot import name 'FavoriteLongshotBias'
ERROR tests/unit/test_flb_strategy_plugin.py: No module named 'pms.strategies.flb'
```

GREEN / verification:

```text
uv run pytest tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_flb_strategy_plugin.py -q
13 passed in 0.20s
```

```text
uv run pytest tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_flb_strategy_plugin.py tests/unit/test_ripple_strategy_plugin.py tests/unit/test_statistical_migration.py tests/unit/test_forecaster_migration_matrix.py tests/unit/test_strategy_projections.py tests/unit/test_import_linter_contracts.py -q
60 passed in 0.83s
```

```text
uv run pytest -q
1001 passed, 161 skipped in 12.54s
```

```text
uv run ruff check src/pms/strategies/flb src/pms/factors/catalog.py src/pms/factors/definitions src/pms/strategies/ripple tests/unit/test_flb_strategy_plugin.py tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_ripple_strategy_plugin.py
All checks passed!
```

```text
uv run mypy src tests
Success: no issues found in 343 source files
```

```text
uv run lint-imports
Contracts: 8 kept, 0 broken.
```

```text
git diff --check
# clean
```

## Existing repo lint note

`uv run ruff check .` still reports existing unrelated unused-import / F541 lint debt in untouched files such as `src/pms/runner.py`, `src/pms/actuator/adapters/paper.py`, and several integration tests. The touched-path ruff gate above is clean.

## Review ask

@Researcher-Ciga please review the H1 semantics/math boundary: low YES <10% maps to buy NO, high YES >90% maps to buy YES, and H2 remains excluded from this implementation slice.