### PR TITLE
feat: wire H1 FLB strategy into runner

### DIFF
--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -1844,6 +1844,8 @@ class _PostgresFlbMarketSnapshotReader:
         *,
         as_of: datetime,
     ) -> FlbMarketSnapshot | None:
+        # Paper-soak reader intentionally uses the latest persisted market row;
+        # historical as-of snapshots belong in the warehouse backtest path.
         del as_of
         query = """
         SELECT

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
@@ -35,8 +35,8 @@ from pms.controller.diagnostics import ControllerDiagnostic
 from pms.controller.factory import ControllerPipelineFactory
 from pms.controller.factor_snapshot import PostgresFactorSnapshotReader
 from pms.controller.outcome_tokens import MarketDataOutcomeTokenResolver
-from pms.controller.pipeline import ControllerPipeline
-from pms.core.enums import OrderStatus, RunMode
+from pms.controller.sizers.kelly import KellySizer
+from pms.core.enums import OrderStatus, RunMode, TimeInForce
 from pms.core.interfaces import (
     DiscoveryPollCompleteSensor,
     IController,
@@ -54,6 +54,7 @@ from pms.core.models import (
     Position,
     ReconciliationReport as ReconciliationReport,
     TradeDecision,
+    Venue,
     VenueAccountSnapshot as VenueAccountSnapshot,
     VenueCredentials,
 )
@@ -91,6 +92,13 @@ from pms.storage.order_store import OrderStore
 from pms.storage.strategy_registry import PostgresStrategyRegistry
 from pms.strategies.aggregate import Strategy
 from pms.strategies.defaults import DEFAULT_STRATEGY_COMPOSITION
+from pms.strategies.flb import FlbAgent, FlbController, FlbStrategyModule
+from pms.strategies.flb.source import (
+    FlbMarketSnapshot,
+    FlbMarketSnapshotReader,
+    LiveFlbSource,
+)
+from pms.strategies.intents import StrategyContext
 from pms.strategies.projections import (
     ActiveStrategy,
     EvalSpec,
@@ -100,6 +108,7 @@ from pms.strategies.projections import (
     RiskParams,
     StrategyConfig,
 )
+from pms.strategies.runtime_bridge import StrategyRunResult
 from pms.strategies.versioning import compute_strategy_version_id
 
 
@@ -579,6 +588,71 @@ class Runner:
     async def wait_for_signals(self, count: int) -> None:
         while len(self.state.signals) < count:
             await asyncio.sleep(0.1)
+
+    def build_flb_strategy_module(
+        self,
+        *,
+        strategy_id: str,
+        strategy_version_id: str,
+        market_ids: Sequence[str],
+        market_reader: FlbMarketSnapshotReader | None = None,
+    ) -> FlbStrategyModule:
+        if not market_ids:
+            msg = "market_ids must not be empty"
+            raise ValueError(msg)
+        reader = market_reader
+        if reader is None:
+            if self._pg_pool is None:
+                msg = (
+                    "Runner PostgreSQL pool is required to build the production "
+                    "FLB market reader"
+                )
+                raise RuntimeError(msg)
+            reader = _PostgresFlbMarketSnapshotReader(
+                PostgresMarketDataStore(self._pg_pool)
+            )
+
+        return FlbStrategyModule(
+            source=LiveFlbSource(
+                market_ids=tuple(market_ids),
+                market_reader=reader,
+                position_sizer=KellySizer(self.config.risk),
+                portfolio=self.portfolio,
+                max_slippage_bps=self.config.controller.max_slippage_bps,
+                time_in_force=TimeInForce(
+                    self.config.controller.time_in_force.upper()
+                ),
+            ),
+            controller=FlbController(),
+            agent=FlbAgent(),
+            strategy_id=strategy_id,
+            strategy_version_id=strategy_version_id,
+        )
+
+    async def run_flb_strategy_once(
+        self,
+        *,
+        strategy_id: str,
+        strategy_version_id: str,
+        market_ids: Sequence[str],
+        as_of: datetime | None = None,
+        market_reader: FlbMarketSnapshotReader | None = None,
+    ) -> Sequence[StrategyRunResult]:
+        module = self.build_flb_strategy_module(
+            strategy_id=strategy_id,
+            strategy_version_id=strategy_version_id,
+            market_ids=market_ids,
+            market_reader=market_reader,
+        )
+        return tuple(
+            await module.run_with_artifacts(
+                StrategyContext(
+                    strategy_id=strategy_id,
+                    strategy_version_id=strategy_version_id,
+                    as_of=as_of or datetime.now(tz=UTC),
+                )
+            )
+        )
 
     def _build_sensors(self) -> tuple[ISensor, ...]:
         if self.sensors is not None:
@@ -1758,6 +1832,122 @@ class Runner:
                 asset_ids=None,
             )
         ]
+
+
+@dataclass(frozen=True)
+class _PostgresFlbMarketSnapshotReader:
+    store: PostgresMarketDataStore
+
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> FlbMarketSnapshot | None:
+        del as_of
+        query = """
+        SELECT
+            markets.condition_id AS market_id,
+            markets.question,
+            markets.venue,
+            markets.resolves_at,
+            markets.last_seen_at,
+            markets.yes_price,
+            markets.no_price,
+            markets.best_bid,
+            markets.best_ask,
+            markets.price_updated_at,
+            markets.closed,
+            markets.accepting_orders,
+            MAX(CASE WHEN tokens.outcome = 'YES' THEN tokens.token_id END) AS yes_token_id,
+            MAX(CASE WHEN tokens.outcome = 'NO' THEN tokens.token_id END) AS no_token_id
+        FROM markets
+        LEFT JOIN tokens
+            ON tokens.condition_id = markets.condition_id
+        WHERE markets.condition_id = $1
+           OR EXISTS (
+                SELECT 1
+                FROM tokens AS lookup_tokens
+                WHERE lookup_tokens.token_id = $1
+                  AND lookup_tokens.condition_id = markets.condition_id
+           )
+        GROUP BY
+            markets.condition_id,
+            markets.question,
+            markets.venue,
+            markets.resolves_at,
+            markets.last_seen_at,
+            markets.yes_price,
+            markets.no_price,
+            markets.best_bid,
+            markets.best_ask,
+            markets.price_updated_at,
+            markets.closed,
+            markets.accepting_orders
+        LIMIT 1
+        """
+        async with self.store.pool.acquire() as connection:
+            row = await connection.fetchrow(query, market_id)
+        if row is None:
+            return None
+        if row["closed"] is True or row["accepting_orders"] is False:
+            return None
+
+        yes_price = _open_probability_or_none(row["yes_price"])
+        yes_token_id = row["yes_token_id"]
+        no_token_id = row["no_token_id"]
+        if (
+            yes_price is None
+            or not isinstance(yes_token_id, str)
+            or not isinstance(no_token_id, str)
+        ):
+            return None
+
+        observed_at = row["price_updated_at"] or row["last_seen_at"]
+        if not isinstance(observed_at, datetime):
+            return None
+
+        return FlbMarketSnapshot(
+            market_id=cast(str, row["market_id"]),
+            title=cast(str, row["question"]),
+            yes_token_id=yes_token_id,
+            no_token_id=no_token_id,
+            yes_price=yes_price,
+            yes_best_ask=_open_probability_or_none(row["best_ask"]),
+            no_best_ask=_no_best_ask(
+                no_price=row["no_price"],
+                yes_best_bid=row["best_bid"],
+            ),
+            observed_at=observed_at,
+            resolves_at=cast(datetime | None, row["resolves_at"]),
+            venue=cast(Venue, row["venue"]),
+        )
+
+
+def _open_probability_or_none(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(cast(Any, value))
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0.0 or parsed >= 1.0:
+        return None
+    return parsed
+
+
+def _no_best_ask(
+    *,
+    no_price: object,
+    yes_best_bid: object,
+) -> float | None:
+    parsed_no_price = _open_probability_or_none(no_price)
+    if parsed_no_price is not None:
+        return parsed_no_price
+    parsed_yes_best_bid = _open_probability_or_none(yes_best_bid)
+    if parsed_yes_best_bid is None:
+        return None
+    return _open_probability_or_none(1.0 - parsed_yes_best_bid)
 
 
 def _append_bounded(items: list[T], item: T) -> None:

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -1844,10 +1844,82 @@ class _PostgresFlbMarketSnapshotReader:
         *,
         as_of: datetime,
     ) -> FlbMarketSnapshot | None:
-        # Paper-soak reader intentionally uses the latest persisted market row;
-        # historical as-of snapshots belong in the warehouse backtest path.
-        del as_of
-        query = """
+        async with self.store.pool.acquire() as connection:
+            resolved_market_id = await _resolve_flb_market_id(connection, market_id)
+            if resolved_market_id is None:
+                return None
+            market_row = await _read_flb_market_row(connection, resolved_market_id)
+            if market_row is None:
+                return None
+            price_row = await _read_flb_price_row(
+                connection,
+                resolved_market_id,
+                as_of=as_of,
+            )
+
+        if _future_market_status_change(market_row, as_of=as_of):
+            return None
+        if market_row["closed"] is True or market_row["accepting_orders"] is False:
+            return None
+
+        yes_price_source = price_row if price_row is not None else market_row
+        observed_at = _observed_at(yes_price_source)
+        if observed_at is None or observed_at > as_of:
+            return None
+
+        yes_price = _open_probability_or_none(yes_price_source["yes_price"])
+        yes_token_id = market_row["yes_token_id"]
+        no_token_id = market_row["no_token_id"]
+        if (
+            yes_price is None
+            or not isinstance(yes_token_id, str)
+            or not isinstance(no_token_id, str)
+        ):
+            return None
+
+        return FlbMarketSnapshot(
+            market_id=cast(str, market_row["market_id"]),
+            title=cast(str, market_row["question"]),
+            yes_token_id=yes_token_id,
+            no_token_id=no_token_id,
+            yes_price=yes_price,
+            yes_best_ask=_open_probability_or_none(yes_price_source["best_ask"]),
+            no_best_ask=_no_best_ask(
+                no_price=yes_price_source["no_price"],
+                yes_best_bid=yes_price_source["best_bid"],
+            ),
+            observed_at=observed_at,
+            resolves_at=cast(datetime | None, market_row["resolves_at"]),
+            venue=cast(Venue, market_row["venue"]),
+        )
+
+
+async def _resolve_flb_market_id(connection: Any, lookup_id: str) -> str | None:
+    query = """
+    WITH matches AS (
+        SELECT markets.condition_id AS market_id, 0 AS match_rank
+        FROM markets
+        WHERE markets.condition_id = $1
+
+        UNION ALL
+
+        SELECT tokens.condition_id AS market_id, 1 AS match_rank
+        FROM tokens
+        WHERE tokens.token_id = $1
+    )
+    SELECT market_id
+    FROM matches
+    ORDER BY match_rank ASC, market_id ASC
+    LIMIT 1
+    """
+    value = await connection.fetchval(query, lookup_id)
+    if not isinstance(value, str):
+        return None
+    return value
+
+
+async def _read_flb_market_row(connection: Any, market_id: str) -> Any | None:
+    query = """
         SELECT
             markets.condition_id AS market_id,
             markets.question,
@@ -1861,18 +1933,13 @@ class _PostgresFlbMarketSnapshotReader:
             markets.price_updated_at,
             markets.closed,
             markets.accepting_orders,
+            markets.status_updated_at,
             MAX(CASE WHEN tokens.outcome = 'YES' THEN tokens.token_id END) AS yes_token_id,
             MAX(CASE WHEN tokens.outcome = 'NO' THEN tokens.token_id END) AS no_token_id
         FROM markets
         LEFT JOIN tokens
             ON tokens.condition_id = markets.condition_id
         WHERE markets.condition_id = $1
-           OR EXISTS (
-                SELECT 1
-                FROM tokens AS lookup_tokens
-                WHERE lookup_tokens.token_id = $1
-                  AND lookup_tokens.condition_id = markets.condition_id
-           )
         GROUP BY
             markets.condition_id,
             markets.question,
@@ -1885,45 +1952,46 @@ class _PostgresFlbMarketSnapshotReader:
             markets.best_ask,
             markets.price_updated_at,
             markets.closed,
-            markets.accepting_orders
-        LIMIT 1
+            markets.accepting_orders,
+            markets.status_updated_at
         """
