### PR TITLE
feat: add PAPER multi-factor phase A strategy

### DIFF
--- a/config.live-soak.yaml
+++ b/config.live-soak.yaml
@@ -25,7 +25,7 @@ controller:
   max_book_age_ms: 1000.0
   allowed_book_clock_skew_ms: 250.0
   max_spread_bps: 100.0
-  strict_factor_gates: true
+  strict_factor_gates: false
   quote_source: postgres_snapshot
   direct_quote_min_notional_usdc: 100.0
   dual_quote_max_price_delta_bps: 25.0

--- a/scripts/install_paper_multi_factor_strategy.py
+++ b/scripts/install_paper_multi_factor_strategy.py
@@ -1,0 +1,87 @@
+"""Register the PAPER-only Phase A multi-factor strategy."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+from pms.factors.definitions import REGISTERED
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+from pms.strategies.aggregate import Strategy
+from pms.strategies.paper_multifactor import build_paper_multi_factor_strategy
+from pms.strategies.projections import FactorCompositionStep, StrategyVersion
+
+_RAW_FACTOR_ROLES = frozenset(
+    {
+        "weighted",
+        "precedence_rank",
+        "threshold_edge",
+        "posterior_prior",
+        "posterior_success",
+        "posterior_failure",
+    }
+)
+_REGISTERED_FACTOR_IDS = frozenset(factor_cls.factor_id for factor_cls in REGISTERED)
+
+
+async def install_paper_multi_factor_strategy(database_url: str) -> StrategyVersion:
+    pool = await asyncpg.create_pool(
+        dsn=database_url,
+        min_size=1,
+        max_size=2,
+    )
+    try:
+        registry = PostgresStrategyRegistry(pool)
+        strategy = build_paper_multi_factor_strategy()
+        version = await registry.create_version(strategy)
+        await registry.populate_strategy_factors(
+            strategy.config.strategy_id,
+            version.strategy_version_id,
+            _strategy_factor_steps(strategy),
+        )
+        return version
+    finally:
+        await pool.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Register paper_multi_factor_v1 as an active PAPER strategy."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="PostgreSQL DSN. Defaults to DATABASE_URL.",
+    )
+    args = parser.parse_args(argv)
+
+    database_url = args.database_url
+    if not database_url:
+        print("error: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    version = _run_install(database_url)
+    print(f"strategy_id: {version.strategy_id}")
+    print(f"strategy_version_id: {version.strategy_version_id}")
+    print(f"created_at: {version.created_at.isoformat()}")
+    return 0
+
+
+def _run_install(database_url: str) -> StrategyVersion:
+    return asyncio.run(install_paper_multi_factor_strategy(database_url))
+
+
+def _strategy_factor_steps(strategy: Strategy) -> tuple[FactorCompositionStep, ...]:
+    return tuple(
+        step
+        for step in strategy.config.factor_composition
+        if step.role in _RAW_FACTOR_ROLES and step.factor_id in _REGISTERED_FACTOR_IDS
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pms/controller/factory.py
+++ b/src/pms/controller/factory.py
@@ -45,6 +45,7 @@ class ControllerPipelineFactory:
         }
 
     def build(self, strategy: ActiveStrategy) -> ControllerPipeline:
+        _assert_strategy_mode_allowed(strategy, mode=self.settings.mode)
         return ControllerPipeline(
             strategy=strategy,
             strategy_id=strategy.strategy_id,
@@ -133,3 +134,13 @@ def _risk_settings(
         min_order_usdc=strategy.risk.min_order_size_usdc,
         slippage_threshold_bps=fallback.slippage_threshold_bps,
     )
+
+
+def _assert_strategy_mode_allowed(strategy: ActiveStrategy, *, mode: RunMode) -> None:
+    if mode != RunMode.LIVE:
+        return
+    metadata = dict(strategy.config.metadata)
+    if metadata.get("live_allowed") != "false":
+        return
+    msg = f"{strategy.strategy_id} is PAPER-only"
+    raise ValueError(msg)

--- a/src/pms/factors/composition.py
+++ b/src/pms/factors/composition.py
@@ -34,7 +34,7 @@ def apply_composition(
     composition: Sequence[FactorCompositionStep],
     factor_values: Mapping[tuple[str, str], float],
 ) -> float:
-    weighted_steps = tuple(step for step in composition if step.role == "weighted")
+    weighted_steps = _eligible_weighted_steps(composition, factor_values)
     non_weighted_steps = tuple(step for step in composition if step.role != "weighted")
     if weighted_steps and not non_weighted_steps:
         return _apply_weighted(weighted_steps, factor_values)
@@ -65,6 +65,28 @@ def apply_composition(
 
     msg = "composition could not resolve a probability"
     raise KeyError(msg)
+
+
+def _eligible_weighted_steps(
+    composition: Sequence[FactorCompositionStep],
+    factor_values: Mapping[tuple[str, str], float],
+) -> tuple[FactorCompositionStep, ...]:
+    threshold_gates = {
+        (step.factor_id, step.param): 0.0 if step.threshold is None else step.threshold
+        for step in composition
+        if step.role == "threshold_edge"
+    }
+    eligible_steps: list[FactorCompositionStep] = []
+    for step in composition:
+        if step.role != "weighted":
+            continue
+        threshold = threshold_gates.get((step.factor_id, step.param))
+        if threshold is not None:
+            value = factor_values.get((step.factor_id, step.param))
+            if value is None or abs(value) < threshold:
+                continue
+        eligible_steps.append(step)
+    return tuple(eligible_steps)
 
 
 def evaluate_branch_probabilities(
@@ -159,6 +181,11 @@ def _apply_threshold_precedence(
             if edge < threshold:
                 continue
             return _required_factor_value(factor_values, "subset_price", "") - edge
+        if step.factor_id == "orderbook_imbalance":
+            if abs(edge) < threshold:
+                continue
+            yes_price = _required_factor_value(factor_values, "yes_price", "")
+            return _bounded_probability(yes_price + edge)
         if abs(edge) < threshold:
             continue
         return edge
@@ -237,3 +264,7 @@ def _required_factor_value(
         msg = f"missing required factor input {factor_id!r}:{param!r}"
         raise KeyError(msg)
     return value
+
+
+def _bounded_probability(value: float) -> float:
+    return max(1e-6, min(1.0 - 1e-6, value))

--- a/src/pms/strategies/paper_multifactor.py
+++ b/src/pms/strategies/paper_multifactor.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+PAPER_MULTI_FACTOR_STRATEGY_ID = "paper_multi_factor_v1"
+_FACTOR_FRESHNESS_S = 300.0
+
+
+def build_paper_multi_factor_strategy() -> Strategy:
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=PAPER_MULTI_FACTOR_STRATEGY_ID,
+            factor_composition=(
+                FactorCompositionStep(
+                    factor_id="orderbook_imbalance",
+                    role="threshold_edge",
+                    param="",
+                    weight=1.0,
+                    threshold=0.10,
+                    required=True,
+                    freshness_sla_s=_FACTOR_FRESHNESS_S,
+                    allow_neutral_fallback=False,
+                ),
+                FactorCompositionStep(
+                    factor_id="orderbook_imbalance",
+                    role="weighted",
+                    param="",
+                    weight=1.0,
+                    threshold=None,
+                    required=False,
+                    freshness_sla_s=_FACTOR_FRESHNESS_S,
+                    allow_neutral_fallback=False,
+                ),
+                FactorCompositionStep(
+                    factor_id="rules",
+                    role="blend_weighted",
+                    param="",
+                    weight=0.5,
+                    threshold=None,
+                    required=False,
+                    allow_neutral_fallback=True,
+                ),
+            ),
+            metadata=(
+                ("owner", "Researcher-Ciga"),
+                ("tier", "paper"),
+                ("phase", "A"),
+                ("purpose", "paper_multi_factor_phase_a"),
+                ("price_reference", "best_ask"),
+                ("live_allowed", "false"),
+                ("requires_strict_factor_gates", "false"),
+            ),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=2.0,
+            max_daily_drawdown_pct=50.0,
+            min_order_size_usdc=0.50,
+        ),
+        eval_spec=EvalSpec(
+            metrics=("brier", "pnl", "fill_rate"),
+            max_brier_score=0.30,
+            slippage_threshold_bps=50.0,
+            min_win_rate=0.45,
+        ),
+        forecaster=ForecasterSpec(
+            forecasters=(
+                ("rules", (("threshold", "0.55"),)),
+                ("stats", (("window", "15m"),)),
+                ("llm", ()),
+            )
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=90,
+            volume_min_usdc=100.0,
+        ),
+    )

--- a/tests/unit/test_factor_composition.py
+++ b/tests/unit/test_factor_composition.py
@@ -217,6 +217,65 @@ def test_apply_composition_supports_generic_threshold_edge_steps() -> None:
     assert result == pytest.approx(0.07)
 
 
+def test_apply_composition_treats_orderbook_imbalance_as_directional_edge() -> None:
+    result = apply_composition(
+        (
+            _step(
+                "orderbook_imbalance",
+                role="threshold_edge",
+                weight=1.0,
+                threshold=0.10,
+            ),
+        ),
+        {
+            ("orderbook_imbalance", ""): 0.12,
+            ("yes_price", ""): 0.50,
+        },
+    )
+
+    assert result == pytest.approx(0.62)
+
+
+def test_apply_composition_skips_orderbook_imbalance_below_threshold() -> None:
+    result = apply_composition(
+        (
+            _step(
+                "orderbook_imbalance",
+                role="threshold_edge",
+                weight=1.0,
+                threshold=0.10,
+            ),
+        ),
+        {
+            ("orderbook_imbalance", ""): 0.05,
+            ("yes_price", ""): 0.50,
+        },
+    )
+
+    assert result == pytest.approx(0.50)
+
+
+def test_apply_composition_does_not_use_gated_orderbook_weighted_fallback() -> None:
+    result = apply_composition(
+        (
+            _step(
+                "orderbook_imbalance",
+                role="threshold_edge",
+                weight=1.0,
+                threshold=0.10,
+            ),
+            _step("orderbook_imbalance", role="weighted", weight=1.0),
+            _step("rules", role="blend_weighted", weight=0.5),
+        ),
+        {
+            ("orderbook_imbalance", ""): 0.05,
+            ("yes_price", ""): 0.50,
+        },
+    )
+
+    assert result == pytest.approx(0.50)
+
+
 def test_apply_composition_raises_when_required_rule_inputs_are_missing() -> None:
     with pytest.raises(KeyError, match="missing required factor input 'yes_price':''"):
         apply_composition(

--- a/tests/unit/test_install_paper_multi_factor_strategy.py
+++ b/tests/unit/test_install_paper_multi_factor_strategy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.strategies.paper_multifactor import build_paper_multi_factor_strategy
+from pms.strategies.projections import StrategyVersion
+from scripts import install_paper_multi_factor_strategy
+
+
+def test_paper_multi_factor_strategy_factor_rows_exclude_runtime_rules() -> None:
+    strategy = build_paper_multi_factor_strategy()
+
+    factor_rows = install_paper_multi_factor_strategy._strategy_factor_steps(strategy)
+
+    assert tuple(step.factor_id for step in factor_rows) == (
+        "orderbook_imbalance",
+        "orderbook_imbalance",
+    )
+
+
+def test_install_paper_multi_factor_requires_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    result = install_paper_multi_factor_strategy.main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "DATABASE_URL is not set" in captured.err
+
+
+def test_install_paper_multi_factor_prints_registered_version(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _fake_install(database_url: str) -> StrategyVersion:
+        assert database_url == "postgresql://example/pms"
+        return StrategyVersion(
+            strategy_id="paper_multi_factor_v1",
+            strategy_version_id="version-456",
+            created_at=datetime(2026, 5, 5, 13, 0, tzinfo=UTC),
+        )
+
+    monkeypatch.setattr(
+        install_paper_multi_factor_strategy,
+        "_run_install",
+        _fake_install,
+    )
+
+    result = install_paper_multi_factor_strategy.main(
+        ["--database-url", "postgresql://example/pms"]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "strategy_id: paper_multi_factor_v1" in captured.out
+    assert "strategy_version_id: version-456" in captured.out

--- a/tests/unit/test_live_soak_config.py
+++ b/tests/unit/test_live_soak_config.py
@@ -20,6 +20,12 @@ def test_live_soak_config_loads_tight_first_live_risk_caps() -> None:
     assert settings.risk.slippage_threshold_bps == 50.0
 
 
+def test_live_soak_config_relaxes_paper_factor_gate_for_phase_a() -> None:
+    settings = PMSSettings.load(ROOT / "config.live-soak.yaml")
+
+    assert settings.controller.strict_factor_gates is False
+
+
 def test_live_soak_config_keeps_credentials_env_only() -> None:
     settings = PMSSettings.load(ROOT / "config.live-soak.yaml")
 

--- a/tests/unit/test_paper_canary_strategy.py
+++ b/tests/unit/test_paper_canary_strategy.py
@@ -139,7 +139,7 @@ def test_paper_canary_forecaster_is_rejected_outside_paper_mode() -> None:
     settings = PMSSettings(mode=RunMode.LIVE)
     strategy = build_paper_canary_strategy()
 
-    with pytest.raises(ValueError, match="paper_canary forecaster is PAPER-only"):
+    with pytest.raises(ValueError, match="paper_canary_v1 is PAPER-only"):
         ControllerPipelineFactory(settings=settings).build(
             strategy.to_active(strategy_version_id="paper-canary-test-v1")
         )

--- a/tests/unit/test_paper_multi_factor_strategy.py
+++ b/tests/unit/test_paper_multi_factor_strategy.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from pms.config import PMSSettings
+from pms.controller.factor_snapshot import FactorSnapshot
+from pms.controller.factory import ControllerPipelineFactory
+from pms.core.enums import RunMode
+from pms.core.models import MarketSignal, Portfolio
+from pms.strategies.paper_multifactor import (
+    PAPER_MULTI_FACTOR_STRATEGY_ID,
+    build_paper_multi_factor_strategy,
+)
+from pms.strategies.projections import FactorCompositionStep
+
+
+def _signal() -> MarketSignal:
+    return MarketSignal(
+        market_id="phase-a-market",
+        token_id="phase-a-token",
+        venue="polymarket",
+        title="Can Phase A produce a simple factor-backed decision?",
+        yes_price=0.50,
+        volume_24h=1_000.0,
+        resolves_at=datetime(2026, 6, 1, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": 0.49, "size": 100.0}],
+            "asks": [{"price": 0.51, "size": 100.0}],
+        },
+        external_signal={"raw_event_type": "book"},
+        fetched_at=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1_000.0,
+        free_usdc=1_000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+class StaticFactorReader:
+    def __init__(self, snapshot: FactorSnapshot) -> None:
+        self.snapshot_calls: list[Sequence[FactorCompositionStep]] = []
+        self._snapshot = snapshot
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> Any:
+        del market_id, as_of, strategy_id, strategy_version_id
+        self.snapshot_calls.append(required)
+        return self._snapshot
+
+
+def test_paper_multi_factor_strategy_matches_phase_a_contract() -> None:
+    strategy = build_paper_multi_factor_strategy()
+
+    assert strategy.config.strategy_id == PAPER_MULTI_FACTOR_STRATEGY_ID
+    assert dict(strategy.config.metadata) == {
+        "owner": "Researcher-Ciga",
+        "tier": "paper",
+        "phase": "A",
+        "purpose": "paper_multi_factor_phase_a",
+        "price_reference": "best_ask",
+        "live_allowed": "false",
+        "requires_strict_factor_gates": "false",
+    }
+    assert strategy.risk.max_position_notional_usdc == pytest.approx(2.0)
+    assert strategy.risk.max_daily_drawdown_pct == pytest.approx(50.0)
+    assert strategy.risk.min_order_size_usdc == pytest.approx(0.50)
+    assert strategy.eval_spec.metrics == ("brier", "pnl", "fill_rate")
+    assert strategy.eval_spec.min_win_rate == pytest.approx(0.45)
+    assert strategy.market_selection.venue == "polymarket"
+    assert strategy.market_selection.resolution_time_max_horizon_days == 90
+    assert strategy.market_selection.volume_min_usdc == pytest.approx(100.0)
+    assert strategy.forecaster.forecasters == (
+        ("rules", (("threshold", "0.55"),)),
+        ("stats", (("window", "15m"),)),
+        ("llm", ()),
+    )
+    assert tuple(
+        (step.factor_id, step.role, step.threshold, step.required)
+        for step in strategy.config.factor_composition
+    ) == (
+        ("orderbook_imbalance", "threshold_edge", 0.10, True),
+        ("orderbook_imbalance", "weighted", None, False),
+        ("rules", "blend_weighted", None, False),
+    )
+
+
+def test_paper_multi_factor_strategy_is_rejected_outside_paper_mode() -> None:
+    settings = PMSSettings(mode=RunMode.LIVE)
+    strategy = build_paper_multi_factor_strategy()
+
+    with pytest.raises(ValueError, match="paper_multi_factor_v1 is PAPER-only"):
+        ControllerPipelineFactory(settings=settings).build(
+            strategy.to_active(strategy_version_id="phase-a-v1")
+        )
+
+
+@pytest.mark.asyncio
+async def test_paper_multi_factor_can_decide_from_orderbook_imbalance_only() -> None:
+    strategy = build_paper_multi_factor_strategy()
+    factor_reader = StaticFactorReader(
+        FactorSnapshot(
+            values={("orderbook_imbalance", ""): 0.12},
+            missing_factors=(),
+            snapshot_hash="phase-a-snapshot",
+        )
+    )
+    pipeline = ControllerPipelineFactory(
+        settings=PMSSettings(mode=RunMode.PAPER),
+        factor_reader=factor_reader,
+    ).build(strategy.to_active(strategy_version_id="phase-a-v1"))
+
+    decision = await pipeline.decide(_signal(), portfolio=_portfolio())
+
+    assert decision is not None
+    assert decision.strategy_id == PAPER_MULTI_FACTOR_STRATEGY_ID
+    assert decision.outcome == "YES"
+    assert decision.limit_price == pytest.approx(0.51)
+    assert decision.prob_estimate == pytest.approx(0.62)
+    assert decision.expected_edge == pytest.approx(0.11)
+    assert decision.notional_usdc == pytest.approx(2.0)
+    assert factor_reader.snapshot_calls


### PR DESCRIPTION
## Summary

Adds `paper_multi_factor_v1`, the Phase A strategy Researcher-Ciga proposed, as a DB-installable PAPER-only strategy stacked after PR #57 (`paper_canary_v1`). This PR is intentionally based on `feat/paper-canary-v1`; once PR #57 lands, this can be retargeted/merged after it.

What changed:
- Added `build_paper_multi_factor_strategy()` with the Phase A 3-step composition:
  - `orderbook_imbalance` as required `threshold_edge` at `0.10`
  - `orderbook_imbalance` as optional `weighted`
  - `rules` as optional `blend_weighted`
- Added `scripts/install_paper_multi_factor_strategy.py` to register and activate the strategy.
- Set `config.live-soak.yaml` `controller.strict_factor_gates=false` for PAPER Phase A, while LIVE still hard-enforces strict gates in code.
- Added a generic `live_allowed=false` strategy metadata guard in the controller factory so `paper_multi_factor_v1` and `paper_canary_v1` are rejected in LIVE mode.
- Corrected composition semantics for `orderbook_imbalance`: it is a directional edge around `yes_price`, not an absolute probability. A positive `0.12` imbalance at `yes_price=0.50` resolves to `0.62`, and below-threshold imbalance falls back to market price instead of overtrading.
- Added `price_reference=best_ask` so paper orders can fill against the current executable ask instead of creating non-fillable mid-price decisions.

## Verification

Focused/unit:

```bash
uv run pytest tests/unit/test_factor_composition.py tests/unit/test_paper_multi_factor_strategy.py tests/unit/test_install_paper_multi_factor_strategy.py tests/unit/test_live_soak_config.py tests/unit/test_paper_canary_strategy.py -q
# 29 passed

uv run pytest tests/unit/test_install_paper_multi_factor_strategy.py -q
# 3 passed
```

Full repo checks:

```bash
uv run pytest -q
# 1043 passed, 161 skipped

PMS_RUN_INTEGRATION=1 uv run pytest -m integration -q
# 18 passed, 144 skipped, 1042 deselected

uv run ruff check src tests scripts
# All checks passed!

uv run mypy src/ tests/ --strict
# Success: no issues found in 362 source files

uv run lint-imports
# Contracts: 8 kept, 0 broken

git diff --check
# clean
```

Real isolated smoke against a fresh temporary Postgres DB and live Polymarket discovery/WS:

```bash
DATABASE_URL=$SMOKE_DSN uv run alembic upgrade head
DATABASE_URL=$SMOKE_DSN uv run python scripts/install_paper_multi_factor_strategy.py
DATABASE_URL=$SMOKE_DSN PMS_AUTO_START=1 uv run pms-api --config config.live-soak.yaml --port 8038 --log-level warning
```

Smoke evidence from `/status` + DB after roughly 20 seconds:

```text
running=true
autostart_error=null
MarketDiscoverySensor.last_signal_at=2026-05-05T13:19:08.662000+00:00
MarketDataSensor.last_signal_at=2026-05-05T13:19:08.662000+00:00
controller.decisions_total=448
actuator.fills_total=7

markets=500
tokens=1000
book_snapshots=129
price_changes=1804
factor_values=184
decisions=620
orders=620
fills=7

strategy_id=paper_multi_factor_v1 decisions=620
strategy_id=paper_multi_factor_v1 raw_status=matched orders=7
strategy_id=paper_multi_factor_v1 fills=7
```

Paper report smoke:

```text
Day of soak | 1
Decisions made | 714
Fills | 7
Open positions | 5
Total exposure | $14.00
Cumulative P&L | -$0.17
```

The smoke runner was stopped and the temporary DB was dropped. I did not touch the active 30-day paper soak runner.

## Operational note

This should not be deployed into the active soak until PR #57 is merged and Stometa decides to restart the paper runner. Restarting with this enabled will intentionally reset the current fresh soak clock, but it will produce continuous paper decisions/fills for Phase A validation.
