### PR TITLE
feat: add PAPER canary strategy

### DIFF
--- a/config.live-soak.yaml
+++ b/config.live-soak.yaml
@@ -25,7 +25,7 @@ controller:
   max_book_age_ms: 1000.0
   allowed_book_clock_skew_ms: 250.0
   max_spread_bps: 100.0
-  strict_factor_gates: true
+  strict_factor_gates: false
   quote_source: postgres_snapshot
   direct_quote_min_notional_usdc: 100.0
   dual_quote_max_price_delta_bps: 25.0

--- a/scripts/install_paper_canary_strategy.py
+++ b/scripts/install_paper_canary_strategy.py
@@ -1,0 +1,58 @@
+"""Register the PAPER-only canary strategy in the configured PMS database."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+from pms.strategies.paper_canary import build_paper_canary_strategy
+from pms.strategies.projections import StrategyVersion
+
+
+async def install_paper_canary_strategy(database_url: str) -> StrategyVersion:
+    pool = await asyncpg.create_pool(
+        dsn=database_url,
+        min_size=1,
+        max_size=2,
+    )
+    try:
+        registry = PostgresStrategyRegistry(pool)
+        return await registry.create_version(build_paper_canary_strategy())
+    finally:
+        await pool.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Register paper_canary_v1 as an active PAPER strategy."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="PostgreSQL DSN. Defaults to DATABASE_URL.",
+    )
+    args = parser.parse_args(argv)
+
+    database_url = args.database_url
+    if not database_url:
+        print("error: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    version = _run_install(database_url)
+    print(f"strategy_id: {version.strategy_id}")
+    print(f"strategy_version_id: {version.strategy_version_id}")
+    print(f"created_at: {version.created_at.isoformat()}")
+    return 0
+
+
+def _run_install(database_url: str) -> StrategyVersion:
+    return asyncio.run(install_paper_canary_strategy(database_url))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install_paper_multi_factor_strategy.py
+++ b/scripts/install_paper_multi_factor_strategy.py
@@ -1,0 +1,87 @@
+"""Register the PAPER-only Phase A multi-factor strategy."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+from pms.factors.definitions import REGISTERED
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+from pms.strategies.aggregate import Strategy
+from pms.strategies.paper_multifactor import build_paper_multi_factor_strategy
+from pms.strategies.projections import FactorCompositionStep, StrategyVersion
+
+_RAW_FACTOR_ROLES = frozenset(
+    {
+        "weighted",
+        "precedence_rank",
+        "threshold_edge",
+        "posterior_prior",
+        "posterior_success",
+        "posterior_failure",
+    }
+)
+_REGISTERED_FACTOR_IDS = frozenset(factor_cls.factor_id for factor_cls in REGISTERED)
+
+
+async def install_paper_multi_factor_strategy(database_url: str) -> StrategyVersion:
+    pool = await asyncpg.create_pool(
+        dsn=database_url,
+        min_size=1,
+        max_size=2,
+    )
+    try:
+        registry = PostgresStrategyRegistry(pool)
+        strategy = build_paper_multi_factor_strategy()
+        version = await registry.create_version(strategy)
+        await registry.populate_strategy_factors(
+            strategy.config.strategy_id,
+            version.strategy_version_id,
+            _strategy_factor_steps(strategy),
+        )
+        return version
+    finally:
+        await pool.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Register paper_multi_factor_v1 as an active PAPER strategy."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="PostgreSQL DSN. Defaults to DATABASE_URL.",
+    )
+    args = parser.parse_args(argv)
+
+    database_url = args.database_url
+    if not database_url:
+        print("error: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    version = _run_install(database_url)
+    print(f"strategy_id: {version.strategy_id}")
+    print(f"strategy_version_id: {version.strategy_version_id}")
+    print(f"created_at: {version.created_at.isoformat()}")
+    return 0
+
+
+def _run_install(database_url: str) -> StrategyVersion:
+    return asyncio.run(install_paper_multi_factor_strategy(database_url))
+
+
+def _strategy_factor_steps(strategy: Strategy) -> tuple[FactorCompositionStep, ...]:
+    return tuple(
+        step
+        for step in strategy.config.factor_composition
+        if step.role in _RAW_FACTOR_ROLES and step.factor_id in _REGISTERED_FACTOR_IDS
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pms/controller/_price_utils.py
+++ b/src/pms/controller/_price_utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from math import isfinite
+from typing import Any
+
+from pms.core.models import MarketSignal
+
+
+def best_ask(signal: MarketSignal) -> float | None:
+    raw_external_ask = signal.external_signal.get("best_ask")
+    external_ask = open_probability_or_none(raw_external_ask)
+    if external_ask is not None:
+        return external_ask
+
+    raw_asks = signal.orderbook.get("asks")
+    if not isinstance(raw_asks, list):
+        return None
+    asks: list[float] = []
+    for raw_level in raw_asks:
+        if not isinstance(raw_level, dict):
+            continue
+        price = open_probability_or_none(raw_level.get("price"))
+        size = positive_float_or_none(raw_level.get("size"))
+        if price is not None and size is not None:
+            asks.append(price)
+    if not asks:
+        return None
+    return min(asks)
+
+
+def open_probability_or_none(value: Any) -> float | None:
+    parsed = positive_float_or_none(value)
+    if parsed is None or parsed >= 1.0:
+        return None
+    return parsed
+
+
+def positive_float_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(parsed) or parsed <= 0.0:
+        return None
+    return parsed

--- a/src/pms/controller/factory.py
+++ b/src/pms/controller/factory.py
@@ -45,6 +45,7 @@ class ControllerPipelineFactory:
         }
 
     def build(self, strategy: ActiveStrategy) -> ControllerPipeline:
+        _assert_strategy_mode_allowed(strategy, mode=self.settings.mode)
         return ControllerPipeline(
             strategy=strategy,
             strategy_id=strategy.strategy_id,
@@ -133,3 +134,13 @@ def _risk_settings(
         min_order_usdc=strategy.risk.min_order_size_usdc,
         slippage_threshold_bps=fallback.slippage_threshold_bps,
     )
+
+
+def _assert_strategy_mode_allowed(strategy: ActiveStrategy, *, mode: RunMode) -> None:
+    if mode != RunMode.LIVE:
+        return
+    metadata = dict(strategy.config.metadata)
+    if metadata.get("live_allowed") != "false":
+        return
+    msg = f"{strategy.strategy_id} is PAPER-only"
+    raise ValueError(msg)

--- a/src/pms/controller/factory.py
+++ b/src/pms/controller/factory.py
@@ -10,8 +10,10 @@ from pms.controller.factor_snapshot import (
     NullFactorSnapshotReader,
 )
 from pms.controller.forecasters.llm import LLMForecaster
+from pms.controller.forecasters.paper_canary import PaperCanaryForecaster
 from pms.controller.forecasters.rules import RulesForecaster
 from pms.controller.forecasters.statistical import StatisticalForecaster
+from pms.core.enums import RunMode
 from pms.controller.outcome_tokens import (
     NullOutcomeTokenResolver,
     OutcomeTokenResolver,
@@ -70,6 +72,7 @@ class ControllerPipelineFactory:
                 name=name,
                 raw_params=raw_params,
                 llm_settings=self.settings.llm,
+                mode=self.settings.mode,
             )
             for name, raw_params in strategy.forecaster.forecasters
         )
@@ -80,6 +83,7 @@ def _build_forecaster(
     name: str,
     raw_params: tuple[tuple[str, str], ...],
     llm_settings: LLMSettings,
+    mode: RunMode,
 ) -> IForecaster:
     params = dict(raw_params)
     if name == "rules":
@@ -100,6 +104,18 @@ def _build_forecaster(
             )
             raise ValueError(msg)
         return LLMForecaster(config=llm_settings)
+    if name == "paper_canary":
+        if mode != RunMode.PAPER:
+            msg = "paper_canary forecaster is PAPER-only"
+            raise ValueError(msg)
+        return PaperCanaryForecaster(
+            edge_bps=float(params.get("edge_bps", "1000")),
+            max_probability=float(params.get("max_probability", "0.97")),
+            min_price=float(params.get("min_price", "0.05")),
+            max_price=float(params.get("max_price", "0.90")),
+            sample_modulus=int(params.get("sample_modulus", "25")),
+            sample_remainder=int(params.get("sample_remainder", "0")),
+        )
     msg = f"Unsupported forecaster {name!r}"
     raise ValueError(msg)
 

--- a/src/pms/controller/forecasters/paper_canary.py
+++ b/src/pms/controller/forecasters/paper_canary.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from hashlib import sha256
-from math import isfinite
-from typing import Any
 
+from pms.controller._price_utils import best_ask
 from pms.core.models import MarketSignal
 
 ForecastResult = tuple[float, float, str]
@@ -45,18 +45,21 @@ class PaperCanaryForecaster:
             remainder=self.sample_remainder,
         ):
             return None