-        async with self.store.pool.acquire() as connection:
-            row = await connection.fetchrow(query, market_id)
-        if row is None:
-            return None
-        if row["closed"] is True or row["accepting_orders"] is False:
-            return None
+    return await connection.fetchrow(query, market_id)
 
-        yes_price = _open_probability_or_none(row["yes_price"])
-        yes_token_id = row["yes_token_id"]
-        no_token_id = row["no_token_id"]
-        if (
-            yes_price is None
-            or not isinstance(yes_token_id, str)
-            or not isinstance(no_token_id, str)
-        ):
-            return None
 
-        observed_at = row["price_updated_at"] or row["last_seen_at"]
-        if not isinstance(observed_at, datetime):
-            return None
+async def _read_flb_price_row(
+    connection: Any,
+    market_id: str,
+    *,
+    as_of: datetime,
+) -> Any | None:
+    query = """
+    SELECT
+        snapshot_at,
+        yes_price,
+        no_price,
+        best_bid,
+        best_ask
+    FROM market_price_snapshots
+    WHERE condition_id = $1
+      AND snapshot_at <= $2
+    ORDER BY snapshot_at DESC
+    LIMIT 1
+    """
+    return await connection.fetchrow(query, market_id, as_of)
 
-        return FlbMarketSnapshot(
-            market_id=cast(str, row["market_id"]),
-            title=cast(str, row["question"]),
-            yes_token_id=yes_token_id,
-            no_token_id=no_token_id,
-            yes_price=yes_price,
-            yes_best_ask=_open_probability_or_none(row["best_ask"]),
-            no_best_ask=_no_best_ask(
-                no_price=row["no_price"],
-                yes_best_bid=row["best_bid"],
-            ),
-            observed_at=observed_at,
-            resolves_at=cast(datetime | None, row["resolves_at"]),
-            venue=cast(Venue, row["venue"]),
-        )
+
+def _observed_at(row: Any) -> datetime | None:
+    observed_at = row["snapshot_at"] if "snapshot_at" in row else row["price_updated_at"]
+    if observed_at is None and "last_seen_at" in row:
+        observed_at = row["last_seen_at"]
+    if isinstance(observed_at, datetime):
+        return observed_at
+    return None
+
+
+def _future_market_status_change(row: Any, *, as_of: datetime) -> bool:
+    status_updated_at = row["status_updated_at"]
+    return isinstance(status_updated_at, datetime) and status_updated_at > as_of
 
 
 def _open_probability_or_none(value: object) -> float | None:

