### PR TITLE
fix: align H1 FLB catalog with schema

### DIFF
--- a/docs/research/h1-flb-strategy.md
+++ b/docs/research/h1-flb-strategy.md
@@ -19,11 +19,25 @@ For binary Polymarket contracts:
 - Factor: `favorite_longshot_bias`
   - negative value: low-YES longshot bucket, actionable side is buy NO
   - positive value: high-YES favorite bucket, actionable side is buy YES
+  - catalog direction stays `neutral` to satisfy the current factor schema; the
+    factor value itself carries the signed H1 semantics
 - Strategy plugin: `pms.strategies.flb`
   - source: `LiveFlbSource`
   - controller: `FlbController`
   - agent: `FlbAgent`
   - module: `FlbStrategyModule`
+
+## Edge Model
+
+The first slice uses `min_expected_edge` as a placeholder edge model:
+
+- probability estimate = observed limit price + `min_expected_edge`
+- default `min_expected_edge` = 2%
+
+This is intentionally conservative and deterministic for paper soak. Before
+live trading, replace the placeholder with data-driven decile edge estimates
+from the historical warehouse / Wilson CI pipeline so 1% longshots, 9%
+longshots, and 95% favorites are not treated as having identical edge.
 
 ## Out Of Scope
 

--- a/src/pms/factors/catalog.py
+++ b/src/pms/factors/catalog.py
@@ -31,7 +31,7 @@ FACTOR_CATALOG_ROWS: tuple[FactorCatalogEntry, ...] = (
         ),
         input_schema_hash="c4288b992546eb39e3a5e71f660d2a381a45e07f5a267349855f010c59785f6b",
         output_type="scalar",
-        direction="signed",
+        direction="neutral",
         owner="system",
     ),
     FactorCatalogEntry(

--- a/src/pms/strategies/flb/source.py
+++ b/src/pms/strategies/flb/source.py
@@ -68,9 +68,10 @@ class FlbMarketSnapshot:
 class LiveFlbSource:
     """Market-price source for H1 FLB signals.
 
-    This source implements only H1 bucket semantics from the research brief. H2
-    anchoring-lag/news replay remains out of scope until the H1 historical data
-    spine is proven viable.
+    This source implements only H1 bucket semantics from the research brief. The
+    edge estimate is a paper-soak placeholder until warehouse decile estimates
+    replace it. H2 anchoring-lag/news replay remains out of scope until the H1
+    historical data spine is proven viable.
     """
 
     market_ids: Sequence[str]

--- a/tests/unit/test_favorite_longshot_bias_factor.py
+++ b/tests/unit/test_favorite_longshot_bias_factor.py
@@ -31,11 +31,11 @@ def test_registered_includes_favorite_longshot_bias() -> None:
     assert FavoriteLongshotBias in REGISTERED
 
 
-def test_catalog_includes_signed_flb_factor() -> None:
+def test_catalog_includes_flb_factor_as_schema_compatible_neutral_direction() -> None:
     entry = next(row for row in FACTOR_CATALOG_ROWS if row.factor_id == "favorite_longshot_bias")
 
     assert entry.output_type == "scalar"
-    assert entry.direction == "signed"
+    assert entry.direction == "neutral"
 
 
 def test_flb_factor_marks_low_yes_longshot_as_buy_no_signal() -> None:


### PR DESCRIPTION
## Summary

Follow-up to PR #49. GitHub merged the first H1 FLB implementation commit before the schema fix landed, so `main` currently has `favorite_longshot_bias.direction = signed`, which violates the existing `factors_direction_check` (`long`, `short`, `neutral`).

This PR:
- changes the catalog direction to `neutral` while keeping the signed H1 semantics in the factor value itself
- updates the factor unit test to assert the schema-compatible direction
- documents that `min_expected_edge` is a paper-soak placeholder until warehouse decile estimates replace it
- adds the same placeholder note to the FLB source docstring per @Researcher-Ciga's review nit

## Verification

```text
uv run pytest tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_flb_strategy_plugin.py tests/unit/test_ripple_strategy_plugin.py tests/unit/test_import_linter_contracts.py -q
34 passed in 0.81s
```

```text
uv run ruff check src/pms/strategies/flb src/pms/factors/catalog.py src/pms/factors/definitions tests/unit/test_flb_strategy_plugin.py tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_ripple_strategy_plugin.py
All checks passed!
```

```text
uv run mypy src/pms/strategies/flb src/pms/factors/catalog.py src/pms/factors/definitions tests/unit/test_flb_strategy_plugin.py tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_ripple_strategy_plugin.py
Success: no issues found in 18 source files
```

```text
git diff --check
# clean
```