### PR TITLE
feat(strategies): add H2 anchoring lag strategy

### DIFF
--- a/docs/research/h2-anchoring-lag-spec.md
+++ b/docs/research/h2-anchoring-lag-spec.md
@@ -1,0 +1,111 @@
+# H2 Anchoring Lag — Math Spec
+
+Status: **Ready for paper-safe ENG implementation**  
+Author: @Researcher-Ciga  
+Date: 2026-05-03
+
+## 1. Core Mechanism
+
+Market prices can anchor on prior beliefs and update slowly after news. The H2
+hypothesis is that a deterministic LLM posterior can process new information
+before the order book fully reprices. The gap between the LLM posterior and the
+market YES price is the exploitable signal.
+
+## 2. Factor Definition
+
+`anchoring_lag_divergence` is a signed scalar factor:
+
+```
+P_market = market YES price
+P_llm    = LLM posterior probability after processing news
+delta    = P_llm - P_market
+```
+
+The signal decays linearly after the triggering news:
+
+```
+T_max           = 24 hours
+delta_effective = delta * max(0, 1 - (now - news_timestamp) / T_max)
+```
+
+Semantics:
+
+- `delta_effective > 0` means the market appears to underreact to positive news;
+  the actionable side is buy YES.
+- `delta_effective < 0` means the market appears to underreact to negative news;
+  the actionable side is buy NO.
+- After `T_max`, the signal is zero and no action should be emitted.
+
+Factor catalog contract:
+
+| Property | Value |
+|----------|-------|
+| factor_id | `anchoring_lag_divergence` |
+| required_inputs | `yes_price`, `external_signal.llm_posterior`, `external_signal.news_timestamp` |
+| output_type | `scalar` |
+| direction | `neutral` with signed semantics in `value` |
+
+## 3. Entry Criteria
+
+| Condition | Threshold |
+|-----------|-----------|
+| Divergence magnitude | `abs(delta_effective) > 0.15` |
+| Within decay window | `now - news_timestamp < 24h` |
+| LLM confidence | `confidence > 0.60` |
+| Market still open | `resolves_at > now` |
+
+The first implementation is intentionally paper-safe: it consumes prepared LLM
+posterior/news observations and does not fetch news or call an LLM provider from
+inside the strategy plugin.
+
+## 4. Exit Criteria
+
+These are strategy-level requirements for the later production loop/backtest:
+
+| Condition | Threshold |
+|-----------|-----------|
+| Price convergence | `abs(P_market - P_llm) < 0.05` |
+| Market resolved | `resolves_at <= now` |
+| Max hold time | `now - entry_time > 7 days` |
+
+## 5. Position Sizing
+
+Use the existing Kelly sizing path with the selected side's effective
+probability:
+
+- Buy YES: `prob = P_market + delta_effective`
+- Buy NO: `prob = 1 - (P_market + delta_effective)`
+
+If the sizer returns `0.0`, suppress the trade intent. H2 must not bypass the
+existing RiskManager or actuator path.
+
+## 6. Strategy Plugin Structure
+
+The H2 plugin mirrors the H1 FLB plugin shape:
+
+| Component | Module | Responsibility |
+|-----------|--------|----------------|
+| Source | `pms.strategies.anchoring.source.LiveAnchoringSource` | Convert prepared LLM/news observations into strategy observations |
+| Controller | `pms.strategies.anchoring.controller.AnchoringController` | Propose candidates |
+| Agent | `pms.strategies.anchoring.agent.AnchoringAgent` | Judge candidates and build typed intents |
+| Evaluator | `pms.strategies.anchoring.evaluator.AnchoringEvidenceEvaluator` | Gate confidence, divergence, evidence, and edge |
+
+## 7. Backtest Compatibility
+
+Task #27 owns backtesting. First-run backtests may use a fixed noise schedule:
+
+```
+noise_std(t) = 0.20 * (1 - t / T_total) + 0.02 * (t / T_total)
+```
+
+A later backtest can use a Beta noise model derived from LLM calibration error:
+
+```
+N_eff = 1 / Brier - 2
+alpha = outcome * N_eff + 1
+beta  = (1 - outcome) * N_eff + 1
+P_llm ~ Beta(alpha, beta)
+```
+
+Do not build H2 live-capital enablement or H1+H2 backtest replay in the initial
+implementation PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ as_packages = false
 [[tool.importlinter.contracts]]
 name = "Strategy plugins: no actuator, controller, or venue adapter imports"
 type = "forbidden"