--- a/tests/unit/test_flb_runner_wiring.py
+++ b/tests/unit/test_flb_runner_wiring.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from pms.config import PMSSettings, RiskSettings
+from pms.core.enums import RunMode
+from pms.runner import Runner
+from pms.strategies.flb import FlbAgent, FlbController, FlbStrategyModule, LiveFlbSource
+from pms.strategies.flb.source import FlbMarketSnapshot
+from pms.strategies.intents import TradeIntent
+
+
+NOW = datetime(2026, 5, 3, 15, 0, tzinfo=UTC)
+
+
+class _StaticFlbMarketReader:
+    def __init__(self, market: FlbMarketSnapshot | None) -> None:
+        self.market = market
+        self.calls: list[tuple[str, datetime]] = []
+
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> FlbMarketSnapshot | None:
+        self.calls.append((market_id, as_of))
+        return self.market
+
+
+def _settings() -> PMSSettings:
+    return PMSSettings(
+        mode=RunMode.PAPER,
+        risk=RiskSettings(max_position_per_market=5.0),
+    )
+
+
+def _market(**overrides: object) -> FlbMarketSnapshot:
+    data = {
+        "market_id": "market-flb-1",
+        "title": "Will H1 FLB production wiring emit the contrarian side?",
+        "yes_token_id": "token-yes",
+        "no_token_id": "token-no",
+        "yes_price": 0.05,
+        "observed_at": NOW,
+        "yes_best_ask": 0.05,
+        "no_best_ask": 0.96,
+        "resolves_at": NOW + timedelta(days=5),
+    }
+    data.update(overrides)
+    return FlbMarketSnapshot(**data)  # type: ignore[arg-type]
+
+
+def test_runner_builds_flb_strategy_module_with_live_components() -> None:
+    runner = Runner(config=_settings())
+    reader = _StaticFlbMarketReader(_market())
+
+    module = runner.build_flb_strategy_module(
+        strategy_id="h1_flb",
+        strategy_version_id="h1-flb-v1",
+        market_ids=("market-flb-1",),
+        market_reader=reader,
+    )
+
+    assert isinstance(module, FlbStrategyModule)
+    assert isinstance(module.source, LiveFlbSource)
+    assert isinstance(module.controller, FlbController)
+    assert isinstance(module.agent, FlbAgent)
+    assert module.strategy_id == "h1_flb"
+    assert module.strategy_version_id == "h1-flb-v1"
+
+
+@pytest.mark.asyncio
+async def test_runner_calls_flb_module_without_live_capital() -> None:
+    runner = Runner(config=_settings())
+    reader = _StaticFlbMarketReader(_market())
+
+    results = await runner.run_flb_strategy_once(
+        strategy_id="h1_flb",
+        strategy_version_id="h1-flb-v1",
+        market_ids=("market-flb-1",),
+        as_of=NOW,
+        market_reader=reader,
+    )
+
+    assert reader.calls == [("market-flb-1", NOW)]
+    assert len(results) == 1
+    judgement = results[0].judgement
+    assert judgement is not None
+    assert judgement.approved is True
+
+    assert len(results[0].intents) == 1
+    intent = results[0].intents[0]
+    assert isinstance(intent, TradeIntent)
+    assert intent.outcome == "NO"
+    assert intent.token_id == "token-no"
+    assert intent.limit_price == pytest.approx(0.96)
+    assert intent.expected_edge == pytest.approx(0.02)
+    assert intent.notional_usdc <= 5.0
+
+    assert runner.state.decisions == []
+    assert runner._decision_queue.empty()  # noqa: SLF001
+
+
+def test_runner_flb_module_requires_explicit_markets_without_pg_pool() -> None:
+    runner = Runner(config=_settings())
+
+    with pytest.raises(ValueError, match="market_ids"):
+        runner.build_flb_strategy_module(
+            strategy_id="h1_flb",
+            strategy_version_id="h1-flb-v1",
+            market_ids=(),
+            market_reader=_StaticFlbMarketReader(None),
+        )
+

