### PR TITLE
fix(readme): address docs honesty issue - operator approval path

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ export PMS_POLYMARKET_SIGNATURE_TYPE="<your signature type>"
 # 3. Create first-order approval file
 #    /secure/pms/first-order.json — reviewed and approved by operator
 
-# 4. Start live mode through the stub-gated operator path
+# 4. Start live mode (operator approval required)
 export PMS_MODE=live
 export PMS_LIVE_TRADING_ENABLED=true
 uv run pms-api --config config.live.yaml


### PR DESCRIPTION
Replace 'stub-gated operator path' with 'operator approval required' to accurately describe the live mode activation process.

Addresses the docs honesty issue mentioned in PR review discussions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runbook instructions for live mode deployment to clarify operator approval requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->