-source_modules = ["pms.strategies.ripple", "pms.strategies.flb"]
+source_modules = ["pms.strategies.ripple", "pms.strategies.flb", "pms.strategies.anchoring"]
 forbidden_modules = [
     "pms.actuator",
     "pms.actuator.adapters",

--- a/src/pms/factors/catalog.py
+++ b/src/pms/factors/catalog.py
@@ -22,6 +22,19 @@ class FactorCatalogEntry:
 
 FACTOR_CATALOG_ROWS: tuple[FactorCatalogEntry, ...] = (
     FactorCatalogEntry(
+        factor_id="anchoring_lag_divergence",
+        name="Anchoring Lag Divergence",
+        description=(
+            "Signed H2 divergence between LLM posterior and market YES price "
+            "after news. Positive means buy YES; negative means buy NO. "
+            "Includes 24h linear decay."
+        ),
+        input_schema_hash="51c833482880179372982cec8f88eb9a7c094ece9e52be91bce487a1c70e9050",
+        output_type="scalar",
+        direction="neutral",
+        owner="system",
+    ),
+    FactorCatalogEntry(
         factor_id="favorite_longshot_bias",
         name="Favorite-Longshot Bias",
         description=(

--- a/src/pms/factors/definitions/__init__.py
+++ b/src/pms/factors/definitions/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pms.factors.base import FactorDefinition
 
+from .anchoring_lag_divergence import AnchoringLagDivergence
 from .favorite_longshot_bias import FavoriteLongshotBias
 from .fair_value_spread import FairValueSpread
 from .metaculus_prior import MetaculusPrior
@@ -11,6 +12,7 @@ from .subset_pricing_violation import SubsetPricingViolation
 from .yes_count import YesCount
 
 REGISTERED: tuple[type[FactorDefinition], ...] = (
+    AnchoringLagDivergence,
     FavoriteLongshotBias,
     FairValueSpread,
     SubsetPricingViolation,
@@ -22,6 +24,7 @@ REGISTERED: tuple[type[FactorDefinition], ...] = (
 
 __all__ = (
     "REGISTERED",
+    "AnchoringLagDivergence",
     "FavoriteLongshotBias",
     "FairValueSpread",
     "MetaculusPrior",

--- a/src/pms/factors/definitions/anchoring_lag_divergence.py
+++ b/src/pms/factors/definitions/anchoring_lag_divergence.py
@@ -52,6 +52,8 @@ class AnchoringLagDivergence(FactorDefinition):
         if (
             "llm_posterior" not in signal.external_signal
             or "news_timestamp" not in signal.external_signal
+            or signal.external_signal["llm_posterior"] is None
+            or signal.external_signal["news_timestamp"] is None
         ):
             return None
         llm_posterior = _require_open_probability(
@@ -88,8 +90,7 @@ def _linear_decay(
 ) -> float:
     elapsed_hours = (now - news_timestamp).total_seconds() / 3600.0
     if elapsed_hours < 0.0:
-        msg = "news_timestamp must not be in the future"
-        raise ValueError(msg)
+        return 0.0
     return max(0.0, 1.0 - elapsed_hours / decay_window_hours)
 
 

--- a/src/pms/factors/definitions/anchoring_lag_divergence.py
+++ b/src/pms/factors/definitions/anchoring_lag_divergence.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pms.core.models import MarketSignal
+from pms.factors.base import FactorDefinition, FactorValueRow, OuterRingReader
+
+
+DEFAULT_DIVERGENCE_THRESHOLD = 0.15
+DEFAULT_DECAY_WINDOW_HOURS = 24.0
+
+
+class AnchoringLagDivergence(FactorDefinition):
+    """Signed H2 divergence between LLM posterior and market YES price.
+
+    Positive values mean the market appears to underreact to positive news
+    (buy YES). Negative values mean the market appears to underreact to negative
+    news (buy NO). Values linearly decay to zero after the configured news
+    window.
+    """
+
+    factor_id = "anchoring_lag_divergence"
+    required_inputs = (
+        "yes_price",
+        "external_signal.llm_posterior",
+        "external_signal.news_timestamp",
+    )
+
+    def __init__(
+        self,
+        *,
+        divergence_threshold: float = DEFAULT_DIVERGENCE_THRESHOLD,
+        decay_window_hours: float = DEFAULT_DECAY_WINDOW_HOURS,
+    ) -> None:
+        if divergence_threshold <= 0.0:
+            msg = "divergence_threshold must be > 0.0"
+            raise ValueError(msg)
+        if decay_window_hours <= 0.0:
+            msg = "decay_window_hours must be > 0.0"
+            raise ValueError(msg)
+        self._divergence_threshold = divergence_threshold
+        self._decay_window_hours = decay_window_hours
+
+    def compute(
+        self,
+        signal: MarketSignal,
+        outer_ring: OuterRingReader,
+    ) -> FactorValueRow | None:
+        del outer_ring
+
+        yes_price = _require_open_probability(signal.yes_price, "yes_price")
+        if (
+            "llm_posterior" not in signal.external_signal
+            or "news_timestamp" not in signal.external_signal
+        ):
+            return None
+        llm_posterior = _require_open_probability(
+            signal.external_signal.get("llm_posterior"),
+            "llm_posterior",
+        )
+        news_timestamp = _require_datetime(
+            signal.external_signal.get("news_timestamp"),
+            "news_timestamp",
+        )
+        decay = _linear_decay(
+            now=signal.timestamp,
+            news_timestamp=news_timestamp,
+            decay_window_hours=self._decay_window_hours,
+        )
+        delta_effective = (llm_posterior - yes_price) * decay
+        if abs(delta_effective) <= self._divergence_threshold:
+            return None
+
+        return FactorValueRow(
+            factor_id=self.factor_id,
+            param="",
+            market_id=signal.market_id,
+            ts=signal.timestamp,
+            value=delta_effective,
+        )
+
+
+def _linear_decay(
+    *,
+    now: datetime,
+    news_timestamp: datetime,
+    decay_window_hours: float,
+) -> float:
+    elapsed_hours = (now - news_timestamp).total_seconds() / 3600.0
+    if elapsed_hours < 0.0:
+        msg = "news_timestamp must not be in the future"
+        raise ValueError(msg)
+    return max(0.0, 1.0 - elapsed_hours / decay_window_hours)
+
+
+def _require_open_probability(value: object, field_name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    probability = float(value)
+    if probability <= 0.0 or probability >= 1.0 or probability != probability:
+        msg = f"{field_name} must satisfy 0.0 < value < 1.0"
+        raise ValueError(msg)
+    return probability
+
+
+def _require_datetime(value: object, field_name: str) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError as error:
+            msg = f"{field_name} must be an ISO datetime"
+            raise ValueError(msg) from error
+    msg = f"{field_name} must be an ISO datetime"
+    raise TypeError(msg)

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -92,6 +92,13 @@ from pms.storage.order_store import OrderStore
 from pms.storage.strategy_registry import PostgresStrategyRegistry
 from pms.strategies.aggregate import Strategy
 from pms.strategies.defaults import DEFAULT_STRATEGY_COMPOSITION
+from pms.strategies.anchoring import (
+    AnchoringAgent,
+    AnchoringController,
+    AnchoringLagStrategyModule,
+    LiveAnchoringSource,
+)
+from pms.strategies.anchoring.source import AnchoringMarketSnapshotReader
 from pms.strategies.flb import FlbAgent, FlbController, FlbStrategyModule
 from pms.strategies.flb.source import (
     FlbMarketSnapshot,
@@ -639,6 +646,66 @@ class Runner:
         market_reader: FlbMarketSnapshotReader | None = None,
     ) -> Sequence[StrategyRunResult]:
         module = self.build_flb_strategy_module(
+            strategy_id=strategy_id,
+            strategy_version_id=strategy_version_id,
+            market_ids=market_ids,
+            market_reader=market_reader,
+        )
+        return tuple(
+            await module.run_with_artifacts(
+                StrategyContext(
+                    strategy_id=strategy_id,
+                    strategy_version_id=strategy_version_id,
+                    as_of=as_of or datetime.now(tz=UTC),
+                )
+            )
+        )
+
+    def build_anchoring_strategy_module(
+        self,
+        *,
+        strategy_id: str,
+        strategy_version_id: str,
+        market_ids: Sequence[str],
+        market_reader: AnchoringMarketSnapshotReader | None = None,
+    ) -> AnchoringLagStrategyModule:
+        if not market_ids:
+            msg = "market_ids must not be empty"
+            raise ValueError(msg)
+        if market_reader is None:
+            msg = (
+                "explicit H2 anchoring market reader is required until the "
+                "LLM/news observation source is wired"
+            )
+            raise RuntimeError(msg)
+
+        return AnchoringLagStrategyModule(
+            source=LiveAnchoringSource(
+                market_ids=tuple(market_ids),
+                market_reader=market_reader,
+                position_sizer=KellySizer(self.config.risk),
+                portfolio=self.portfolio,
+                max_slippage_bps=self.config.controller.max_slippage_bps,
+                time_in_force=TimeInForce(
+                    self.config.controller.time_in_force.upper()
+                ),
+            ),
+            controller=AnchoringController(),
+            agent=AnchoringAgent(),
+            strategy_id=strategy_id,
+            strategy_version_id=strategy_version_id,
+        )
+
+    async def run_anchoring_strategy_once(
+        self,
+        *,
+        strategy_id: str,
+        strategy_version_id: str,
+        market_ids: Sequence[str],
+        as_of: datetime | None = None,
+        market_reader: AnchoringMarketSnapshotReader | None = None,
+    ) -> Sequence[StrategyRunResult]:
+        module = self.build_anchoring_strategy_module(
             strategy_id=strategy_id,
             strategy_version_id=strategy_version_id,
             market_ids=market_ids,

--- a/src/pms/strategies/anchoring/__init__.py
+++ b/src/pms/strategies/anchoring/__init__.py
@@ -1,0 +1,19 @@
+"""H2 anchoring-lag strategy plugin."""
+
+from pms.strategies.anchoring.agent import AnchoringAgent
+from pms.strategies.anchoring.controller import AnchoringController
+from pms.strategies.anchoring.source import (
+    ANCHORING_RESEARCH_REF,
+    AnchoringMarketSnapshot,
+    LiveAnchoringSource,
+)
+from pms.strategies.anchoring.strategy import AnchoringLagStrategyModule
+
+__all__ = [
+    "ANCHORING_RESEARCH_REF",
+    "AnchoringAgent",
+    "AnchoringController",
+    "AnchoringLagStrategyModule",
+    "AnchoringMarketSnapshot",
+    "LiveAnchoringSource",
+]

--- a/src/pms/strategies/anchoring/agent.py
+++ b/src/pms/strategies/anchoring/agent.py
@@ -1,0 +1,140 @@
+"""Deterministic H2 anchoring-lag agent that builds trade intents."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from pms.core.enums import TimeInForce
+from pms.core.models import BookSide, Outcome, Venue
+from pms.strategies.anchoring.evaluator import AnchoringEvidenceEvaluator
+from pms.strategies.intents import (
+    BasketIntent,
+    StrategyCandidate,
+    StrategyContext,
+    StrategyJudgement,
+    TradeIntent,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoringAgent:
+    min_evidence_refs: int = 2
+    min_confidence: float = 0.6
+    min_expected_edge: float = 0.02
+    min_divergence: float = 0.15
+    _evaluator: AnchoringEvidenceEvaluator = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "_evaluator",
+            AnchoringEvidenceEvaluator(
+                min_evidence_refs=self.min_evidence_refs,
+                min_confidence=self.min_confidence,
+                min_expected_edge=self.min_expected_edge,
+                min_divergence=self.min_divergence,
+            ),
+        )
+
+    async def judge(
+        self,
+        context: StrategyContext,
+        candidate: StrategyCandidate,
+    ) -> StrategyJudgement:
+        _require_same_strategy(context, candidate)
+        assessment = self._evaluator.assess(candidate)
+        return StrategyJudgement(
+            judgement_id=f"judgement-{candidate.candidate_id}",
+            candidate_id=candidate.candidate_id,
+            strategy_id=context.strategy_id,
+            strategy_version_id=context.strategy_version_id,
+            approved=assessment.approved,
+            confidence=assessment.confidence,
+            rationale=assessment.rationale,
+            evidence_refs=assessment.evidence_refs,
+            failure_reasons=assessment.failure_reasons,
+            created_at=context.as_of,
+        )
+
+    async def build_intents(
+        self,
+        context: StrategyContext,
+        candidate: StrategyCandidate,
+        judgement: StrategyJudgement,
+    ) -> Sequence[TradeIntent | BasketIntent]:
+        _require_same_strategy(context, candidate)
+        if judgement.candidate_id != candidate.candidate_id:
+            msg = "judgement candidate_id must match candidate"
+            raise ValueError(msg)
+        if not judgement.approved:
+            return ()
+
+        metadata = candidate.metadata
+        intent = TradeIntent(
+            intent_id=f"intent-{candidate.candidate_id}",
+            strategy_id=context.strategy_id,
+            strategy_version_id=context.strategy_version_id,
+            candidate_id=candidate.candidate_id,
+            market_id=candidate.market_id,
+            token_id=_metadata_str(metadata, "token_id"),
+            venue=cast(Venue, _metadata_str(metadata, "venue")),
+            side=cast(BookSide, _metadata_str(metadata, "side")),
+            outcome=cast(Outcome, _metadata_str(metadata, "outcome")),
+            limit_price=_metadata_float(metadata, "limit_price"),
+            notional_usdc=_metadata_float(metadata, "notional_usdc"),
+            expected_price=_metadata_float(metadata, "expected_price"),
+            expected_edge=candidate.expected_edge,
+            max_slippage_bps=_metadata_int(metadata, "max_slippage_bps"),
+            time_in_force=_metadata_time_in_force(metadata),
+            evidence_refs=(judgement.judgement_id, *judgement.evidence_refs),
+            created_at=context.as_of,
+        )
+        return (intent,)
+
+
+def _require_same_strategy(
+    context: StrategyContext,
+    candidate: StrategyCandidate,
+) -> None:
+    if (
+        candidate.strategy_id != context.strategy_id
+        or candidate.strategy_version_id != context.strategy_version_id
+    ):
+        msg = "candidate strategy identity must match context"
+        raise ValueError(msg)
+
+
+def _metadata_str(metadata: Mapping[str, Any], field_name: str) -> str:
+    value = metadata[field_name]
+    if not isinstance(value, str):
+        msg = f"{field_name} must be a string"
+        raise TypeError(msg)
+    return value
+
+
+def _metadata_float(metadata: Mapping[str, Any], field_name: str) -> float:
+    value = metadata[field_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    return float(value)
+
+
+def _metadata_int(metadata: Mapping[str, Any], field_name: str) -> int:
+    value = metadata[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f"{field_name} must be an integer"
+        raise TypeError(msg)
+    return cast(int, value)
+
+
+def _metadata_time_in_force(metadata: Mapping[str, Any]) -> TimeInForce:
+    value = metadata["time_in_force"]
+    if isinstance(value, TimeInForce):
+        return value
+    if isinstance(value, str):
+        return TimeInForce(value)
+    msg = "time_in_force must be a TimeInForce or string"
+    raise TypeError(msg)

--- a/src/pms/strategies/anchoring/controller.py
+++ b/src/pms/strategies/anchoring/controller.py
@@ -1,0 +1,110 @@
+"""Candidate proposal for H2 anchoring-lag observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+from pms.strategies.intents import StrategyCandidate, StrategyContext, StrategyObservation
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoringController:
+    async def propose(
+        self,
+        context: StrategyContext,
+        observations: Sequence[StrategyObservation],
+    ) -> Sequence[StrategyCandidate]:
+        del context
+        return tuple(_candidate_from_observation(observation) for observation in observations)
+
+
+def _candidate_from_observation(observation: StrategyObservation) -> StrategyCandidate:
+    payload = observation.payload
+    payload_metadata = _mapping(payload.get("metadata", {}))
+    metadata: dict[str, Any] = {
+        "observation_id": observation.observation_id,
+        "source": observation.source,
+        "confidence": _required_float(payload, "confidence"),
+        "token_id": _required_str(payload, "token_id"),
+        "venue": _required_str(payload, "venue"),
+        "side": _required_str(payload, "side"),
+        "outcome": _required_str(payload, "outcome"),
+        "limit_price": _required_float(payload, "limit_price"),
+        "notional_usdc": _required_float(payload, "notional_usdc"),
+        "expected_price": _required_float(payload, "expected_price"),
+        "max_slippage_bps": _required_int(payload, "max_slippage_bps"),
+        "time_in_force": _required_str(payload, "time_in_force"),
+        "contradiction_refs": _string_tuple(payload.get("contradiction_refs", ())),
+        "h2_metadata": payload_metadata,
+    }
+    for field_name in (
+        "decay_window_hours",
+        "delta_effective",
+        "h2_signal",
+        "llm_confidence",
+        "llm_posterior",
+        "min_divergence",
+        "min_expected_edge",
+        "news_timestamp",
+        "no_best_ask",
+        "yes_best_ask",
+        "yes_price",
+    ):
+        if field_name in payload_metadata:
+            metadata[field_name] = payload_metadata[field_name]
+    return StrategyCandidate(
+        candidate_id=f"candidate-{observation.observation_id}",
+        strategy_id=observation.strategy_id,
+        strategy_version_id=observation.strategy_version_id,
+        market_id=_required_str(payload, "market_id"),
+        title=_required_str(payload, "title"),
+        thesis=_required_str(payload, "thesis"),
+        probability_estimate=_required_float(payload, "probability_estimate"),
+        expected_edge=_required_float(payload, "expected_edge"),
+        evidence_refs=observation.evidence_refs,
+        created_at=observation.observed_at,
+        metadata=metadata,
+    )
+
+
+def _required_str(payload: Mapping[str, Any], field_name: str) -> str:
+    value = payload[field_name]
+    if not isinstance(value, str):
+        msg = f"{field_name} must be a string"
+        raise TypeError(msg)
+    return value
+
+
+def _required_float(payload: Mapping[str, Any], field_name: str) -> float:
+    value = payload[field_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    return float(value)
+
+
+def _required_int(payload: Mapping[str, Any], field_name: str) -> int:
+    value = payload[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        msg = f"{field_name} must be an integer"
+        raise TypeError(msg)
+    return cast(int, value)
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, tuple):
+        msg = "contradiction_refs must be a tuple"
+        raise TypeError(msg)
+    if any(not isinstance(item, str) for item in value):
+        msg = "contradiction_refs must contain strings"
+        raise TypeError(msg)
+    return cast(tuple[str, ...], value)
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        msg = "metadata must be a mapping"
+        raise TypeError(msg)
+    return cast(Mapping[str, Any], value)

--- a/src/pms/strategies/anchoring/evaluator.py
+++ b/src/pms/strategies/anchoring/evaluator.py
@@ -1,0 +1,112 @@
+"""Deterministic evidence gate for H2 anchoring-lag signals."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, cast
+
+from pms.strategies.intents import StrategyCandidate
+
+
+DEFAULT_MIN_DIVERGENCE = 0.15
+DEFAULT_MIN_CONFIDENCE = 0.60
+DEFAULT_MIN_EXPECTED_EDGE = 0.02
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoringEvidenceAssessment:
+    approved: bool
+    expected_edge: float
+    confidence: float
+    rationale: str
+    evidence_refs: tuple[str, ...]
+    failure_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoringEvidenceEvaluator:
+    min_evidence_refs: int = 2
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE
+    min_expected_edge: float = DEFAULT_MIN_EXPECTED_EDGE
+    min_divergence: float = DEFAULT_MIN_DIVERGENCE
+
+    def assess(self, candidate: StrategyCandidate) -> AnchoringEvidenceAssessment:
+        confidence = _metadata_float(candidate.metadata, "confidence")
+        contradiction_refs = _metadata_tuple(candidate.metadata, "contradiction_refs")
+        delta_effective = abs(_metadata_float(candidate.metadata, "delta_effective"))
+        if len(candidate.evidence_refs) < self.min_evidence_refs:
+            return AnchoringEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=min(confidence, self.min_confidence - 0.01),
+                rationale="rejected: insufficient H2 anchoring-lag evidence",
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("insufficient_evidence",),
+            )
+        if contradiction_refs:
+            return AnchoringEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=min(confidence, self.min_confidence - 0.01),
+                rationale="rejected: H2 anchoring-lag evidence contains a contradiction",
+                evidence_refs=(*candidate.evidence_refs, *contradiction_refs),
+                failure_reasons=("contradiction",),
+            )
+        if confidence < self.min_confidence:
+            return AnchoringEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=confidence,
+                rationale="rejected: H2 anchoring-lag confidence below threshold",
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("low_confidence",),
+            )
+        if delta_effective <= self.min_divergence:
+            return AnchoringEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=confidence,
+                rationale="rejected: H2 anchoring-lag divergence below threshold",
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("insufficient_divergence",),
+            )
+        if candidate.expected_edge < self.min_expected_edge:
+            return AnchoringEvidenceAssessment(
+                approved=False,
+                expected_edge=candidate.expected_edge,
+                confidence=confidence,
+                rationale="rejected: H2 anchoring-lag expected edge below threshold",
+                evidence_refs=candidate.evidence_refs,
+                failure_reasons=("insufficient_expected_edge",),
+            )
+        return AnchoringEvidenceAssessment(
+            approved=True,
+            expected_edge=candidate.expected_edge,
+            confidence=confidence,
+            rationale=(
+                "approved: H2 anchoring-lag signal gives "
+                f"{candidate.expected_edge:.4f} expected edge"
+            ),
+            evidence_refs=candidate.evidence_refs,
+            failure_reasons=(),
+        )
+
+
+def _metadata_float(metadata: Mapping[str, Any], field_name: str) -> float:
+    value = metadata[field_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"{field_name} must be numeric"
+        raise TypeError(msg)
+    return float(value)
+
+
+def _metadata_tuple(metadata: Mapping[str, Any], field_name: str) -> tuple[str, ...]:
+    value = metadata[field_name]
+    if not isinstance(value, tuple):
+        msg = f"{field_name} must be a tuple"
+        raise TypeError(msg)
+    if any(not isinstance(item, str) for item in value):
+        msg = f"{field_name} must contain strings"
+        raise TypeError(msg)
+    return cast(tuple[str, ...], value)

--- a/src/pms/strategies/anchoring/source.py
+++ b/src/pms/strategies/anchoring/source.py
@@ -1,0 +1,340 @@
+"""Observation source for the H2 anchoring-lag strategy."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from pms.core.enums import TimeInForce
+from pms.core.models import BookSide, Outcome, Portfolio, Venue
+from pms.factors.definitions.anchoring_lag_divergence import DEFAULT_DECAY_WINDOW_HOURS
+from pms.strategies.anchoring.evaluator import (
+    DEFAULT_MIN_CONFIDENCE,
+    DEFAULT_MIN_DIVERGENCE,
+    DEFAULT_MIN_EXPECTED_EDGE,
+)
+from pms.strategies.intents import StrategyContext, StrategyObservation
+
+
+ANCHORING_RESEARCH_REF = "research:h2-anchoring-lag-spec#h2"
+LIVE_ANCHORING_SOURCE = "live_anchoring_lag_source"
+
+
+class AnchoringMarketSnapshotReader(Protocol):
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> AnchoringMarketSnapshot | None: ...
+
+
+class AnchoringPositionSizer(Protocol):
+    def size(
+        self,
+        *,
+        prob: float,
+        market_price: float,
+        portfolio: Portfolio,
+    ) -> float: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoringMarketSnapshot:
+    market_id: str
+    title: str
+    yes_token_id: str
+    no_token_id: str
+    yes_price: float
+    llm_posterior: float
+    llm_confidence: float
+    news_timestamp: datetime
+    observed_at: datetime
+    yes_best_ask: float | None = None
+    no_best_ask: float | None = None
+    resolves_at: datetime | None = None
+    news_ref: str | None = None
+    venue: Venue = "polymarket"
+
+    def __post_init__(self) -> None:
+        _require_non_empty(self.market_id, "market_id")
+        _require_non_empty(self.title, "title")
+        _require_non_empty(self.yes_token_id, "yes_token_id")
+        _require_non_empty(self.no_token_id, "no_token_id")
+        _require_open_probability(self.yes_price, "yes_price")
+        _require_open_probability(self.llm_posterior, "llm_posterior")
+        _require_probability(self.llm_confidence, "llm_confidence")
+        if self.yes_best_ask is not None:
+            _require_open_probability(self.yes_best_ask, "yes_best_ask")
+        if self.no_best_ask is not None:
+            _require_open_probability(self.no_best_ask, "no_best_ask")
+
+
+@dataclass(frozen=True, slots=True)
+class LiveAnchoringSource:
+    """Paper-safe source for H2 anchoring-lag signals.
+
+    This source consumes already prepared LLM posterior/news observations. It
+    does not call the LLM provider or fetch news itself, keeping the first H2
+    slice deterministic and suitable for paper-soak validation.
+    """
+
+    market_ids: Sequence[str]
+    market_reader: AnchoringMarketSnapshotReader
+    position_sizer: AnchoringPositionSizer
+    portfolio: Portfolio
+    min_divergence: float = DEFAULT_MIN_DIVERGENCE
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE
+    min_expected_edge: float = DEFAULT_MIN_EXPECTED_EDGE
+    decay_window_hours: float = DEFAULT_DECAY_WINDOW_HOURS
+    max_slippage_bps: int = 50
+    time_in_force: TimeInForce = TimeInForce.GTC
+
+    def __post_init__(self) -> None:
+        if not self.market_ids:
+            msg = "market_ids must not be empty"
+            raise ValueError(msg)
+        for market_id in self.market_ids:
+            _require_non_empty(market_id, "market_id")
+        if self.min_divergence <= 0.0:
+            msg = "min_divergence must be > 0.0"
+            raise ValueError(msg)
+        if self.min_expected_edge <= 0.0:
+            msg = "min_expected_edge must be > 0.0"
+            raise ValueError(msg)
+        _require_probability(self.min_confidence, "min_confidence")
+        if self.decay_window_hours <= 0.0:
+            msg = "decay_window_hours must be > 0.0"
+            raise ValueError(msg)
+        if self.max_slippage_bps < 0:
+            msg = "max_slippage_bps must be >= 0"
+            raise ValueError(msg)
+
+    async def observe(self, context: StrategyContext) -> Sequence[StrategyObservation]:
+        observations: list[StrategyObservation] = []
+        for market_id in self.market_ids:
+            market = await self.market_reader.latest(market_id, as_of=context.as_of)
+            if market is None or _is_resolved(context.as_of, market.resolves_at):
+                continue
+            observation = _observation_from_market(
+                context=context,
+                market=market,
+                position_sizer=self.position_sizer,
+                portfolio=self.portfolio,
+                min_divergence=self.min_divergence,
+                min_confidence=self.min_confidence,
+                min_expected_edge=self.min_expected_edge,
+                decay_window_hours=self.decay_window_hours,
+                max_slippage_bps=self.max_slippage_bps,
+                time_in_force=self.time_in_force,
+            )
+            if observation is not None:
+                observations.append(observation)
+        return tuple(observations)
+
+
+@dataclass(frozen=True, slots=True)
+class _AnchoringSignal:
+    signal_name: str
+    thesis: str
+    token_id: str
+    outcome: Outcome
+    side: BookSide
+    limit_price: float
+    probability_estimate: float
+    delta_effective: float
+
+
+def _observation_from_market(
+    *,
+    context: StrategyContext,
+    market: AnchoringMarketSnapshot,
+    position_sizer: AnchoringPositionSizer,
+    portfolio: Portfolio,
+    min_divergence: float,
+    min_confidence: float,
+    min_expected_edge: float,
+    decay_window_hours: float,
+    max_slippage_bps: int,
+    time_in_force: TimeInForce,
+) -> StrategyObservation | None:
+    signal = _classify_market(
+        context=context,
+        market=market,
+        min_divergence=min_divergence,
+        min_confidence=min_confidence,
+        decay_window_hours=decay_window_hours,
+    )
+    if signal is None:
+        return None
+
+    expected_edge = signal.probability_estimate - signal.limit_price
+    if expected_edge < min_expected_edge:
+        return None
+    notional_usdc = position_sizer.size(
+        prob=signal.probability_estimate,
+        market_price=signal.limit_price,
+        portfolio=portfolio,
+    )
+    if notional_usdc <= 0.0:
+        return None
+
+    evidence_refs = _evidence_refs(market)
+    metadata = {
+        "source": LIVE_ANCHORING_SOURCE,
+        "h2_signal": signal.signal_name,
+        "yes_price": market.yes_price,
+        "llm_posterior": market.llm_posterior,
+        "llm_confidence": market.llm_confidence,
+        "news_timestamp": market.news_timestamp.isoformat(),
+        "yes_best_ask": market.yes_best_ask,
+        "no_best_ask": market.no_best_ask,
+        "observed_at": market.observed_at.isoformat(),
+        "resolves_at": market.resolves_at.isoformat() if market.resolves_at else None,
+        "delta_effective": signal.delta_effective,
+        "min_divergence": min_divergence,
+        "decay_window_hours": decay_window_hours,
+        "min_expected_edge": min_expected_edge,
+    }
+    payload = {
+        "market_id": market.market_id,
+        "title": market.title,
+        "thesis": signal.thesis,
+        "probability_estimate": signal.probability_estimate,
+        "expected_edge": expected_edge,
+        "confidence": market.llm_confidence,
+        "token_id": signal.token_id,
+        "venue": market.venue,
+        "side": signal.side,
+        "outcome": signal.outcome,
+        "limit_price": signal.limit_price,
+        "notional_usdc": notional_usdc,
+        "expected_price": signal.probability_estimate,
+        "max_slippage_bps": max_slippage_bps,
+        "time_in_force": time_in_force,
+        "contradiction_refs": (),
+        "metadata": metadata,
+    }
+    return StrategyObservation(
+        observation_id=f"live-anchoring-{market.market_id}-{context.as_of.isoformat()}",
+        strategy_id=context.strategy_id,
+        strategy_version_id=context.strategy_version_id,
+        source=LIVE_ANCHORING_SOURCE,
+        observed_at=context.as_of,
+        summary=signal.thesis,
+        payload=payload,
+        evidence_refs=evidence_refs,
+    )
+
+
+def _classify_market(
+    *,
+    context: StrategyContext,
+    market: AnchoringMarketSnapshot,
+    min_divergence: float,
+    min_confidence: float,
+    decay_window_hours: float,
+) -> _AnchoringSignal | None:
+    if market.llm_confidence < min_confidence:
+        return None
+    decay = _linear_decay(
+        now=context.as_of,
+        news_timestamp=market.news_timestamp,
+        decay_window_hours=decay_window_hours,
+    )
+    delta_effective = (market.llm_posterior - market.yes_price) * decay
+    if abs(delta_effective) <= min_divergence:
+        return None
+
+    effective_yes_probability = _bounded_probability(
+        market.yes_price + delta_effective,
+        "effective_yes_probability",
+    )
+    if delta_effective > 0.0:
+        limit_price = _bounded_probability(
+            market.yes_best_ask if market.yes_best_ask is not None else market.yes_price,
+            "yes_limit_price",
+        )
+        return _AnchoringSignal(
+            signal_name="positive_news_underreaction_buy_yes",
+            thesis=(
+                "H2 anchoring lag: LLM posterior is above market price after "
+                "fresh news; buy YES exposure."
+            ),
+            token_id=market.yes_token_id,
+            outcome="YES",
+            side="BUY",
+            limit_price=limit_price,
+            probability_estimate=effective_yes_probability,
+            delta_effective=delta_effective,
+        )
+
+    limit_price = _bounded_probability(
+        market.no_best_ask if market.no_best_ask is not None else 1.0 - market.yes_price,
+        "no_limit_price",
+    )
+    return _AnchoringSignal(
+        signal_name="negative_news_underreaction_buy_no",
+        thesis=(
+            "H2 anchoring lag: LLM posterior is below market price after "
+            "fresh news; buy NO exposure."
+        ),
+        token_id=market.no_token_id,
+        outcome="NO",
+        side="BUY",
+        limit_price=limit_price,
+        probability_estimate=_bounded_probability(
+            1.0 - effective_yes_probability,
+            "no_probability_estimate",
+        ),
+        delta_effective=delta_effective,
+    )
+
+
+def _is_resolved(as_of: datetime, resolves_at: datetime | None) -> bool:
+    return resolves_at is not None and resolves_at <= as_of
+
+
+def _evidence_refs(market: AnchoringMarketSnapshot) -> tuple[str, ...]:
+    market_ref = f"market_snapshot:{market.market_id}:{market.observed_at.isoformat()}"
+    news_ref = market.news_ref or f"news_timestamp:{market.news_timestamp.isoformat()}"
+    return (ANCHORING_RESEARCH_REF, market_ref, news_ref)
+
+
+def _linear_decay(
+    *,
+    now: datetime,
+    news_timestamp: datetime,
+    decay_window_hours: float,
+) -> float:
+    elapsed_hours = (now - news_timestamp).total_seconds() / 3600.0
+    if elapsed_hours < 0.0:
+        return 0.0
+    return max(0.0, 1.0 - elapsed_hours / decay_window_hours)
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    if not value:
+        msg = f"{field_name} must be non-empty"
+        raise ValueError(msg)
+
+
+def _require_probability(value: float, field_name: str) -> None:
+    if value < 0.0 or value > 1.0 or value != value:
+        msg = f"{field_name} must satisfy 0.0 <= value <= 1.0"
+        raise ValueError(msg)
+
+
+def _require_open_probability(value: float, field_name: str) -> None:
+    if value <= 0.0 or value >= 1.0 or value != value:
+        msg = f"{field_name} must satisfy 0.0 < value < 1.0"
+        raise ValueError(msg)
+
+
+def _bounded_probability(value: float, field_name: str) -> float:
+    if value != value:
+        msg = f"{field_name} must not be NaN"
+        raise ValueError(msg)
+    return min(max(float(value), 0.0001), 0.9999)

--- a/src/pms/strategies/anchoring/strategy.py
+++ b/src/pms/strategies/anchoring/strategy.py
@@ -1,0 +1,51 @@
+"""Composable H2 anchoring-lag strategy module."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from pms.strategies.base import StrategyAgent, StrategyController, StrategyObservationSource
+from pms.strategies.intents import BasketIntent, StrategyContext, TradeIntent
+from pms.strategies.runtime_bridge import StrategyRunResult
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoringLagStrategyModule:
+    source: StrategyObservationSource
+    controller: StrategyController
+    agent: StrategyAgent
+    strategy_id: str
+    strategy_version_id: str
+
+    async def run(
+        self,
+        context: StrategyContext,
+    ) -> Sequence[TradeIntent | BasketIntent]:
+        results = await self.run_with_artifacts(context)
+        return tuple(intent for result in results for intent in result.intents)
+
+    async def run_with_artifacts(
+        self,
+        context: StrategyContext,
+    ) -> Sequence[StrategyRunResult]:
+        if (
+            context.strategy_id != self.strategy_id
+            or context.strategy_version_id != self.strategy_version_id
+        ):
+            msg = "context strategy identity must match H2 anchoring-lag module"
+            raise ValueError(msg)
+
+        observations = await self.source.observe(context)
+        candidates = await self.controller.propose(context, observations)
+        results: list[StrategyRunResult] = []
+        for candidate in candidates:
+            judgement = await self.agent.judge(context, candidate)
+            intents = await self.agent.build_intents(context, candidate, judgement)
+            results.append(
+                StrategyRunResult(
+                    judgement=judgement,
+                    intents=tuple(intents),
+                )
+            )
+        return tuple(results)

--- a/tests/unit/test_anchoring_lag_factor.py
+++ b/tests/unit/test_anchoring_lag_factor.py
@@ -99,6 +99,23 @@ def test_anchoring_lag_factor_returns_none_when_llm_news_inputs_are_absent() -> 
     assert AnchoringLagDivergence().compute(signal, EMPTY_OUTER_RING) is None
 
 
+def test_anchoring_lag_factor_returns_none_for_null_llm_news_inputs() -> None:
+    signal = _signal()
+    signal.external_signal["llm_posterior"] = None
+    assert AnchoringLagDivergence().compute(signal, EMPTY_OUTER_RING) is None
+
+    signal = _signal()
+    signal.external_signal["news_timestamp"] = None
+    assert AnchoringLagDivergence().compute(signal, EMPTY_OUTER_RING) is None
+
+
+def test_anchoring_lag_factor_returns_none_for_future_news_timestamp() -> None:
+    assert AnchoringLagDivergence().compute(
+        _signal(news_timestamp=NOW + timedelta(seconds=1)),
+        EMPTY_OUTER_RING,
+    ) is None
+
+
 def test_anchoring_lag_factor_rejects_invalid_probability_inputs() -> None:
     with pytest.raises(ValueError, match="llm_posterior"):
         AnchoringLagDivergence().compute(

--- a/tests/unit/test_anchoring_lag_factor.py
+++ b/tests/unit/test_anchoring_lag_factor.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from pms.core.enums import MarketStatus
+from pms.core.models import MarketSignal
+from pms.factors.base import EMPTY_OUTER_RING
+from pms.factors.catalog import FACTOR_CATALOG_ROWS
+from pms.factors.definitions import AnchoringLagDivergence, REGISTERED
+
+
+NOW = datetime(2026, 5, 4, 1, 0, tzinfo=UTC)
+
+
+def _signal(
+    *,
+    yes_price: float = 0.50,
+    llm_posterior: float = 0.80,
+    news_timestamp: datetime | None = None,
+) -> MarketSignal:
+    return MarketSignal(
+        market_id="market-h2",
+        token_id="token-h2-yes",
+        venue="polymarket",
+        title="Will H2 anchoring lag detect delayed repricing?",
+        yes_price=yes_price,
+        volume_24h=1000.0,
+        resolves_at=NOW + timedelta(days=5),
+        orderbook={"bids": [], "asks": []},
+        external_signal={
+            "llm_posterior": llm_posterior,
+            "news_timestamp": (news_timestamp or NOW).isoformat(),
+        },
+        fetched_at=NOW,
+        market_status=MarketStatus.OPEN.value,
+    )
+
+
+def test_registered_includes_anchoring_lag_divergence() -> None:
+    assert AnchoringLagDivergence in REGISTERED
+
+
+def test_catalog_includes_anchoring_lag_as_neutral_signed_factor() -> None:
+    entry = next(row for row in FACTOR_CATALOG_ROWS if row.factor_id == "anchoring_lag_divergence")
+
+    assert entry.output_type == "scalar"
+    assert entry.direction == "neutral"
+
+
+def test_anchoring_lag_factor_outputs_positive_decayed_divergence() -> None:
+    row = AnchoringLagDivergence().compute(
+        _signal(
+            yes_price=0.50,
+            llm_posterior=0.80,
+            news_timestamp=NOW - timedelta(hours=6),
+        ),
+        EMPTY_OUTER_RING,
+    )
+
+    assert row is not None
+    assert row.factor_id == "anchoring_lag_divergence"
+    assert row.param == ""
+    assert row.value == pytest.approx(0.225)
+
+
+def test_anchoring_lag_factor_outputs_negative_decayed_divergence() -> None:
+    row = AnchoringLagDivergence().compute(
+        _signal(
+            yes_price=0.80,
+            llm_posterior=0.40,
+            news_timestamp=NOW - timedelta(hours=12),
+        ),
+        EMPTY_OUTER_RING,
+    )
+
+    assert row is not None
+    assert row.value == pytest.approx(-0.20)
+
+
+def test_anchoring_lag_factor_returns_none_below_threshold_or_after_decay_window() -> None:
+    factor = AnchoringLagDivergence()
+
+    assert factor.compute(
+        _signal(yes_price=0.50, llm_posterior=0.60, news_timestamp=NOW),
+        EMPTY_OUTER_RING,
+    ) is None
+    assert factor.compute(
+        _signal(yes_price=0.50, llm_posterior=0.90, news_timestamp=NOW - timedelta(hours=24)),
+        EMPTY_OUTER_RING,
+    ) is None
+
+
+def test_anchoring_lag_factor_returns_none_when_llm_news_inputs_are_absent() -> None:
+    signal = _signal()
+    signal.external_signal.clear()
+
+    assert AnchoringLagDivergence().compute(signal, EMPTY_OUTER_RING) is None
+
+
+def test_anchoring_lag_factor_rejects_invalid_probability_inputs() -> None:
+    with pytest.raises(ValueError, match="llm_posterior"):
+        AnchoringLagDivergence().compute(
+            _signal(llm_posterior=1.0),
+            EMPTY_OUTER_RING,
+        )

--- a/tests/unit/test_anchoring_runner_wiring.py
+++ b/tests/unit/test_anchoring_runner_wiring.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from pms.config import PMSSettings, RiskSettings
+from pms.core.enums import RunMode
+from pms.runner import Runner
+from pms.strategies.anchoring import (
+    AnchoringAgent,
+    AnchoringController,
+    AnchoringLagStrategyModule,
+    AnchoringMarketSnapshot,
+    LiveAnchoringSource,
+)
+from pms.strategies.intents import TradeIntent
+
+
+NOW = datetime(2026, 5, 4, 1, 0, tzinfo=UTC)
+
+
+class _StaticAnchoringReader:
+    def __init__(self, market: AnchoringMarketSnapshot | None) -> None:
+        self.market = market
+        self.calls: list[tuple[str, datetime]] = []
+
+    async def latest(
+        self,
+        market_id: str,
+        *,
+        as_of: datetime,
+    ) -> AnchoringMarketSnapshot | None:
+        self.calls.append((market_id, as_of))
+        return self.market
+
+
+def _settings() -> PMSSettings:
+    return PMSSettings(
+        mode=RunMode.PAPER,
+        risk=RiskSettings(max_position_per_market=5.0),
+    )
+
+
+def _market(**overrides: object) -> AnchoringMarketSnapshot:
+    data = {
+        "market_id": "market-h2-1",
+        "title": "Will H2 anchoring lag production wiring emit the LLM side?",
+        "yes_token_id": "token-yes",
+        "no_token_id": "token-no",
+        "yes_price": 0.50,
+        "llm_posterior": 0.80,
+        "llm_confidence": 0.70,
+        "news_timestamp": NOW,
+        "observed_at": NOW,
+        "yes_best_ask": 0.51,
+        "no_best_ask": 0.50,
+        "resolves_at": NOW + timedelta(days=5),
+        "news_ref": "news:headline-1",
+    }
+    data.update(overrides)
+    return AnchoringMarketSnapshot(**data)  # type: ignore[arg-type]
+
+
+def test_runner_builds_anchoring_strategy_module_with_live_components() -> None:
+    runner = Runner(config=_settings())
+    reader = _StaticAnchoringReader(_market())
+
+    module = runner.build_anchoring_strategy_module(
+        strategy_id="h2_anchoring_lag",
+        strategy_version_id="h2-anchoring-lag-v1",
+        market_ids=("market-h2-1",),
+        market_reader=reader,
+    )
+
+    assert isinstance(module, AnchoringLagStrategyModule)
+    assert isinstance(module.source, LiveAnchoringSource)
+    assert isinstance(module.controller, AnchoringController)
+    assert isinstance(module.agent, AnchoringAgent)
+    assert module.strategy_id == "h2_anchoring_lag"
+    assert module.strategy_version_id == "h2-anchoring-lag-v1"
+
+
+@pytest.mark.asyncio
+async def test_runner_calls_anchoring_module_without_live_capital() -> None:
+    runner = Runner(config=_settings())
+    reader = _StaticAnchoringReader(_market())
+
+    results = await runner.run_anchoring_strategy_once(
+        strategy_id="h2_anchoring_lag",
+        strategy_version_id="h2-anchoring-lag-v1",
+        market_ids=("market-h2-1",),
+        as_of=NOW,
+        market_reader=reader,
+    )
+
+    assert reader.calls == [("market-h2-1", NOW)]
+    assert len(results) == 1
+    judgement = results[0].judgement
+    assert judgement is not None
+    assert judgement.approved is True
+
+    assert len(results[0].intents) == 1
+    intent = results[0].intents[0]
+    assert isinstance(intent, TradeIntent)
+    assert intent.outcome == "YES"
+    assert intent.token_id == "token-yes"
+    assert intent.limit_price == pytest.approx(0.51)
+    assert intent.expected_edge == pytest.approx(0.29)
+    assert intent.notional_usdc <= 5.0
+
+    assert runner.state.decisions == []
+    assert runner._decision_queue.empty()  # noqa: SLF001
+
+
+def test_runner_anchoring_module_requires_explicit_reader_until_news_source_lands() -> None:
+    runner = Runner(config=_settings())
+
+    with pytest.raises(RuntimeError, match="explicit H2 anchoring market reader"):
+        runner.build_anchoring_strategy_module(
+            strategy_id="h2_anchoring_lag",
+            strategy_version_id="h2-anchoring-lag-v1",
+            market_ids=("market-h2-1",),
+        )

--- a/tests/unit/test_anchoring_strategy_plugin.py
+++ b/tests/unit/test_anchoring_strategy_plugin.py
@@ -9,32 +9,26 @@ import tomllib
 import pytest
 
 from pms.core.models import Portfolio
-from pms.strategies.base import (
-    StrategyAgent,
-    StrategyController,
-    StrategyModule,
-    StrategyObservationSource,
+from pms.strategies.anchoring import (
+    ANCHORING_RESEARCH_REF,
+    AnchoringAgent,
+    AnchoringController,
+    AnchoringLagStrategyModule,
+    AnchoringMarketSnapshot,
+    LiveAnchoringSource,
 )
-from pms.strategies.flb.agent import FlbAgent
-from pms.strategies.flb.controller import FlbController
-from pms.strategies.flb.source import (
-    FLB_RESEARCH_REF,
-    FlbPositionSizer,
-    LiveFlbSource,
-    FlbMarketSnapshot,
-)
-from pms.strategies.flb.strategy import FlbStrategyModule
+from pms.strategies.base import StrategyAgent, StrategyController, StrategyModule, StrategyObservationSource
 from pms.strategies.intents import StrategyContext, TradeIntent
 
 
-NOW = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+NOW = datetime(2026, 5, 4, 1, 0, tzinfo=UTC)
 ROOT = Path(__file__).resolve().parents[2]
 
 
 def _context() -> StrategyContext:
     return StrategyContext(
-        strategy_id="h1_flb",
-        strategy_version_id="h1-flb-v1",
+        strategy_id="h2_anchoring_lag",
+        strategy_version_id="h2-anchoring-lag-v1",
         as_of=NOW,
     )
 
@@ -77,8 +71,8 @@ class _ZeroSizer:
         return 0.0
 
 
-class _StaticMarketReader:
-    def __init__(self, market: FlbMarketSnapshot | None) -> None:
+class _StaticAnchoringReader:
+    def __init__(self, market: AnchoringMarketSnapshot | None) -> None:
         self.market = market
         self.calls: list[tuple[str, datetime]] = []
 
@@ -87,47 +81,51 @@ class _StaticMarketReader:
         market_id: str,
         *,
         as_of: datetime,
-    ) -> FlbMarketSnapshot | None:
+    ) -> AnchoringMarketSnapshot | None:
         self.calls.append((market_id, as_of))
         return self.market
 
 
-def _market(**overrides: object) -> FlbMarketSnapshot:
+def _market(**overrides: object) -> AnchoringMarketSnapshot:
     data: dict[str, object] = {
-        "market_id": "market-flb-1",
-        "title": "Will the H1 FLB strategy choose the contrarian side?",
+        "market_id": "market-h2-1",
+        "title": "Will H2 anchoring lag detect delayed repricing?",
         "yes_token_id": "token-yes",
         "no_token_id": "token-no",
-        "yes_price": 0.05,
+        "yes_price": 0.50,
+        "llm_posterior": 0.80,
+        "llm_confidence": 0.70,
+        "news_timestamp": NOW,
         "observed_at": NOW,
-        "yes_best_ask": 0.05,
-        "no_best_ask": 0.96,
+        "yes_best_ask": 0.51,
+        "no_best_ask": 0.50,
         "resolves_at": NOW + timedelta(days=7),
+        "news_ref": "news:headline-1",
     }
     data.update(overrides)
-    return FlbMarketSnapshot(**cast(Any, data))
+    return AnchoringMarketSnapshot(**cast(Any, data))
 
 
 def _module(
-    market: FlbMarketSnapshot | None,
+    market: AnchoringMarketSnapshot | None,
     *,
-    sizer: FlbPositionSizer | None = None,
-) -> FlbStrategyModule:
-    return FlbStrategyModule(
-        source=LiveFlbSource(
-            market_ids=("market-flb-1",),
-            market_reader=_StaticMarketReader(market),
+    sizer: Any | None = None,
+) -> AnchoringLagStrategyModule:
+    return AnchoringLagStrategyModule(
+        source=LiveAnchoringSource(
+            market_ids=("market-h2-1",),
+            market_reader=_StaticAnchoringReader(market),
             position_sizer=sizer or _FixedSizer(),
             portfolio=_portfolio(),
         ),
-        controller=FlbController(),
-        agent=FlbAgent(),
-        strategy_id="h1_flb",
-        strategy_version_id="h1-flb-v1",
+        controller=AnchoringController(),
+        agent=AnchoringAgent(),
+        strategy_id="h2_anchoring_lag",
+        strategy_version_id="h2-anchoring-lag-v1",
     )
 
 
-def test_flb_components_satisfy_strategy_protocols() -> None:
+def test_anchoring_components_satisfy_strategy_protocols() -> None:
     module = _module(_market())
 
     source: StrategyObservationSource = module.source
@@ -138,35 +136,13 @@ def test_flb_components_satisfy_strategy_protocols() -> None:
     assert source is module.source
     assert controller is module.controller
     assert agent is module.agent
-    assert strategy_module.strategy_id == "h1_flb"
+    assert strategy_module.strategy_id == "h2_anchoring_lag"
 
 
 @pytest.mark.asyncio
-async def test_flb_longshot_signal_buys_no_contract() -> None:
+async def test_anchoring_positive_divergence_buys_yes_contract() -> None:
     sizer = _FixedSizer(5.0)
-    module = _module(_market(yes_price=0.05, no_best_ask=0.96), sizer=sizer)
-
-    intents = await module.run(_context())
-
-    assert len(intents) == 1
-    intent = intents[0]
-    assert isinstance(intent, TradeIntent)
-    assert intent.outcome == "NO"
-    assert intent.side == "BUY"
-    assert intent.token_id == "token-no"
-    assert intent.limit_price == pytest.approx(0.96)
-    assert intent.expected_price == pytest.approx(0.98)
-    assert intent.expected_edge == pytest.approx(0.02)
-    assert intent.notional_usdc == pytest.approx(5.0)
-    assert len(sizer.calls) == 1
-    assert sizer.calls[0][0] == pytest.approx(0.98)
-    assert sizer.calls[0][1] == pytest.approx(0.96)
-    assert FLB_RESEARCH_REF in intent.evidence_refs
-
-
-@pytest.mark.asyncio
-async def test_flb_favorite_signal_buys_yes_contract() -> None:
-    module = _module(_market(yes_price=0.95, yes_best_ask=0.94))
+    module = _module(_market(yes_price=0.50, llm_posterior=0.80, yes_best_ask=0.51), sizer=sizer)
 
     intents = await module.run(_context())
 
@@ -176,37 +152,58 @@ async def test_flb_favorite_signal_buys_yes_contract() -> None:
     assert intent.outcome == "YES"
     assert intent.side == "BUY"
     assert intent.token_id == "token-yes"
-    assert intent.limit_price == pytest.approx(0.94)
-    assert intent.expected_price == pytest.approx(0.96)
+    assert intent.limit_price == pytest.approx(0.51)
+    assert intent.expected_price == pytest.approx(0.80)
+    assert intent.expected_edge == pytest.approx(0.29)
+    assert intent.notional_usdc == pytest.approx(5.0)
+    assert len(sizer.calls) == 1
+    assert sizer.calls[0][0] == pytest.approx(0.80)
+    assert sizer.calls[0][1] == pytest.approx(0.51)
+    assert ANCHORING_RESEARCH_REF in intent.evidence_refs
 
 
 @pytest.mark.asyncio
-async def test_flb_source_ignores_middle_decile_markets() -> None:
-    module = _module(_market(yes_price=0.50, yes_best_ask=0.50, no_best_ask=0.50))
+async def test_anchoring_negative_divergence_buys_no_contract() -> None:
+    module = _module(
+        _market(
+            yes_price=0.75,
+            llm_posterior=0.45,
+            no_best_ask=0.26,
+        )
+    )
 
-    assert await module.run(_context()) == ()
+    intents = await module.run(_context())
+
+    assert len(intents) == 1
+    intent = intents[0]
+    assert isinstance(intent, TradeIntent)
+    assert intent.outcome == "NO"
+    assert intent.side == "BUY"
+    assert intent.token_id == "token-no"
+    assert intent.limit_price == pytest.approx(0.26)
+    assert intent.expected_price == pytest.approx(0.55)
+    assert intent.expected_edge == pytest.approx(0.29)
 
 
 @pytest.mark.asyncio
-async def test_flb_source_suppresses_zero_sized_trades() -> None:
+async def test_anchoring_source_rejects_stale_or_low_confidence_signals() -> None:
+    assert await _module(_market(news_timestamp=NOW - timedelta(hours=24))).run(_context()) == ()
+    assert await _module(_market(llm_confidence=0.50)).run(_context()) == ()
+
+
+@pytest.mark.asyncio
+async def test_anchoring_source_suppresses_zero_sized_trades() -> None:
     module = _module(_market(), sizer=_ZeroSizer())
 
     assert await module.run(_context()) == ()
 
 
 @pytest.mark.asyncio
-async def test_flb_source_skips_resolved_markets() -> None:
-    module = _module(_market(resolves_at=NOW - timedelta(minutes=1)))
-
-    assert await module.run(_context()) == ()
-
-
-@pytest.mark.asyncio
-async def test_flb_module_rejects_context_strategy_mismatch() -> None:
+async def test_anchoring_module_rejects_context_strategy_mismatch() -> None:
     module = _module(_market())
     context = StrategyContext(
         strategy_id="other",
-        strategy_version_id="h1-flb-v1",
+        strategy_version_id="h2-anchoring-lag-v1",
         as_of=NOW,
     )
 
@@ -214,11 +211,9 @@ async def test_flb_module_rejects_context_strategy_mismatch() -> None:
         await module.run(context)
 
 
-def test_strategy_import_linter_contract_includes_flb_plugin() -> None:
+def test_strategy_import_linter_contract_includes_anchoring_plugin() -> None:
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    contracts: Sequence[dict[str, object]] = pyproject["tool"]["importlinter"][
-        "contracts"
-    ]
+    contracts: Sequence[dict[str, object]] = pyproject["tool"]["importlinter"]["contracts"]
     contract = next(
         candidate
         for candidate in contracts

--- a/tests/unit/test_ripple_strategy_plugin.py
+++ b/tests/unit/test_ripple_strategy_plugin.py
@@ -577,6 +577,7 @@ def test_ripple_import_linter_contract_is_declared() -> None:
     assert contract["source_modules"] == [
         "pms.strategies.ripple",
         "pms.strategies.flb",
+        "pms.strategies.anchoring",
     ]
     assert contract["forbidden_modules"] == [
         "pms.actuator",


### PR DESCRIPTION
## Summary
- Adds the persistent H2 anchoring-lag math/spec contract at `docs/research/h2-anchoring-lag-spec.md`.
- Registers `anchoring_lag_divergence` as a neutral signed factor with 24h linear decay and missing-input no-op behavior.
- Adds a paper-safe `pms.strategies.anchoring` plugin: source/controller/evaluator/agent/module, plus runner single-call wiring that requires an explicit prepared LLM/news observation reader.
- Keeps scope narrow: no H1+H2 backtest, no live-capital enablement, no LLM/news fetch loop.

## Verification
- `uv run pytest tests/unit/test_anchoring_lag_factor.py tests/unit/test_anchoring_strategy_plugin.py tests/unit/test_anchoring_runner_wiring.py -q` → 16 passed
- `uv run pytest tests/unit/test_anchoring_lag_factor.py tests/unit/test_anchoring_strategy_plugin.py tests/unit/test_anchoring_runner_wiring.py tests/unit/test_flb_strategy_plugin.py tests/unit/test_flb_runner_wiring.py tests/unit/test_favorite_longshot_bias_factor.py tests/unit/test_ripple_strategy_plugin.py -q` → 49 passed
- `uv run pytest tests/unit/test_anchoring_lag_factor.py tests/unit/test_forecaster_migration_matrix.py tests/unit/test_statistical_migration.py tests/integration/test_pipeline_end_to_end.py tests/unit/test_api_cp09.py -q` → 45 passed
- `uv run pytest -q` → 1023 passed, 161 skipped
- `uv run mypy src/ tests/ --strict` → Success: no issues found in 354 source files
- `uv run lint-imports` → 8 kept, 0 broken
- `uv run ruff check <changed paths>` → All checks passed
- `git diff --check` → clean

## Notes
- `uv run ruff check .` still reports unrelated pre-existing F401/F541 findings outside this PR's changed paths; scoped ruff on the changed files is clean.

Review requested: @Researcher-Ciga for H2 math/research correctness.