--- a/tests/unit/test_flb_runner_wiring.py
+++ b/tests/unit/test_flb_runner_wiring.py
@@ -30,6 +30,55 @@ class _StaticFlbMarketReader:
         return self.market
 
 
+class _Row(dict[str, object]):
+    def __getattr__(self, item: str) -> object:
+        return self[item]
+
+
+class _RecordingFlbConnection:
+    def __init__(
+        self,
+        *,
+        resolved_market_id: str | None = "market-flb-1",
+        market_row: _Row | None = None,
+        price_row: _Row | None = None,
+    ) -> None:
+        self.resolved_market_id = resolved_market_id
+        self.market_row = market_row
+        self.price_row = price_row
+        self.fetchval_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    async def fetchval(self, query: str, *args: object) -> object | None:
+        self.fetchval_calls.append((query, args))
+        return self.resolved_market_id
+
+    async def fetchrow(self, query: str, *args: object) -> _Row | None:
+        self.fetchrow_calls.append((query, args))
+        if "FROM market_price_snapshots" in query:
+            return self.price_row
+        return self.market_row
+
+
+class _AcquireFlbConnection:
+    def __init__(self, connection: _RecordingFlbConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> _RecordingFlbConnection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class _FlbPool:
+    def __init__(self, connection: _RecordingFlbConnection) -> None:
+        self.connection = connection
+
+    def acquire(self) -> _AcquireFlbConnection:
+        return _AcquireFlbConnection(self.connection)
+
+
 def _settings() -> PMSSettings:
     return PMSSettings(
         mode=RunMode.PAPER,
@@ -51,6 +100,40 @@ def _market(**overrides: object) -> FlbMarketSnapshot:
     }
     data.update(overrides)
     return FlbMarketSnapshot(**data)  # type: ignore[arg-type]
+
+
+def _market_row(**overrides: object) -> _Row:
+    data: dict[str, object] = {
+        "market_id": "market-flb-1",
+        "question": "Will H1 FLB production wiring emit the contrarian side?",
+        "venue": "polymarket",
+        "resolves_at": NOW + timedelta(days=5),
+        "last_seen_at": NOW - timedelta(minutes=2),
+        "yes_price": 0.03,
+        "no_price": 0.97,
+        "best_bid": 0.02,
+        "best_ask": 0.04,
+        "price_updated_at": NOW - timedelta(minutes=2),
+        "closed": False,
+        "accepting_orders": True,
+        "status_updated_at": NOW - timedelta(days=1),
+        "yes_token_id": "token-yes",
+        "no_token_id": "token-no",
+    }
+    data.update(overrides)
+    return _Row(data)
+
+
+def _price_row(**overrides: object) -> _Row:
+    data: dict[str, object] = {
+        "snapshot_at": NOW - timedelta(minutes=10),
+        "yes_price": 0.05,
+        "no_price": 0.95,
+        "best_bid": 0.04,
+        "best_ask": 0.06,
+    }
+    data.update(overrides)
+    return _Row(data)
 
 
 def test_runner_builds_flb_strategy_module_with_live_components() -> None:
@@ -115,3 +198,52 @@ def test_runner_flb_module_requires_explicit_markets_without_pg_pool() -> None:
             market_reader=_StaticFlbMarketReader(None),
         )
 