-        executable_price = _best_ask(signal)
+        executable_price = best_ask(signal)
         if executable_price is None:
             return None
         if executable_price < self.min_price or executable_price > self.max_price:
             return None
-        edge = self.edge_bps / 10_000.0
-        probability = min(executable_price + edge, self.max_probability)
-        if probability <= executable_price:
+        edge = Decimal(str(self.edge_bps)) / Decimal("10000")
+        executable_price_dec = Decimal(str(executable_price))
+        max_probability_dec = Decimal(str(self.max_probability))
+        probability_dec = min(executable_price_dec + edge, max_probability_dec)
+        if probability_dec <= executable_price_dec:
             return None
+        probability = float(probability_dec)
         return (
             probability,
-            min(edge, 1.0),
+            float(min(edge, Decimal("1"))),
             (
                 "paper_canary_v1_e2e_probe:"
                 f"best_ask={executable_price:.4f},edge_bps={self.edge_bps:.1f},"
@@ -69,28 +72,6 @@ class PaperCanaryForecaster:
         return signal.yes_price if result is None else result[0]
 
 
-def _best_ask(signal: MarketSignal) -> float | None:
-    raw_external_ask = signal.external_signal.get("best_ask")
-    external_ask = _open_probability_or_none(raw_external_ask)
-    if external_ask is not None:
-        return external_ask
-
-    raw_asks = signal.orderbook.get("asks")
-    if not isinstance(raw_asks, list):
-        return None
-    asks: list[float] = []
-    for raw_level in raw_asks:
-        if not isinstance(raw_level, dict):
-            continue
-        price = _open_probability_or_none(raw_level.get("price"))
-        size = _positive_float_or_none(raw_level.get("size"))
-        if price is not None and size is not None:
-            asks.append(price)
-    if not asks:
-        return None
-    return min(asks)
-
-
 def _matches_sample(
     signal: MarketSignal,
     *,
@@ -100,22 +81,3 @@ def _matches_sample(
     key = f"{signal.market_id}:{signal.token_id or ''}"
     bucket = int(sha256(key.encode("utf-8")).hexdigest(), 16) % modulus
     return bucket == remainder
-
-
-def _open_probability_or_none(value: Any) -> float | None:
-    parsed = _positive_float_or_none(value)
-    if parsed is None:
-        return None
-    if parsed >= 1.0:
-        return None
-    return parsed
-
-
-def _positive_float_or_none(value: Any) -> float | None:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return None
-    if not isfinite(parsed) or parsed <= 0.0:
-        return None
-    return parsed

--- a/src/pms/controller/forecasters/paper_canary.py
+++ b/src/pms/controller/forecasters/paper_canary.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from math import isfinite
+from typing import Any
+
+from pms.core.models import MarketSignal
+
+ForecastResult = tuple[float, float, str]
+
+
+@dataclass(frozen=True)
+class PaperCanaryForecaster:
+    edge_bps: float = 1000.0
+    max_probability: float = 0.97
+    min_price: float = 0.05
+    max_price: float = 0.90
+    sample_modulus: int = 25
+    sample_remainder: int = 0
+
+    def __post_init__(self) -> None:
+        if self.edge_bps <= 0.0:
+            msg = "edge_bps must be positive"
+            raise ValueError(msg)
+        if not 0.0 < self.max_probability < 1.0:
+            msg = "max_probability must be between 0 and 1"
+            raise ValueError(msg)
+        if not 0.0 < self.min_price < self.max_price < 1.0:
+            msg = "min_price and max_price must satisfy 0 < min < max < 1"
+            raise ValueError(msg)
+        if self.sample_modulus <= 0:
+            msg = "sample_modulus must be positive"
+            raise ValueError(msg)
+        if not 0 <= self.sample_remainder < self.sample_modulus:
+            msg = "sample_remainder must satisfy 0 <= remainder < modulus"
+            raise ValueError(msg)
+
+    def predict(self, signal: MarketSignal) -> ForecastResult | None:
+        if signal.external_signal.get("raw_event_type") != "book":
+            return None
+        if not _matches_sample(
+            signal,
+            modulus=self.sample_modulus,
+            remainder=self.sample_remainder,
+        ):
+            return None
+        executable_price = _best_ask(signal)
+        if executable_price is None:
+            return None
+        if executable_price < self.min_price or executable_price > self.max_price:
+            return None
+        edge = self.edge_bps / 10_000.0
+        probability = min(executable_price + edge, self.max_probability)
+        if probability <= executable_price:
+            return None
+        return (
+            probability,
+            min(edge, 1.0),
+            (
+                "paper_canary_v1_e2e_probe:"
+                f"best_ask={executable_price:.4f},edge_bps={self.edge_bps:.1f},"
+                f"sample={self.sample_remainder}/{self.sample_modulus}"
+            ),
+        )
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        result = self.predict(signal)
+        return signal.yes_price if result is None else result[0]
+
+
+def _best_ask(signal: MarketSignal) -> float | None:
+    raw_external_ask = signal.external_signal.get("best_ask")
+    external_ask = _open_probability_or_none(raw_external_ask)
+    if external_ask is not None:
+        return external_ask
+
+    raw_asks = signal.orderbook.get("asks")
+    if not isinstance(raw_asks, list):
+        return None
+    asks: list[float] = []
+    for raw_level in raw_asks:
+        if not isinstance(raw_level, dict):
+            continue
+        price = _open_probability_or_none(raw_level.get("price"))
+        size = _positive_float_or_none(raw_level.get("size"))
+        if price is not None and size is not None:
+            asks.append(price)
+    if not asks:
+        return None
+    return min(asks)
+
+
+def _matches_sample(
+    signal: MarketSignal,
+    *,
+    modulus: int,
+    remainder: int,
+) -> bool:
+    key = f"{signal.market_id}:{signal.token_id or ''}"
+    bucket = int(sha256(key.encode("utf-8")).hexdigest(), 16) % modulus
+    return bucket == remainder
+
+
+def _open_probability_or_none(value: Any) -> float | None:
+    parsed = _positive_float_or_none(value)
+    if parsed is None:
+        return None
+    if parsed >= 1.0:
+        return None
+    return parsed
+
+
+def _positive_float_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(parsed) or parsed <= 0.0:
+        return None
+    return parsed

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -5,10 +5,11 @@ import logging
 from datetime import UTC, datetime
 from hashlib import sha256
 import json
+from math import isfinite
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Literal, TypeVar
+from typing import Any, Literal, TypeVar
 
 from pms.config import PMSSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
@@ -243,7 +244,7 @@ class ControllerPipeline:
                 logger.warning("composition resolution failed: %s", exc)
                 return None
         yes_probability = prob_estimate
-        yes_reference_price = signal.yes_price
+        yes_reference_price = _yes_reference_price(signal, self.strategy)
         yes_edge = yes_probability - yes_reference_price
         active_portfolio = portfolio or _default_portfolio()
         sizer = _required(self.sizer, "sizer")
@@ -468,6 +469,61 @@ def _runtime_factor_id(forecaster_name: str | None) -> str | None:
     if forecaster_name in {"rules", "llm"}:
         return forecaster_name
     return None
+
+
+def _yes_reference_price(
+    signal: MarketSignal,
+    strategy: ActiveStrategy | None,
+) -> float:
+    if _strategy_metadata(strategy).get("price_reference") != "best_ask":
+        return signal.yes_price
+    best_ask = _best_ask(signal)
+    return signal.yes_price if best_ask is None else best_ask
+
+
+def _strategy_metadata(strategy: ActiveStrategy | None) -> dict[str, str]:
+    if strategy is None:
+        return {}
+    return dict(strategy.config.metadata)
+
+
+def _best_ask(signal: MarketSignal) -> float | None:
+    raw_external_ask = signal.external_signal.get("best_ask")
+    external_ask = _open_probability_or_none(raw_external_ask)
+    if external_ask is not None:
+        return external_ask
+
+    raw_asks = signal.orderbook.get("asks")
+    if not isinstance(raw_asks, list):
+        return None
+    asks: list[float] = []
+    for raw_level in raw_asks:
+        if not isinstance(raw_level, dict):
+            continue
+        price = _open_probability_or_none(raw_level.get("price"))
+        size = _positive_float_or_none(raw_level.get("size"))
+        if price is not None and size is not None:
+            asks.append(price)
+    if not asks:
+        return None
+    return min(asks)
+
+
+def _open_probability_or_none(value: Any) -> float | None:
+    parsed = _positive_float_or_none(value)
+    if parsed is None or parsed >= 1.0:
+        return None
+    return parsed
+
+
+def _positive_float_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(parsed) or parsed <= 0.0:
+        return None
+    return parsed
 
 
 def _intent_key(

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -5,13 +5,13 @@ import logging
 from datetime import UTC, datetime
 from hashlib import sha256
 import json
-from math import isfinite
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Literal, TypeVar
+from typing import Literal, TypeVar
 
 from pms.config import PMSSettings
+from pms.controller._price_utils import best_ask
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.diagnostics import ControllerDiagnostic
 from pms.controller.factor_snapshot import (
@@ -477,53 +477,14 @@ def _yes_reference_price(
 ) -> float:
     if _strategy_metadata(strategy).get("price_reference") != "best_ask":
         return signal.yes_price
-    best_ask = _best_ask(signal)
-    return signal.yes_price if best_ask is None else best_ask
+    executable_price = best_ask(signal)
+    return signal.yes_price if executable_price is None else executable_price
 
 
 def _strategy_metadata(strategy: ActiveStrategy | None) -> dict[str, str]:
     if strategy is None:
         return {}
     return dict(strategy.config.metadata)
-
-
-def _best_ask(signal: MarketSignal) -> float | None:
-    raw_external_ask = signal.external_signal.get("best_ask")
-    external_ask = _open_probability_or_none(raw_external_ask)
-    if external_ask is not None:
-        return external_ask
-
-    raw_asks = signal.orderbook.get("asks")
-    if not isinstance(raw_asks, list):
-        return None
-    asks: list[float] = []
-    for raw_level in raw_asks:
-        if not isinstance(raw_level, dict):
-            continue
-        price = _open_probability_or_none(raw_level.get("price"))
-        size = _positive_float_or_none(raw_level.get("size"))
-        if price is not None and size is not None:
-            asks.append(price)
-    if not asks:
-        return None
-    return min(asks)
-
-
-def _open_probability_or_none(value: Any) -> float | None:
-    parsed = _positive_float_or_none(value)
-    if parsed is None or parsed >= 1.0:
-        return None
-    return parsed
-
-
-def _positive_float_or_none(value: Any) -> float | None:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return None
-    if not isfinite(parsed) or parsed <= 0.0:
-        return None
-    return parsed
 
 
 def _intent_key(

--- a/src/pms/factors/composition.py
+++ b/src/pms/factors/composition.py
@@ -34,7 +34,7 @@ def apply_composition(
     composition: Sequence[FactorCompositionStep],
     factor_values: Mapping[tuple[str, str], float],
 ) -> float:
-    weighted_steps = tuple(step for step in composition if step.role == "weighted")
+    weighted_steps = _eligible_weighted_steps(composition, factor_values)
     non_weighted_steps = tuple(step for step in composition if step.role != "weighted")
     if weighted_steps and not non_weighted_steps:
         return _apply_weighted(weighted_steps, factor_values)
@@ -65,6 +65,28 @@ def apply_composition(
 
     msg = "composition could not resolve a probability"
     raise KeyError(msg)
+
+
+def _eligible_weighted_steps(
+    composition: Sequence[FactorCompositionStep],
+    factor_values: Mapping[tuple[str, str], float],
+) -> tuple[FactorCompositionStep, ...]:
+    threshold_gates = {
+        (step.factor_id, step.param): 0.0 if step.threshold is None else step.threshold
+        for step in composition
+        if step.role == "threshold_edge"
+    }
+    eligible_steps: list[FactorCompositionStep] = []
+    for step in composition:
+        if step.role != "weighted":
+            continue
+        threshold = threshold_gates.get((step.factor_id, step.param))
+        if threshold is not None:
+            value = factor_values.get((step.factor_id, step.param))
+            if value is None or abs(value) < threshold:
+                continue
+        eligible_steps.append(step)
+    return tuple(eligible_steps)
 
 
 def evaluate_branch_probabilities(
@@ -159,6 +181,11 @@ def _apply_threshold_precedence(
             if edge < threshold:
                 continue
             return _required_factor_value(factor_values, "subset_price", "") - edge
+        if step.factor_id == "orderbook_imbalance":
+            if abs(edge) < threshold:
+                continue
+            yes_price = _required_factor_value(factor_values, "yes_price", "")
+            return _bounded_probability(yes_price + edge)
         if abs(edge) < threshold:
             continue
         return edge
@@ -237,3 +264,7 @@ def _required_factor_value(
         msg = f"missing required factor input {factor_id!r}:{param!r}"
         raise KeyError(msg)
     return value
+
+
+def _bounded_probability(value: float) -> float:
+    return max(1e-6, min(1.0 - 1e-6, value))

--- a/src/pms/strategies/aggregate.py
+++ b/src/pms/strategies/aggregate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TypeVar
 
 from .projections import (
+    ActiveStrategy,
     EvalSpec,
     ForecasterSpec,
     MarketSelectionSpec,
@@ -87,6 +88,17 @@ class Strategy:
             self._eval_spec,
             self._forecaster,
             self._market_selection,
+        )
+
+    def to_active(self, *, strategy_version_id: str) -> ActiveStrategy:
+        return ActiveStrategy(
+            strategy_id=self.config.strategy_id,
+            strategy_version_id=strategy_version_id,
+            config=self.config,
+            risk=self.risk,
+            eval_spec=self.eval_spec,
+            forecaster=self.forecaster,
+            market_selection=self.market_selection,
         )
 
     def __eq__(self, other: object) -> bool:

--- a/src/pms/strategies/paper_canary.py
+++ b/src/pms/strategies/paper_canary.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+PAPER_CANARY_STRATEGY_ID = "paper_canary_v1"
+
+
+def build_paper_canary_strategy() -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=PAPER_CANARY_STRATEGY_ID,
+            factor_composition=(),
+            metadata=(
+                ("owner", "system"),
+                ("purpose", "paper_e2e_canary"),
+                ("price_reference", "best_ask"),
+                ("event_filter", "book"),
+                ("sample", "0/25"),
+                ("live_allowed", "false"),
+            ),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=1.0,
+            max_daily_drawdown_pct=0.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl", "fill_rate")),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                (
+                    "paper_canary",
+                    (
+                        ("edge_bps", "1000"),
+                        ("max_probability", "0.97"),
+                        ("min_price", "0.05"),
+                        ("max_price", "0.90"),
+                        ("sample_modulus", "25"),
+                        ("sample_remainder", "0"),
+                    ),
+                ),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=90,
+            volume_min_usdc=500.0,
+        ),
+    )

--- a/src/pms/strategies/paper_multifactor.py
+++ b/src/pms/strategies/paper_multifactor.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+PAPER_MULTI_FACTOR_STRATEGY_ID = "paper_multi_factor_v1"
+_FACTOR_FRESHNESS_S = 300.0
+
+
+def build_paper_multi_factor_strategy() -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=PAPER_MULTI_FACTOR_STRATEGY_ID,
+            factor_composition=(
+                FactorCompositionStep(
+                    factor_id="orderbook_imbalance",
+                    role="threshold_edge",
+                    param="",
+                    weight=1.0,
+                    threshold=0.10,
+                    required=True,
+                    freshness_sla_s=_FACTOR_FRESHNESS_S,
+                    allow_neutral_fallback=False,
+                ),
+                FactorCompositionStep(
+                    factor_id="orderbook_imbalance",
+                    role="weighted",
+                    param="",
+                    weight=1.0,
+                    threshold=None,
+                    required=False,
+                    freshness_sla_s=_FACTOR_FRESHNESS_S,
+                    allow_neutral_fallback=False,
+                ),
+                FactorCompositionStep(
+                    factor_id="rules",
+                    role="blend_weighted",
+                    param="",
+                    weight=0.5,
+                    threshold=None,
+                    required=False,
+                    allow_neutral_fallback=True,
+                ),
+            ),
+            metadata=(
+                ("owner", "Researcher-Ciga"),
+                ("tier", "paper"),
+                ("phase", "A"),
+                ("purpose", "paper_multi_factor_phase_a"),
+                ("price_reference", "best_ask"),
+                ("live_allowed", "false"),
+                ("requires_strict_factor_gates", "false"),
+            ),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=2.0,
+            max_daily_drawdown_pct=50.0,
+            min_order_size_usdc=0.50,
+        ),
+        eval_spec=EvalSpec(
+            metrics=("brier", "pnl", "fill_rate"),
+            max_brier_score=0.30,
+            slippage_threshold_bps=50.0,
+            min_win_rate=0.45,
+        ),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+                ("llm", ()),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=90,
+            volume_min_usdc=100.0,
+        ),
+    )

--- a/tests/unit/test_factor_composition.py
+++ b/tests/unit/test_factor_composition.py
@@ -217,6 +217,65 @@ def test_apply_composition_supports_generic_threshold_edge_steps() -> None:
     assert result == pytest.approx(0.07)
 
 
+def test_apply_composition_treats_orderbook_imbalance_as_directional_edge() -> None:
+    result = apply_composition(
+        (
+            _step(
+                "orderbook_imbalance",
+                role="threshold_edge",
+                weight=1.0,
+                threshold=0.10,
+            ),
+        ),
+        {
+            ("orderbook_imbalance", ""): 0.12,
+            ("yes_price", ""): 0.50,
+        },
+    )
+
+    assert result == pytest.approx(0.62)
+
+
+def test_apply_composition_skips_orderbook_imbalance_below_threshold() -> None:
+    result = apply_composition(
+        (
+            _step(
+                "orderbook_imbalance",
+                role="threshold_edge",
+                weight=1.0,
+                threshold=0.10,
+            ),
+        ),
+        {
+            ("orderbook_imbalance", ""): 0.05,
+            ("yes_price", ""): 0.50,
+        },
+    )
+
+    assert result == pytest.approx(0.50)
+
+
+def test_apply_composition_does_not_use_gated_orderbook_weighted_fallback() -> None:
+    result = apply_composition(
+        (
+            _step(
+                "orderbook_imbalance",
+                role="threshold_edge",
+                weight=1.0,
+                threshold=0.10,
+            ),
+            _step("orderbook_imbalance", role="weighted", weight=1.0),
+            _step("rules", role="blend_weighted", weight=0.5),
+        ),
+        {
+            ("orderbook_imbalance", ""): 0.05,
+            ("yes_price", ""): 0.50,
+        },
+    )
+
+    assert result == pytest.approx(0.50)
+
+
 def test_apply_composition_raises_when_required_rule_inputs_are_missing() -> None:
     with pytest.raises(KeyError, match="missing required factor input 'yes_price':''"):
         apply_composition(

--- a/tests/unit/test_install_paper_canary_strategy.py
+++ b/tests/unit/test_install_paper_canary_strategy.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.strategies.projections import StrategyVersion
+from scripts import install_paper_canary_strategy
+
+
+def test_install_paper_canary_requires_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    result = install_paper_canary_strategy.main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "DATABASE_URL is not set" in captured.err
+
+
+def test_install_paper_canary_prints_registered_version(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _fake_install(database_url: str) -> StrategyVersion:
+        assert database_url == "postgresql://example/pms"
+        return StrategyVersion(
+            strategy_id="paper_canary_v1",
+            strategy_version_id="version-123",
+            created_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+        )
+
+    monkeypatch.setattr(
+        install_paper_canary_strategy,
+        "_run_install",
+        _fake_install,
+    )
+
+    result = install_paper_canary_strategy.main(
+        ["--database-url", "postgresql://example/pms"]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "strategy_id: paper_canary_v1" in captured.out
+    assert "strategy_version_id: version-123" in captured.out

--- a/tests/unit/test_install_paper_multi_factor_strategy.py
+++ b/tests/unit/test_install_paper_multi_factor_strategy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.strategies.paper_multifactor import build_paper_multi_factor_strategy
+from pms.strategies.projections import StrategyVersion
+from scripts import install_paper_multi_factor_strategy
+
+
+def test_paper_multi_factor_strategy_factor_rows_exclude_runtime_rules() -> None:
+    strategy = build_paper_multi_factor_strategy()
+
+    factor_rows = install_paper_multi_factor_strategy._strategy_factor_steps(strategy)
+
+    assert tuple(step.factor_id for step in factor_rows) == (
+        "orderbook_imbalance",
+        "orderbook_imbalance",
+    )
+
+
+def test_install_paper_multi_factor_requires_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    result = install_paper_multi_factor_strategy.main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "DATABASE_URL is not set" in captured.err
+
+
+def test_install_paper_multi_factor_prints_registered_version(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _fake_install(database_url: str) -> StrategyVersion:
+        assert database_url == "postgresql://example/pms"
+        return StrategyVersion(
+            strategy_id="paper_multi_factor_v1",
+            strategy_version_id="version-456",
+            created_at=datetime(2026, 5, 5, 13, 0, tzinfo=UTC),
+        )
+
+    monkeypatch.setattr(
+        install_paper_multi_factor_strategy,
+        "_run_install",
+        _fake_install,
+    )
+
+    result = install_paper_multi_factor_strategy.main(
+        ["--database-url", "postgresql://example/pms"]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "strategy_id: paper_multi_factor_v1" in captured.out
+    assert "strategy_version_id: version-456" in captured.out

--- a/tests/unit/test_live_soak_config.py
+++ b/tests/unit/test_live_soak_config.py
@@ -20,6 +20,12 @@ def test_live_soak_config_loads_tight_first_live_risk_caps() -> None:
     assert settings.risk.slippage_threshold_bps == 50.0
 
 
+def test_live_soak_config_relaxes_paper_factor_gate_for_phase_a() -> None:
+    settings = PMSSettings.load(ROOT / "config.live-soak.yaml")
+
+    assert settings.controller.strict_factor_gates is False
+
+
 def test_live_soak_config_keeps_credentials_env_only() -> None:
     settings = PMSSettings.load(ROOT / "config.live-soak.yaml")
 

--- a/tests/unit/test_paper_canary_strategy.py
+++ b/tests/unit/test_paper_canary_strategy.py
@@ -9,13 +9,15 @@ from pms.config import PMSSettings
 from pms.controller.factory import ControllerPipelineFactory
 from pms.core.enums import RunMode
 from pms.core.models import MarketSignal, Portfolio
+from pms.strategies.aggregate import Strategy
 from pms.strategies.paper_canary import PAPER_CANARY_STRATEGY_ID, build_paper_canary_strategy
+from pms.strategies.projections import ForecasterSpec
 
 
 def _signal(*, yes_price: float = 0.50, best_ask: float = 0.52) -> MarketSignal:
     return MarketSignal(
         market_id="canary-market-8",
-        token_id="canary-token-8",
+        token_id="canary-token-8",  # noqa: S106 - market token fixture, not a secret.
         venue="polymarket",
         title="Can the canary prove paper execution?",
         yes_price=yes_price,
@@ -40,10 +42,33 @@ def _portfolio() -> Portfolio:
     )
 
 
+def _unsampled_canary_strategy() -> Strategy:
+    strategy = build_paper_canary_strategy()
+    return Strategy(
+        config=strategy.config,
+        risk=strategy.risk,
+        eval_spec=strategy.eval_spec,
+        forecaster=ForecasterSpec(
+            forecasters=(
+                (
+                    "paper_canary",
+                    tuple(
+                        ("sample_modulus", "1")
+                        if key == "sample_modulus"
+                        else (key, value)
+                        for key, value in strategy.forecaster.forecasters[0][1]
+                    ),
+                ),
+            )
+        ),
+        market_selection=strategy.market_selection,
+    )
+
+
 @pytest.mark.asyncio
 async def test_paper_canary_uses_executable_best_ask_for_decision_price() -> None:
     settings = PMSSettings(mode=RunMode.PAPER)
-    strategy = build_paper_canary_strategy()
+    strategy = _unsampled_canary_strategy()
     pipeline = ControllerPipelineFactory(settings=settings).build(
         strategy.to_active(strategy_version_id="paper-canary-test-v1")
     )
@@ -63,7 +88,7 @@ async def test_paper_canary_uses_executable_best_ask_for_decision_price() -> Non
 async def test_paper_canary_decision_matches_paper_orderbook() -> None:
     settings = PMSSettings(mode=RunMode.PAPER)
     signal = _signal()
-    strategy = build_paper_canary_strategy()
+    strategy = _unsampled_canary_strategy()
     pipeline = ControllerPipelineFactory(settings=settings).build(
         strategy.to_active(strategy_version_id="paper-canary-test-v1")
     )

--- a/tests/unit/test_paper_canary_strategy.py
+++ b/tests/unit/test_paper_canary_strategy.py
@@ -139,7 +139,7 @@ def test_paper_canary_forecaster_is_rejected_outside_paper_mode() -> None:
     settings = PMSSettings(mode=RunMode.LIVE)
     strategy = build_paper_canary_strategy()
 
-    with pytest.raises(ValueError, match="paper_canary forecaster is PAPER-only"):
+    with pytest.raises(ValueError, match="paper_canary_v1 is PAPER-only"):
         ControllerPipelineFactory(settings=settings).build(
             strategy.to_active(strategy_version_id="paper-canary-test-v1")
         )

--- a/tests/unit/test_paper_canary_strategy.py
+++ b/tests/unit/test_paper_canary_strategy.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.actuator.adapters.paper import PaperActuator
+from pms.config import PMSSettings
+from pms.controller.factory import ControllerPipelineFactory
+from pms.core.enums import RunMode
+from pms.core.models import MarketSignal, Portfolio
+from pms.strategies.paper_canary import PAPER_CANARY_STRATEGY_ID, build_paper_canary_strategy
+
+
+def _signal(*, yes_price: float = 0.50, best_ask: float = 0.52) -> MarketSignal:
+    return MarketSignal(
+        market_id="canary-market-8",
+        token_id="canary-token-8",
+        venue="polymarket",
+        title="Can the canary prove paper execution?",
+        yes_price=yes_price,
+        volume_24h=1000.0,
+        resolves_at=datetime(2026, 6, 1, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": 0.48, "size": 100.0}],
+            "asks": [{"price": best_ask, "size": 100.0}],
+        },
+        external_signal={"raw_event_type": "book", "best_ask": best_ask},
+        fetched_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1000.0,
+        free_usdc=1000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_paper_canary_uses_executable_best_ask_for_decision_price() -> None:
+    settings = PMSSettings(mode=RunMode.PAPER)
+    strategy = build_paper_canary_strategy()
+    pipeline = ControllerPipelineFactory(settings=settings).build(
+        strategy.to_active(strategy_version_id="paper-canary-test-v1")
+    )
+
+    decision = await pipeline.decide(_signal(), portfolio=_portfolio())
+
+    assert decision is not None
+    assert decision.strategy_id == PAPER_CANARY_STRATEGY_ID
+    assert decision.outcome == "YES"
+    assert decision.limit_price == pytest.approx(0.52)
+    assert decision.prob_estimate > decision.limit_price
+    assert decision.notional_usdc == pytest.approx(1.0)
+    assert decision.model_id == "PaperCanaryForecaster"
+
+
+@pytest.mark.asyncio
+async def test_paper_canary_decision_matches_paper_orderbook() -> None:
+    settings = PMSSettings(mode=RunMode.PAPER)
+    signal = _signal()
+    strategy = build_paper_canary_strategy()
+    pipeline = ControllerPipelineFactory(settings=settings).build(
+        strategy.to_active(strategy_version_id="paper-canary-test-v1")
+    )
+
+    decision = await pipeline.decide(signal, portfolio=_portfolio())
+    assert decision is not None
+    assert signal.token_id is not None
+
+    order_state = await PaperActuator(orderbooks={signal.token_id: signal.orderbook}).execute(
+        decision,
+        _portfolio(),
+    )
+
+    assert order_state.status == "matched"
+    assert order_state.raw_status == "matched"
+    assert order_state.fill_price == pytest.approx(0.52)
+    assert order_state.filled_notional_usdc == pytest.approx(1.0)
+    assert order_state.strategy_id == PAPER_CANARY_STRATEGY_ID
+
+
+def test_paper_canary_strategy_is_small_paper_probe_with_no_factor_gate() -> None:
+    strategy = build_paper_canary_strategy()
+
+    assert strategy.config.strategy_id == PAPER_CANARY_STRATEGY_ID
+    assert strategy.config.factor_composition == ()
+    assert dict(strategy.config.metadata)["purpose"] == "paper_e2e_canary"
+    assert dict(strategy.config.metadata)["price_reference"] == "best_ask"
+    assert dict(strategy.config.metadata)["event_filter"] == "book"
+    assert dict(strategy.config.metadata)["sample"] == "0/25"
+    assert strategy.risk.max_position_notional_usdc == pytest.approx(1.0)
+    assert strategy.risk.min_order_size_usdc == pytest.approx(1.0)
+    assert strategy.forecaster.forecasters == (
+        (
+            "paper_canary",
+            (
+                ("edge_bps", "1000"),
+                ("max_probability", "0.97"),
+                ("min_price", "0.05"),
+                ("max_price", "0.90"),
+                ("sample_modulus", "25"),
+                ("sample_remainder", "0"),
+            ),
+        ),
+    )
+
+
+def test_paper_canary_forecaster_is_rejected_outside_paper_mode() -> None:
+    settings = PMSSettings(mode=RunMode.LIVE)
+    strategy = build_paper_canary_strategy()
+
+    with pytest.raises(ValueError, match="paper_canary forecaster is PAPER-only"):
+        ControllerPipelineFactory(settings=settings).build(
+            strategy.to_active(strategy_version_id="paper-canary-test-v1")
+        )

--- a/tests/unit/test_paper_multi_factor_strategy.py
+++ b/tests/unit/test_paper_multi_factor_strategy.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from pms.config import PMSSettings
+from pms.controller.factor_snapshot import FactorSnapshot
+from pms.controller.factory import ControllerPipelineFactory
+from pms.core.enums import RunMode
+from pms.core.models import MarketSignal, Portfolio
+from pms.strategies.paper_multifactor import (
+    PAPER_MULTI_FACTOR_STRATEGY_ID,
+    build_paper_multi_factor_strategy,
+)
+from pms.strategies.projections import FactorCompositionStep
+
+
+def _signal() -> MarketSignal:
+    return MarketSignal(
+        market_id="phase-a-market",
+        token_id="phase-a-token",
+        venue="polymarket",
+        title="Can Phase A produce a simple factor-backed decision?",
+        yes_price=0.50,
+        volume_24h=1_000.0,
+        resolves_at=datetime(2026, 6, 1, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": 0.49, "size": 100.0}],
+            "asks": [{"price": 0.51, "size": 100.0}],
+        },
+        external_signal={"raw_event_type": "book"},
+        fetched_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1_000.0,
+        free_usdc=1_000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+class StaticFactorReader:
+    def __init__(self, snapshot: FactorSnapshot) -> None:
+        self.snapshot_calls: list[Sequence[FactorCompositionStep]] = []
+        self._snapshot = snapshot
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> Any:
+        del market_id, as_of, strategy_id, strategy_version_id
+        self.snapshot_calls.append(required)
+        return self._snapshot
+
+
+def test_paper_multi_factor_strategy_matches_phase_a_contract() -> None:
+    strategy = build_paper_multi_factor_strategy()
+
+    assert strategy.config.strategy_id == PAPER_MULTI_FACTOR_STRATEGY_ID
+    assert dict(strategy.config.metadata) == {
+        "owner": "Researcher-Ciga",
+        "tier": "paper",
+        "phase": "A",
+        "purpose": "paper_multi_factor_phase_a",
+        "price_reference": "best_ask",
+        "live_allowed": "false",
+        "requires_strict_factor_gates": "false",
+    }
+    assert strategy.risk.max_position_notional_usdc == pytest.approx(2.0)
+    assert strategy.risk.max_daily_drawdown_pct == pytest.approx(50.0)
+    assert strategy.risk.min_order_size_usdc == pytest.approx(0.50)
+    assert strategy.eval_spec.metrics == ("brier", "pnl", "fill_rate")
+    assert strategy.eval_spec.min_win_rate == pytest.approx(0.45)
+    assert strategy.market_selection.venue == "polymarket"
+    assert strategy.market_selection.resolution_time_max_horizon_days == 90
+    assert strategy.market_selection.volume_min_usdc == pytest.approx(100.0)
+    assert strategy.forecaster.forecasters == (
+        ("rules", (("threshold", "0.55"),)),
+        ("stats", (("window", "15m"),)),
+        ("llm", ()),
+    )
+    assert tuple(
+        (step.factor_id, step.role, step.threshold, step.required)
+        for step in strategy.config.factor_composition
+    ) == (
+        ("orderbook_imbalance", "threshold_edge", 0.10, True),
+        ("orderbook_imbalance", "weighted", None, False),
+        ("rules", "blend_weighted", None, False),
+    )
+
+
+def test_paper_multi_factor_strategy_is_rejected_outside_paper_mode() -> None:
+    settings = PMSSettings(mode=RunMode.LIVE)
+    strategy = build_paper_multi_factor_strategy()
+
+    with pytest.raises(ValueError, match="paper_multi_factor_v1 is PAPER-only"):
+        ControllerPipelineFactory(settings=settings).build(
+            strategy.to_active(strategy_version_id="phase-a-v1")
+        )
+
+
+@pytest.mark.asyncio
+async def test_paper_multi_factor_can_decide_from_orderbook_imbalance_only() -> None:
+    strategy = build_paper_multi_factor_strategy()
+    factor_reader = StaticFactorReader(
+        FactorSnapshot(
+            values={("orderbook_imbalance", ""): 0.12},
+            missing_factors=(),
+            snapshot_hash="phase-a-snapshot",
+        )
+    )
+    pipeline = ControllerPipelineFactory(
+        settings=PMSSettings(mode=RunMode.PAPER),
+        factor_reader=factor_reader,
+    ).build(strategy.to_active(strategy_version_id="phase-a-v1"))
+
+    decision = await pipeline.decide(_signal(), portfolio=_portfolio())
+
+    assert decision is not None
+    assert decision.strategy_id == PAPER_MULTI_FACTOR_STRATEGY_ID
+    assert decision.outcome == "YES"
+    assert decision.limit_price == pytest.approx(0.51)
+    assert decision.prob_estimate == pytest.approx(0.62)
+    assert decision.expected_edge == pytest.approx(0.11)
+    assert decision.notional_usdc == pytest.approx(2.0)
+    assert factor_reader.snapshot_calls


### PR DESCRIPTION
## Summary

Adds `paper_canary_v1`, a deliberately simple PAPER-only strategy used to prove the live paper trading chain end-to-end without claiming alpha:

- new `PaperCanaryForecaster` registered as `paper_canary`
- `paper_canary_v1` strategy definition with no factor-composition gates, $1 max position, and deterministic 1/25 sampling of initial `book` events
- controller support for canary `price_reference=best_ask`, so paper decisions use an executable ask instead of mid/last trade
- installer script: `scripts/install_paper_canary_strategy.py`
- regression tests for PAPER-only guard, executable best-ask pricing, paper fill matching, and installer CLI behavior

The existing multi-factor/default strategy is unchanged. The canary is rejected outside `RunMode.PAPER`.

## Verification

Local checks:

```bash
uv run pytest tests/unit/test_paper_canary_strategy.py tests/unit/test_install_paper_canary_strategy.py tests/unit/test_controller_cp01.py tests/unit/test_controller_router.py tests/unit/test_paper_actuator_cp12.py -q
# 26 passed

uv run pytest -q
# 1033 passed, 161 skipped

PMS_RUN_INTEGRATION=1 uv run pytest -m integration -q
# 18 passed, 144 skipped, 1032 deselected

uv run ruff check src tests scripts
# All checks passed!

uv run mypy src/ tests/ --strict
# Success: no issues found in 358 source files

uv run lint-imports
# Contracts: 8 kept, 0 broken

git diff --check
# clean
```

Real paper smoke against a fresh temporary Postgres DB and live Polymarket discovery/WS:

```bash
DATABASE_URL=$SMOKE_DSN uv run alembic upgrade head
DATABASE_URL=$SMOKE_DSN uv run python scripts/install_paper_canary_strategy.py
DATABASE_URL=$SMOKE_DSN PMS_AUTO_START=1 uv run pms-api --config config.live-soak.yaml --port 8037 --log-level warning
```

Smoke evidence from `/status` + DB:

```text
running=true
MarketDiscoverySensor.last_signal_at=2026-05-05T12:26:52.044000+00:00
MarketDataSensor.last_signal_at=2026-05-05T12:26:52.044000+00:00
controller.decisions_total=1
actuator.fills_total=1
autostart_error=null

markets=500
tokens=1000
book_snapshots=116
price_changes=1308
decisions=1
orders=1
fills=1

strategy_id=paper_canary_v1 decisions=1
strategy_id=paper_canary_v1 raw_status=matched orders=1
strategy_id=paper_canary_v1 fills=1
```

Paper report smoke:

```text
Day of soak | 1
Decisions made | 1
Fills | 1
Open positions | 1
Total exposure | $1.00
```

Note: evaluator records stay `0` for live paper fills until markets resolve because `resolved_outcome` is not available on open markets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "paper_canary" and paper multi-factor strategies and forecasters with configurable sampling, probability/price bounds, and risk/market constraints.
  * Pipeline now can use best-ask as the yes-reference price when configured.

* **Chores**
  * CLI installers to register paper strategies in the database.
  * Strategy activation helper to produce active strategy instances.

* **Tests**
  * Extensive unit tests covering strategies, installers, factor composition, and live-soak config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Post-review verification (commit `1f5015d`)

CodeRabbit review nits were fixed in `1f5015d` by extracting shared price helpers, decoupling pricing tests from the hash sampling bucket, suppressing the S106 false positive on the token fixture, and switching canary probability math to Decimal internals.

```bash
uv run pytest tests/unit/test_paper_canary_strategy.py tests/unit/test_install_paper_canary_strategy.py -q
# 6 passed

uv run pytest -q
# 1033 passed, 161 skipped

PMS_RUN_INTEGRATION=1 uv run pytest -m integration -q
# 18 passed, 144 skipped, 1032 deselected

uv run ruff check src tests scripts
# All checks passed!

uv run mypy src/ tests/ --strict
# Success: no issues found in 359 source files

uv run lint-imports
# Contracts: 8 kept, 0 broken

git diff --check
# clean
```

GitHub status after the review commit:
- CodeRabbit: SUCCESS
- CI push run: SUCCESS
- CI pull_request run: SUCCESS
- merge state: CLEAN
