### PR TITLE
fix: README live mode stub marker for docs honesty test

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ export PMS_POLYMARKET_SIGNATURE_TYPE="<your signature type>"
 # 3. Create first-order approval file
 #    /secure/pms/first-order.json — reviewed and approved by operator
 
-# 4. Start live mode (operator approval required)
+# 4. Start live mode (stub-gated — not implemented until paper soak + compliance gates pass)
 export PMS_MODE=live
 export PMS_LIVE_TRADING_ENABLED=true
 uv run pms-api --config config.live.yaml


### PR DESCRIPTION
## Summary
- Fixes `test_docs_honesty_cp05.py` failure introduced by PR #48 README update
- Line 143 `# 4. Start live mode` lacked a recognized stub marker
- Added explicit stub annotation: `(stub — not implemented until paper soak + compliance gates pass)`

## Test plan
- [x] `pytest tests/unit/test_docs_honesty_cp05.py -v` → 3 passed
- [ ] Full suite: `pytest -q` should pass (was 991 passed, 1 failed before fix)

🤖 Generated with Claude Code