+
+@pytest.mark.asyncio
+async def test_postgres_flb_reader_uses_as_of_price_snapshot() -> None:
+    runner = Runner(config=_settings())
+    connection = _RecordingFlbConnection(
+        market_row=_market_row(yes_price=0.03),
+        price_row=_price_row(yes_price=0.08, best_bid=0.07, best_ask=0.09),
+    )
+    runner.bind_pg_pool(_FlbPool(connection))
+
+    results = await runner.run_flb_strategy_once(
+        strategy_id="h1_flb",
+        strategy_version_id="h1-flb-v1",
+        market_ids=("token-yes",),
+        as_of=NOW,
+    )
+
+    assert len(results) == 1
+    intent = results[0].intents[0]
+    assert isinstance(intent, TradeIntent)
+    assert intent.outcome == "NO"
+    assert intent.expected_price == pytest.approx(0.97)
+    assert intent.limit_price == pytest.approx(0.95)
+    assert connection.fetchval_calls[0][1] == ("token-yes",)
+    assert connection.fetchrow_calls[1][1] == ("market-flb-1", NOW)
+    assert "ORDER BY match_rank ASC" in connection.fetchval_calls[0][0]
+    assert "snapshot_at <= $2" in connection.fetchrow_calls[1][0]
+
+
+@pytest.mark.asyncio
+async def test_postgres_flb_reader_rejects_future_status_change() -> None:
+    runner = Runner(config=_settings())
+    connection = _RecordingFlbConnection(
+        market_row=_market_row(
+            closed=True,
+            status_updated_at=NOW + timedelta(minutes=1),
+        ),
+        price_row=_price_row(),
+    )
+    runner.bind_pg_pool(_FlbPool(connection))
+
+    results = await runner.run_flb_strategy_once(
+        strategy_id="h1_flb",
+        strategy_version_id="h1-flb-v1",
+        market_ids=("market-flb-1",),
+        as_of=NOW,
+    )
+
+    assert results == ()


