### PR TITLE
fix: restore paper soak market data flow

### DIFF
--- a/scripts/paper_report.py
+++ b/scripts/paper_report.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 import argparse
+import json
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 from pms.config import PMSSettings, RiskSettings
+
+
+DEFAULT_API_BASE_URL = "http://127.0.0.1:8000"
+_API_TIMEOUT_S = 5.0
 
 
 @dataclass(frozen=True)
@@ -32,6 +40,93 @@ class PaperReportMetrics:
     @classmethod
     def empty(cls, *, report_date: date) -> PaperReportMetrics:
         return cls(report_date=report_date)
+
+
+def metrics_from_api_payloads(
+    *,
+    report_date: date,
+    status: dict[str, Any],
+    trades: dict[str, Any],
+    positions: dict[str, Any],
+    risk_events: tuple[tuple[str, str, str], ...] = (),
+) -> PaperReportMetrics:
+    events = list(risk_events)
+    started_at = _parse_datetime(status.get("runner_started_at"))
+    if started_at is None:
+        events.append(("report generation", "runner_started_at missing", "check /status"))
+        day_of_soak = 0
+    else:
+        day_of_soak = max(0, (report_date - started_at.date()).days)
+
+    controller = _dict_value(status, "controller")
+    actuator = _dict_value(status, "actuator")
+    evaluator = _dict_value(status, "evaluator")
+    trade_rows = _list_value(trades, "trades")
+    position_rows = _list_value(positions, "positions")
+
+    total_exposure = sum(_float_from_dict(row, "locked_usdc") for row in position_rows)
+    cumulative_pnl = sum(_float_from_dict(row, "unrealized_pnl") for row in position_rows)
+
+    return PaperReportMetrics(
+        report_date=report_date,
+        strategy=str(status.get("strategy") or "ripple_v2"),
+        day_of_soak=day_of_soak,
+        decisions_made=_int_from_dict(controller, "decisions_total"),
+        decisions_rejected=_int_from_dict(controller, "diagnostics_total"),
+        fills=_int_from_dict(actuator, "fills_total", fallback=len(trade_rows)),
+        cumulative_pnl=cumulative_pnl,
+        open_positions=len(position_rows),
+        total_exposure=total_exposure,
+        brier_score_7d=_optional_float_from_dict(evaluator, "brier_overall"),
+        risk_events=tuple(events),
+    )
+
+
+def load_live_metrics(
+    *,
+    report_date: date,
+    api_base_url: str = DEFAULT_API_BASE_URL,
+    api_token: str | None = None,
+) -> PaperReportMetrics:
+    status, status_error = _fetch_api_json(
+        api_base_url=api_base_url,
+        path="/status",
+        api_token=api_token,
+    )
+    if status_error is not None:
+        return PaperReportMetrics(
+            report_date=report_date,
+            risk_events=(
+                ("report generation", "pms api unavailable", status_error),
+            ),
+        )
+
+    events: list[tuple[str, str, str]] = []
+    trades, trades_error = _fetch_api_json(
+        api_base_url=api_base_url,
+        path="/trades?limit=200",
+        api_token=api_token,
+    )
+    if trades_error is not None:
+        events.append(("report generation", "/trades unavailable", trades_error))
+        trades = {}
+
+    positions, positions_error = _fetch_api_json(
+        api_base_url=api_base_url,
+        path="/positions",
+        api_token=api_token,
+    )
+    if positions_error is not None:
+        events.append(("report generation", "/positions unavailable", positions_error))
+        positions = {}
+
+    return metrics_from_api_payloads(
+        report_date=report_date,
+        status=status,
+        trades=trades,
+        positions=positions,
+        risk_events=tuple(events),
+    )
 
 
 def render_report(metrics: PaperReportMetrics, *, risk: RiskSettings) -> str:
@@ -103,6 +198,16 @@ def main(argv: list[str] | None = None) -> int:
         help="Directory for the generated Markdown report.",
     )
     parser.add_argument(
+        "--api-base-url",
+        default=DEFAULT_API_BASE_URL,
+        help="PMS API base URL used to populate live paper metrics.",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Render an empty fallback report without calling the PMS API.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the report instead of writing it to disk.",
@@ -111,8 +216,17 @@ def main(argv: list[str] | None = None) -> int:
 
     report_date = date.fromisoformat(args.date)
     settings = PMSSettings.load(args.config)
+    metrics = (
+        PaperReportMetrics.empty(report_date=report_date)
+        if args.offline
+        else load_live_metrics(
+            report_date=report_date,
+            api_base_url=args.api_base_url,
+            api_token=settings.api_token,
+        )
+    )
     report = render_report(
-        PaperReportMetrics.empty(report_date=report_date),
+        metrics,
         risk=settings.risk,
     )
     if args.dry_run:
@@ -152,6 +266,93 @@ def _fmt_ratio_percent(value: float | None) -> str:
     if value is None:
         return "N/A"
     return f"{value * 100.0:.1f}%"
+
+
+def _fetch_api_json(
+    *,
+    api_base_url: str,
+    path: str,
+    api_token: str | None,
+) -> tuple[dict[str, Any], str | None]:
+    url = f"{api_base_url.rstrip('/')}{path}"
+    headers = {"Accept": "application/json"}
+    if api_token:
+        headers["Authorization"] = f"Bearer {api_token}"
+
+    request = Request(url, headers=headers)
+    try:
+        with urlopen(request, timeout=_API_TIMEOUT_S) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        return {}, f"HTTP {exc.code}"
+    except (TimeoutError, URLError, OSError, json.JSONDecodeError) as exc:
+        return {}, exc.__class__.__name__
+
+    if not isinstance(payload, dict):
+        return {}, "invalid JSON payload"
+    return payload, None
+
+
+def _parse_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _dict_value(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
+def _list_value(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _int_from_dict(payload: dict[str, Any], key: str, *, fallback: int = 0) -> int:
+    value = payload.get(key)
+    if isinstance(value, bool):
+        return fallback
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return fallback
+    return fallback
+
+
+def _float_from_dict(payload: dict[str, Any], key: str) -> float:
+    value = _optional_float_from_dict(payload, key)
+    return 0.0 if value is None else value
+
+
+def _optional_float_from_dict(payload: dict[str, Any], key: str) -> float | None:
+    value = payload.get(key)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
 
 
 if __name__ == "__main__":

--- a/src/pms/actuator/adapters/paper.py
+++ b/src/pms/actuator/adapters/paper.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from pms.actuator.risk import InsufficientLiquidityError
 from pms.core.enums import OrderStatus, Side, Venue
-from pms.core.exceptions import KalshiStubError
+from pms.core.exceptions import KalshiStubError  # noqa: F401
 from pms.core.models import OrderState, Portfolio, TradeDecision
 from pms.core.venue_support import kalshi_stub_error
 

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Final, Literal, Protocol, cast
+from typing import Callable, Final, Literal, Protocol, cast
 from uuid import uuid4
 
 from pms.config import PMSSettings, validate_live_mode_ready

--- a/src/pms/api/research_routes.py
+++ b/src/pms/api/research_routes.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 import json
 import os
-from typing import Any, cast
+from typing import cast
 from uuid import UUID
 
 import asyncpg

--- a/src/pms/market_selection/selector.py
+++ b/src/pms/market_selection/selector.py
@@ -5,7 +5,7 @@ import logging
 from typing import Protocol
 
 from pms.core.enums import Venue
-from pms.core.exceptions import KalshiStubError
+from pms.core.exceptions import KalshiStubError  # noqa: F401
 from pms.core.interfaces import MarketDataStore, StrategySelectionRegistry
 from pms.core.models import Market, Token
 from pms.core.venue_support import kalshi_stub_error, normalize_venue

--- a/src/pms/research/comparison.py
+++ b/src/pms/research/comparison.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 import json
-from typing import Any, cast
+from typing import cast
 from uuid import uuid4
 
 import asyncpg

--- a/src/pms/research/entities.py
+++ b/src/pms/research/entities.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 import json
-from typing import Any, Literal, TypeAlias, cast
+from typing import Literal, TypeAlias, cast
 
 
 EvaluationRankingMetric = Literal["brier", "sharpe", "pnl_cum"]

--- a/src/pms/research/report.py
+++ b/src/pms/research/report.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import json
-from typing import Any, cast
+from typing import cast
 from uuid import uuid4
 
 import asyncpg

--- a/src/pms/sensor/adapters/historical.py
+++ b/src/pms/sensor/adapters/historical.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from pms.core.enums import Venue
-from pms.core.exceptions import KalshiStubError
+from pms.core.exceptions import KalshiStubError  # noqa: F401
 from pms.core.models import MarketSignal, Venue as VenueValue
 from pms.core.venue_support import kalshi_stub_error, normalize_venue
 

--- a/src/pms/sensor/adapters/market_data.py
+++ b/src/pms/sensor/adapters/market_data.py
@@ -398,12 +398,18 @@ class MarketDataSensor:
             await websocket.send(json.dumps(_subscription_payload(self._asset_ids)))
 
     def _connect(self) -> Any:
-        try:
-            return connect(self.ws_url, close_timeout=self._CLOSE_TIMEOUT_S)
-        except TypeError as exc:
-            if "close_timeout" not in str(exc):
-                raise
-            return connect(self.ws_url)
+        connect_kwargs: tuple[dict[str, Any], ...] = (
+            {"close_timeout": self._CLOSE_TIMEOUT_S, "proxy": None},
+            {"close_timeout": self._CLOSE_TIMEOUT_S},
+            {},
+        )
+        for kwargs in connect_kwargs:
+            try:
+                return connect(self.ws_url, **kwargs)
+            except TypeError as exc:
+                if not _is_unsupported_connect_kwarg_error(exc):
+                    raise
+        return connect(self.ws_url)
 
     async def _send_subscription_update(
         self,
@@ -517,6 +523,15 @@ def _subscription_payload(asset_ids: list[str]) -> dict[str, Any]:
         "initial_dump": True,
         "level": 2,
     }
+
+
+def _is_unsupported_connect_kwarg_error(exc: TypeError) -> bool:
+    message = str(exc)
+    return (
+        "unexpected keyword argument" in message
+        or "got an unexpected keyword" in message
+        or "takes no keyword arguments" in message
+    )
 
 
 def _subscription_update_payload(

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -13,7 +13,7 @@ import asyncpg
 import httpx
 
 from pms.core.enums import Venue
-from pms.core.exceptions import KalshiStubError
+from pms.core.exceptions import KalshiStubError  # noqa: F401
 from pms.core.models import Market, MarketSignal, Outcome, Token
 from pms.core.models import Venue as VenueValue
 from pms.core.venue_support import kalshi_stub_error, normalize_venue

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime
 import logging
-from typing import Any, cast
+from typing import cast
 
 import asyncpg
 

--- a/tests/integration/test_alembic_baseline_cp02.py
+++ b/tests/integration/test_alembic_baseline_cp02.py
@@ -90,7 +90,7 @@ def _run_pg_dump(database_url: str) -> str:
         shutil.which(f"pg_dump-{major_version}"),
         f"/opt/homebrew/opt/postgresql@{major_version}/bin/pg_dump",
         f"/usr/local/opt/postgresql@{major_version}/bin/pg_dump",
-        f"/opt/homebrew/opt/libpq/bin/pg_dump",
+        "/opt/homebrew/opt/libpq/bin/pg_dump",
     ]
     pg_dump_binary = next(
         (path for path in candidate_paths if path and Path(path).exists()),

--- a/tests/integration/test_alembic_order_intents_cp15.py
+++ b/tests/integration/test_alembic_order_intents_cp15.py
@@ -103,7 +103,7 @@ def _run_pg_dump(database_url: str) -> str:
         shutil.which(f"pg_dump-{major_version}"),
         f"/opt/homebrew/opt/postgresql@{major_version}/bin/pg_dump",
         f"/usr/local/opt/postgresql@{major_version}/bin/pg_dump",
-        f"/opt/homebrew/opt/libpq/bin/pg_dump",
+        "/opt/homebrew/opt/libpq/bin/pg_dump",
     ]
     pg_dump_binary = next(
         (path for path in candidate_paths if path and Path(path).exists()),

--- a/tests/integration/test_alembic_unit_split_cp09.py
+++ b/tests/integration/test_alembic_unit_split_cp09.py
@@ -90,7 +90,7 @@ def _run_pg_dump(database_url: str) -> str:
         shutil.which(f"pg_dump-{major_version}"),
         f"/opt/homebrew/opt/postgresql@{major_version}/bin/pg_dump",
         f"/usr/local/opt/postgresql@{major_version}/bin/pg_dump",
-        f"/opt/homebrew/opt/libpq/bin/pg_dump",
+        "/opt/homebrew/opt/libpq/bin/pg_dump",
     ]
     pg_dump_binary = next(
         (path for path in candidate_paths if path and Path(path).exists()),

--- a/tests/integration/test_market_data_store.py
+++ b/tests/integration/test_market_data_store.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from importlib import import_module
 from typing import Any, cast

--- a/tests/integration/test_markets_route.py
+++ b/tests/integration/test_markets_route.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 from datetime import UTC, datetime, timedelta
-from typing import Any, cast
+from typing import cast
 
 import asyncpg
 import httpx

--- a/tests/integration/test_research_cli_cp06a.py
+++ b/tests/integration/test_research_cli_cp06a.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 from uuid import uuid4
 
 import asyncpg

--- a/tests/integration/test_research_runner_cp04b.py
+++ b/tests/integration/test_research_runner_cp04b.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 import json
 import os
-from typing import Any, cast
+from typing import cast
 from uuid import uuid4
 
 import asyncpg

--- a/tests/unit/test_api_markets.py
+++ b/tests/unit/test_api_markets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any, cast
 
 import httpx

--- a/tests/unit/test_api_positions.py
+++ b/tests/unit/test_api_positions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
 
 import httpx
 import pytest

--- a/tests/unit/test_evaluation_cp07.py
+++ b/tests/unit/test_evaluation_cp07.py
@@ -13,7 +13,6 @@ from pms.evaluation.adapters.scoring import Scorer
 from pms.evaluation.feedback import EvaluatorFeedback
 from pms.evaluation.metrics import (
     MetricsCollector,
-    MetricsSnapshot,
     StrategyMetricsSnapshot,
 )
 from pms.evaluation.spool import EvalSpool

--- a/tests/unit/test_live_trading_blockers.py
+++ b/tests/unit/test_live_trading_blockers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, cast
 

--- a/tests/unit/test_market_data_sensor.py
+++ b/tests/unit/test_market_data_sensor.py
@@ -296,6 +296,7 @@ async def test_market_data_sensor_bounds_websocket_close_timeout(
 
     assert signal.market_id == "m-close-timeout"
     assert captured_kwargs["close_timeout"] == 1.0
+    assert captured_kwargs["proxy"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_paper_report.py
+++ b/tests/unit/test_paper_report.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 
 from pms.config import RiskSettings
-from scripts.paper_report import PaperReportMetrics, render_report
+from scripts.paper_report import PaperReportMetrics, metrics_from_api_payloads, render_report
 
 
 def test_paper_report_renders_empty_day_without_crashing() -> None:
@@ -50,3 +50,58 @@ def test_paper_report_contains_all_gate_three_metrics() -> None:
     assert "| Hit rate (all trades) | 50.0% | > 45% |" in report
     assert "| Average edge (bps) | 35.0 | > 5 |" in report
     assert "| Sharpe ratio (cumulative) | 0.70 | > 0 |" in report
+
+
+def test_metrics_from_api_payloads_uses_live_runner_status() -> None:
+    metrics = metrics_from_api_payloads(
+        report_date=date(2026, 5, 5),
+        status={
+            "mode": "paper",
+            "runner_started_at": "2026-05-03T09:03:03.240858+00:00",
+            "controller": {
+                "decisions_total": 17,
+                "diagnostics_total": 3,
+            },
+            "actuator": {
+                "fills_total": 4,
+            },
+            "evaluator": {
+                "brier_overall": 0.18,
+            },
+        },
+        trades={
+            "trades": [
+                {"fill_notional_usdc": 2.5},
+                {"fill_notional_usdc": 1.5},
+            ],
+        },
+        positions={
+            "positions": [
+                {"locked_usdc": 3.0, "unrealized_pnl": 1.25},
+                {"locked_usdc": 2.0, "unrealized_pnl": -0.25},
+            ],
+        },
+    )
+
+    assert metrics.day_of_soak == 2
+    assert metrics.decisions_made == 17
+    assert metrics.decisions_rejected == 3
+    assert metrics.fills == 4
+    assert metrics.open_positions == 2
+    assert metrics.total_exposure == 5.0
+    assert metrics.cumulative_pnl == 1.0
+    assert metrics.brier_score_7d == 0.18
+
+
+def test_metrics_from_api_payloads_records_missing_status_as_risk_event() -> None:
+    metrics = metrics_from_api_payloads(
+        report_date=date(2026, 5, 5),
+        status={},
+        trades={},
+        positions={},
+    )
+
+    assert metrics.day_of_soak == 0
+    assert metrics.risk_events == (
+        ("report generation", "runner_started_at missing", "check /status"),
+    )

--- a/tests/unit/test_runner_pool_lifecycle.py
+++ b/tests/unit/test_runner_pool_lifecycle.py
@@ -10,7 +10,6 @@ from typing import Any, cast
 import pytest
 
 from pms.config import DatabaseSettings, PMSSettings, RiskSettings
-from pms.controller.pipeline import ControllerPipeline
 from pms.core.enums import MarketStatus, RunMode
 from pms.core.models import MarketSignal
 from pms.runner import Runner

--- a/tests/unit/test_schema_check.py
+++ b/tests/unit/test_schema_check.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-from typing import Any
 
 import asyncpg
 import pytest

--- a/tests/unit/test_share_projection_cp11.py
+++ b/tests/unit/test_share_projection_cp11.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
 
 import pytest
 

--- a/tests/unit/test_strategy_registry.py
+++ b/tests/unit/test_strategy_registry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta, timezone
 import json
-from typing import Any
 
 import pytest
 


### PR DESCRIPTION
## Summary

Fixes the paper soak runner stall where Gamma discovery populated markets but the Polymarket market WebSocket produced zero book snapshots / price changes after 48h.

Changes:
- Disable ambient proxy auto-detection for the public Polymarket market WebSocket by passing `proxy=None` to `websockets.connect`, with compatibility fallback for older/fake connect signatures.
- Make `scripts/paper_report.py` populate metrics from the live PMS API (`/status`, `/trades`, `/positions`) instead of always rendering the static Day 0 empty template.
- Add regression tests for WebSocket connect kwargs and report metric construction from API payloads.
- Apply repo-wide ruff mechanical fixes for the pre-existing 25 lint failures from the audit, keeping Kalshi stub sentinel literals where tests intentionally inspect source strings.

## Verification

Local clean worktree from `origin/main` (`0645b8f`), branch `fix/paper-soak-market-data`:

- `uv run pytest tests/unit/test_market_data_sensor.py tests/unit/test_paper_report.py -q` -> `31 passed`
- `uv run pytest -q` -> `1027 passed, 161 skipped`
- `PMS_RUN_INTEGRATION=1 uv run pytest -m integration -q` -> `18 passed, 144 skipped, 1026 deselected`
- `uv run ruff check src tests scripts` -> clean
- `uv run mypy src/ tests/ --strict` -> clean on 354 files
- `git diff --check` -> clean

Fresh paper-mode smoke against a temporary Postgres DB on port 8024:

- `/status`: `autostart_error=null`, both `MarketDiscoverySensor` and `MarketDataSensor` have non-null `last_signal_at`
- DB counts after ~8s:
  - `markets=500`
  - `tokens=1000`
  - `book_snapshots=103`
  - `book_levels=7145`
  - `price_changes=641`
  - `trades=1`
  - `decisions=0`, `orders=0`, `fills=0`, `eval_records=0`
- `scripts/paper_report.py --date 2026-05-07 --api-base-url http://127.0.0.1:8024 --dry-run` rendered `Day of soak | 2` from live `runner_started_at`.

The temporary DB was dropped and the smoke server was stopped.

## Notes

The runner is no longer blind to live market data. Remaining zero decisions/fills are strict controller gate behavior on real market data, not WebSocket/data-source connectivity failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live metrics reporting that fetches real-time data from configurable API endpoints, with `--api-base-url` and `--offline` flag support for fallback reporting.

* **Improvements**
  * Enhanced websocket connection resilience with improved fallback handling for unsupported connection arguments.

* **Refactor**
  * Cleaned up unused imports across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->