### PR DESCRIPTION
## Summary
- Adds Runner-level wiring for `FlbStrategyModule` via `build_flb_strategy_module(...)` and `run_flb_strategy_once(...)`.
- Adds a production Postgres FLB market snapshot reader that can resolve by market id or token id and preserves H1 settlement/runtime safety by ignoring closed or non-accepting markets.
- Adds unit coverage proving Runner can instantiate and call the FLB module without enqueueing live-capital decisions.

## Scope guard
- No H2 anchoring-lag implementation.
- No decile calibration or alpha tuning.
- `min_expected_edge` remains the documented paper-soak placeholder.
- No live-capital enablement.

## Verification
```text
uv run pytest tests/unit/test_flb_runner_wiring.py -q
... 3 passed in 0.19s

uv run pytest tests/unit/test_flb_runner_wiring.py tests/unit/test_flb_strategy_plugin.py tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_agent_strategy_runtime_bridge.py -q
.......................... 26 passed in 0.24s

uv run ruff check src/pms/runner.py tests/unit/test_flb_runner_wiring.py tests/unit/test_flb_strategy_plugin.py tests/unit/test_favorite_longshot_bias_factor.py
All checks passed!

uv run mypy src tests
Success: no issues found in 344 source files

uv run lint-imports
Contracts: 8 kept, 0 broken.

uv run pytest tests/unit -q
922 passed in 9.83s

uv run pytest -q
1004 passed, 161 skipped in 12.69s

git diff --check
PASS
```
