### PR TITLE
feat: add strategy meta-evidence analytics

### DIFF
--- a/alembic/versions/0001_baseline.py
+++ b/alembic/versions/0001_baseline.py
@@ -18,6 +18,8 @@ _CREATED_TABLES: Final[tuple[str, ...]] = (
     "evaluation_reports",
     "strategy_runs",
     "backtest_runs",
+    "alpha_competition_snapshots",
+    "strategy_performance_peaks",
     "opportunities",
     "fills",
     "order_intents",

--- a/alembic/versions/0015_strategy_meta_evidence.py
+++ b/alembic/versions/0015_strategy_meta_evidence.py
@@ -29,6 +29,12 @@ def upgrade() -> None:
     )
     connection.exec_driver_sql(
         """
+        CREATE INDEX IF NOT EXISTS idx_eval_records_strategy_identity_recorded_at
+            ON eval_records(strategy_id, strategy_version_id, recorded_at DESC)
+        """
+    )
+    connection.exec_driver_sql(
+        """
         CREATE TABLE IF NOT EXISTS strategy_performance_peaks (
             strategy_id TEXT NOT NULL,
             strategy_version_id TEXT NOT NULL,
@@ -68,6 +74,9 @@ def downgrade() -> None:
     connection: Connection = op.get_bind()
     connection.exec_driver_sql("DROP TABLE IF EXISTS alpha_competition_snapshots")
     connection.exec_driver_sql("DROP TABLE IF EXISTS strategy_performance_peaks")
+    connection.exec_driver_sql(
+        "DROP INDEX IF EXISTS idx_eval_records_strategy_identity_recorded_at"
+    )
     connection.exec_driver_sql(
         """
         ALTER TABLE eval_records

--- a/alembic/versions/0015_strategy_meta_evidence.py
+++ b/alembic/versions/0015_strategy_meta_evidence.py
@@ -1,0 +1,83 @@
+"""Add strategy meta-evidence capture and analytics surfaces."""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy.engine import Connection
+
+
+revision = "0015_strategy_meta_evidence"
+down_revision = "0014_strategy_artifacts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    connection: Connection = op.get_bind()
+    connection.exec_driver_sql(
+        """
+        ALTER TABLE strategy_versions
+            ADD COLUMN IF NOT EXISTS metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb
+        """
+    )
+    connection.exec_driver_sql(
+        """
+        ALTER TABLE eval_records
+            ADD COLUMN IF NOT EXISTS edge_at_decision DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+            ADD COLUMN IF NOT EXISTS spread_bps_at_decision INTEGER
+        """
+    )
+    connection.exec_driver_sql(
+        """
+        CREATE TABLE IF NOT EXISTS strategy_performance_peaks (
+            strategy_id TEXT NOT NULL,
+            strategy_version_id TEXT NOT NULL,
+            peak_sharpe_7d DOUBLE PRECISION NOT NULL,
+            peak_sharpe_30d DOUBLE PRECISION NOT NULL,
+            peak_hit_rate DOUBLE PRECISION NOT NULL,
+            recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (strategy_id, strategy_version_id)
+        )
+        """
+    )
+    connection.exec_driver_sql(
+        """
+        CREATE TABLE IF NOT EXISTS alpha_competition_snapshots (
+            snapshot_id TEXT PRIMARY KEY,
+            strategy_id TEXT NOT NULL,
+            strategy_version_id TEXT NOT NULL,
+            snapshot_date DATE NOT NULL,
+            mean_edge_30d DOUBLE PRECISION,
+            mean_spread_bps_30d DOUBLE PRECISION,
+            edge_trend_slope_90d DOUBLE PRECISION,
+            spread_trend_slope_90d DOUBLE PRECISION,
+            sample_count_30d INTEGER NOT NULL,
+            trend_status TEXT NOT NULL CHECK (trend_status IN ('warming_up', 'active')),
+            days_collected INTEGER NOT NULL,
+            short_term_slope_30d DOUBLE PRECISION,
+            short_term_slope_60d DOUBLE PRECISION,
+            interpretation TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (strategy_id, strategy_version_id, snapshot_date)
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    connection: Connection = op.get_bind()
+    connection.exec_driver_sql("DROP TABLE IF EXISTS alpha_competition_snapshots")
+    connection.exec_driver_sql("DROP TABLE IF EXISTS strategy_performance_peaks")
+    connection.exec_driver_sql(
+        """
+        ALTER TABLE eval_records
+            DROP COLUMN IF EXISTS spread_bps_at_decision,
+            DROP COLUMN IF EXISTS edge_at_decision
+        """
+    )
+    connection.exec_driver_sql(
+        """
+        ALTER TABLE strategy_versions
+            DROP COLUMN IF EXISTS metadata_json
+        """
+    )

--- a/schema.sql
+++ b/schema.sql
@@ -171,9 +171,13 @@ CREATE TABLE IF NOT EXISTS strategy_versions (
     strategy_version_id TEXT PRIMARY KEY,
     strategy_id TEXT NOT NULL REFERENCES strategies(strategy_id) ON DELETE CASCADE,
     config_json JSONB NOT NULL,
+    metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE (strategy_id, strategy_version_id)
 );
+
+ALTER TABLE strategy_versions
+    ADD COLUMN IF NOT EXISTS metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb;
 
 DO $$
 BEGIN
@@ -254,7 +258,42 @@ CREATE TABLE IF NOT EXISTS eval_records (
     slippage_bps DOUBLE PRECISION NOT NULL DEFAULT 0.0,
     filled BOOLEAN NOT NULL DEFAULT TRUE,
     strategy_id TEXT NOT NULL,
-    strategy_version_id TEXT NOT NULL
+    strategy_version_id TEXT NOT NULL,
+    edge_at_decision DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    spread_bps_at_decision INTEGER
+);
+
+ALTER TABLE eval_records
+    ADD COLUMN IF NOT EXISTS edge_at_decision DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    ADD COLUMN IF NOT EXISTS spread_bps_at_decision INTEGER;
+
+CREATE TABLE IF NOT EXISTS strategy_performance_peaks (
+    strategy_id TEXT NOT NULL,
+    strategy_version_id TEXT NOT NULL,
+    peak_sharpe_7d DOUBLE PRECISION NOT NULL,
+    peak_sharpe_30d DOUBLE PRECISION NOT NULL,
+    peak_hit_rate DOUBLE PRECISION NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (strategy_id, strategy_version_id)
+);
+
+CREATE TABLE IF NOT EXISTS alpha_competition_snapshots (
+    snapshot_id TEXT PRIMARY KEY,
+    strategy_id TEXT NOT NULL,
+    strategy_version_id TEXT NOT NULL,
+    snapshot_date DATE NOT NULL,
+    mean_edge_30d DOUBLE PRECISION,
+    mean_spread_bps_30d DOUBLE PRECISION,
+    edge_trend_slope_90d DOUBLE PRECISION,
+    spread_trend_slope_90d DOUBLE PRECISION,
+    sample_count_30d INTEGER NOT NULL,
+    trend_status TEXT NOT NULL CHECK (trend_status IN ('warming_up', 'active')),
+    days_collected INTEGER NOT NULL,
+    short_term_slope_30d DOUBLE PRECISION,
+    short_term_slope_60d DOUBLE PRECISION,
+    interpretation TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (strategy_id, strategy_version_id, snapshot_date)
 );
 
 CREATE TABLE IF NOT EXISTS decisions (

--- a/schema.sql
+++ b/schema.sql
@@ -763,6 +763,9 @@ CREATE INDEX IF NOT EXISTS idx_feedback_strategy_identity
 CREATE INDEX IF NOT EXISTS idx_eval_records_strategy_identity
     ON eval_records(strategy_id, strategy_version_id);
 
+CREATE INDEX IF NOT EXISTS idx_eval_records_strategy_identity_recorded_at
+    ON eval_records(strategy_id, strategy_version_id, recorded_at DESC);
+
 CREATE INDEX IF NOT EXISTS idx_orders_strategy_identity
     ON orders(strategy_id, strategy_version_id);
 

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -28,6 +28,7 @@ from pms.api.routes.decisions import (
     get_decision as get_decision_item,
     list_decisions as list_decisions_items,
 )
+from pms.api.routes.decay import get_strategy_decay_status as get_strategy_decay_status_item
 from pms.api.routes.events import encode_sse_event
 from pms.api.research_routes import (
     compute_backtest_live_comparison,
@@ -506,6 +507,23 @@ def create_app(
         if active_runner.pg_pool is None:
             raise HTTPException(status_code=503, detail="Runner PostgreSQL pool is not initialized")
         return await list_strategy_metrics_items(active_runner.pg_pool)
+
+    @app.get("/strategies/{strategy_id}/decay-status")
+    async def strategy_decay_status(
+        strategy_id: str,
+        strategy_version_id: str | None = None,
+    ) -> dict[str, Any]:
+        if active_runner.pg_pool is None:
+            raise HTTPException(status_code=503, detail="Runner PostgreSQL pool is not initialized")
+        try:
+            return await get_strategy_decay_status_item(
+                active_runner.pg_pool,
+                strategy_id=strategy_id,
+                strategy_version_id=strategy_version_id,
+                min_resolved_samples=active_runner.config.decay_min_resolved_samples,
+            )
+        except LookupError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     @app.get("/share/{strategy_id}")
     async def share_strategy(strategy_id: str) -> dict[str, Any]:

--- a/src/pms/api/routes/decay.py
+++ b/src/pms/api/routes/decay.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, date, datetime
+from datetime import UTC, datetime, timedelta
 import json
 from typing import Any, cast
 
@@ -8,7 +8,14 @@ import asyncpg
 
 from pms.core.models import EvalRecord
 from pms.meta_evidence.decay import compute_decay_status
-from pms.meta_evidence.models import CompetitionSnapshot, PerformancePeak, TrendStatus
+from pms.meta_evidence.models import CompetitionSnapshot
+from pms.storage.meta_evidence_store import (
+    competition_snapshot_from_row,
+    performance_peak_from_row,
+)
+
+
+DECAY_RECORD_LOOKBACK_DAYS = 40
 
 
 async def get_strategy_decay_status(
@@ -18,6 +25,8 @@ async def get_strategy_decay_status(
     strategy_version_id: str | None = None,
     min_resolved_samples: int = 10,
 ) -> dict[str, Any]:
+    now = datetime.now(tz=UTC)
+    cutoff_ts = now - timedelta(days=DECAY_RECORD_LOOKBACK_DAYS)
     async with pg_pool.acquire() as connection:
         active_version_id = strategy_version_id
         if active_version_id is None:
@@ -96,24 +105,27 @@ async def get_strategy_decay_status(
                 edge_at_decision,
                 spread_bps_at_decision
             FROM eval_records
-            WHERE strategy_id = $1 AND strategy_version_id = $2
+            WHERE strategy_id = $1
+              AND strategy_version_id = $2
+              AND recorded_at >= $3
             ORDER BY recorded_at ASC, decision_id ASC
             """,
             strategy_id,
             active_version_id,
+            cutoff_ts,
         )
 
     records = [_eval_record_from_row(row) for row in rows]
-    peak = None if peak_row is None else _performance_peak_from_row(peak_row)
+    peak = None if peak_row is None else performance_peak_from_row(peak_row)
     status = compute_decay_status(
         records,
         strategy_id=strategy_id,
         strategy_version_id=active_version_id,
-        now=datetime.now(tz=UTC),
+        now=now,
         min_resolved_samples=min_resolved_samples,
         existing_peak=peak,
     )
-    snapshot = None if snapshot_row is None else _competition_snapshot_from_row(snapshot_row)
+    snapshot = None if snapshot_row is None else competition_snapshot_from_row(snapshot_row)
     return {
         "strategy_id": status.strategy_id,
         "strategy_version_id": status.strategy_version_id,
@@ -162,37 +174,6 @@ def _citations(value: object) -> list[str]:
         if isinstance(loaded, list):
             return [str(item) for item in loaded]
     return []
-
-
-def _performance_peak_from_row(row: asyncpg.Record) -> PerformancePeak:
-    return PerformancePeak(
-        strategy_id=cast(str, row["strategy_id"]),
-        strategy_version_id=cast(str, row["strategy_version_id"]),
-        peak_sharpe_7d=float(cast(float, row["peak_sharpe_7d"])),
-        peak_sharpe_30d=float(cast(float, row["peak_sharpe_30d"])),
-        peak_hit_rate=float(cast(float, row["peak_hit_rate"])),
-        recorded_at=cast(datetime, row["recorded_at"]),
-    )
-
-
-def _competition_snapshot_from_row(row: asyncpg.Record) -> CompetitionSnapshot:
-    return CompetitionSnapshot(
-        snapshot_id=cast(str, row["snapshot_id"]),
-        strategy_id=cast(str, row["strategy_id"]),
-        strategy_version_id=cast(str, row["strategy_version_id"]),
-        snapshot_date=cast(date, row["snapshot_date"]),
-        mean_edge_30d=cast(float | None, row["mean_edge_30d"]),
-        mean_spread_bps_30d=cast(float | None, row["mean_spread_bps_30d"]),
-        edge_trend_slope_90d=cast(float | None, row["edge_trend_slope_90d"]),
-        spread_trend_slope_90d=cast(float | None, row["spread_trend_slope_90d"]),
-        sample_count_30d=cast(int, row["sample_count_30d"]),
-        trend_status=cast(TrendStatus, row["trend_status"]),
-        days_collected=cast(int, row["days_collected"]),
-        short_term_slope_30d=cast(float | None, row["short_term_slope_30d"]),
-        short_term_slope_60d=cast(float | None, row["short_term_slope_60d"]),
-        interpretation=cast(str, row["interpretation"]),
-        created_at=cast(datetime, row["created_at"]),
-    )
 
 
 def _competition_payload(snapshot: CompetitionSnapshot) -> dict[str, Any]:

--- a/src/pms/api/routes/decay.py
+++ b/src/pms/api/routes/decay.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+import json
+from typing import Any, cast
+
+import asyncpg
+
+from pms.core.models import EvalRecord
+from pms.meta_evidence.decay import compute_decay_status
+from pms.meta_evidence.models import CompetitionSnapshot, PerformancePeak, TrendStatus
+
+
+async def get_strategy_decay_status(
+    pg_pool: asyncpg.Pool,
+    *,
+    strategy_id: str,
+    strategy_version_id: str | None = None,
+    min_resolved_samples: int = 10,
+) -> dict[str, Any]:
+    async with pg_pool.acquire() as connection:
+        active_version_id = strategy_version_id
+        if active_version_id is None:
+            row = await connection.fetchrow(
+                """
+                SELECT active_version_id
+                FROM strategies
+                WHERE strategy_id = $1
+                """,
+                strategy_id,
+            )
+            if row is None or row["active_version_id"] is None:
+                msg = f"strategy {strategy_id} has no active version"
+                raise LookupError(msg)
+            active_version_id = cast(str, row["active_version_id"])
+
+        peak_row = await connection.fetchrow(
+            """
+            SELECT
+                strategy_id,
+                strategy_version_id,
+                peak_sharpe_7d,
+                peak_sharpe_30d,
+                peak_hit_rate,
+                recorded_at
+            FROM strategy_performance_peaks
+            WHERE strategy_id = $1 AND strategy_version_id = $2
+            """,
+            strategy_id,
+            active_version_id,
+        )
+        snapshot_row = await connection.fetchrow(
+            """
+            SELECT
+                snapshot_id,
+                strategy_id,
+                strategy_version_id,
+                snapshot_date,
+                mean_edge_30d,
+                mean_spread_bps_30d,
+                edge_trend_slope_90d,
+                spread_trend_slope_90d,
+                sample_count_30d,
+                trend_status,
+                days_collected,
+                short_term_slope_30d,
+                short_term_slope_60d,
+                interpretation,
+                created_at
+            FROM alpha_competition_snapshots
+            WHERE strategy_id = $1 AND strategy_version_id = $2
+            ORDER BY snapshot_date DESC
+            LIMIT 1
+            """,
+            strategy_id,
+            active_version_id,
+        )
+        rows = await connection.fetch(
+            """
+            SELECT
+                market_id,
+                decision_id,
+                strategy_id,
+                strategy_version_id,
+                prob_estimate,
+                resolved_outcome,
+                brier_score,
+                fill_status,
+                recorded_at,
+                citations,
+                category,
+                model_id,
+                pnl,
+                slippage_bps,
+                filled,
+                edge_at_decision,
+                spread_bps_at_decision
+            FROM eval_records
+            WHERE strategy_id = $1 AND strategy_version_id = $2
+            ORDER BY recorded_at ASC, decision_id ASC
+            """,
+            strategy_id,
+            active_version_id,
+        )
+
+    records = [_eval_record_from_row(row) for row in rows]
+    peak = None if peak_row is None else _performance_peak_from_row(peak_row)
+    status = compute_decay_status(
+        records,
+        strategy_id=strategy_id,
+        strategy_version_id=active_version_id,
+        now=datetime.now(tz=UTC),
+        min_resolved_samples=min_resolved_samples,
+        existing_peak=peak,
+    )
+    snapshot = None if snapshot_row is None else _competition_snapshot_from_row(snapshot_row)
+    return {
+        "strategy_id": status.strategy_id,
+        "strategy_version_id": status.strategy_version_id,
+        "decay_status": status.decay_status,
+        "rolling_sharpe_7d": status.rolling_sharpe_7d,
+        "peak_sharpe_7d": status.peak_sharpe_7d,
+        "sharpe_ratio_vs_peak": status.sharpe_ratio_vs_peak,
+        "rolling_sharpe_30d": status.rolling_sharpe_30d,
+        "hit_rate_7d": status.hit_rate_7d,
+        "peak_hit_rate": status.peak_hit_rate,
+        "trading_days_in_window": status.trading_days_in_window,
+        "resolved_sample_count": status.resolved_sample_count,
+        "min_resolved_samples": status.min_resolved_samples,
+        "last_updated": status.last_updated.isoformat(),
+        "alpha_competition": None if snapshot is None else _competition_payload(snapshot),
+    }
+
+
+def _eval_record_from_row(row: asyncpg.Record) -> EvalRecord:
+    return EvalRecord(
+        market_id=cast(str, row["market_id"]),
+        decision_id=cast(str, row["decision_id"]),
+        strategy_id=cast(str, row["strategy_id"]),
+        strategy_version_id=cast(str, row["strategy_version_id"]),
+        prob_estimate=float(cast(float, row["prob_estimate"])),
+        resolved_outcome=float(cast(float, row["resolved_outcome"])),
+        brier_score=float(cast(float, row["brier_score"])),
+        fill_status=cast(str, row["fill_status"]),
+        recorded_at=cast(datetime, row["recorded_at"]),
+        citations=_citations(row["citations"]),
+        category=cast(str | None, row["category"]),
+        model_id=cast(str | None, row["model_id"]),
+        pnl=float(cast(float, row["pnl"])),
+        slippage_bps=float(cast(float, row["slippage_bps"])),
+        filled=cast(bool, row["filled"]),
+        edge_at_decision=float(cast(float, row["edge_at_decision"])),
+        spread_bps_at_decision=cast(int | None, row["spread_bps_at_decision"]),
+    )
+
+
+def _citations(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        loaded = json.loads(value)
+        if isinstance(loaded, list):
+            return [str(item) for item in loaded]
+    return []
+
+
+def _performance_peak_from_row(row: asyncpg.Record) -> PerformancePeak:
+    return PerformancePeak(
+        strategy_id=cast(str, row["strategy_id"]),
+        strategy_version_id=cast(str, row["strategy_version_id"]),
+        peak_sharpe_7d=float(cast(float, row["peak_sharpe_7d"])),
+        peak_sharpe_30d=float(cast(float, row["peak_sharpe_30d"])),
+        peak_hit_rate=float(cast(float, row["peak_hit_rate"])),
+        recorded_at=cast(datetime, row["recorded_at"]),
+    )
+
+
+def _competition_snapshot_from_row(row: asyncpg.Record) -> CompetitionSnapshot:
+    return CompetitionSnapshot(
+        snapshot_id=cast(str, row["snapshot_id"]),
+        strategy_id=cast(str, row["strategy_id"]),
+        strategy_version_id=cast(str, row["strategy_version_id"]),
+        snapshot_date=cast(date, row["snapshot_date"]),
+        mean_edge_30d=cast(float | None, row["mean_edge_30d"]),
+        mean_spread_bps_30d=cast(float | None, row["mean_spread_bps_30d"]),
+        edge_trend_slope_90d=cast(float | None, row["edge_trend_slope_90d"]),
+        spread_trend_slope_90d=cast(float | None, row["spread_trend_slope_90d"]),
+        sample_count_30d=cast(int, row["sample_count_30d"]),
+        trend_status=cast(TrendStatus, row["trend_status"]),
+        days_collected=cast(int, row["days_collected"]),
+        short_term_slope_30d=cast(float | None, row["short_term_slope_30d"]),
+        short_term_slope_60d=cast(float | None, row["short_term_slope_60d"]),
+        interpretation=cast(str, row["interpretation"]),
+        created_at=cast(datetime, row["created_at"]),
+    )
+
+
+def _competition_payload(snapshot: CompetitionSnapshot) -> dict[str, Any]:
+    return {
+        "mean_edge_30d": snapshot.mean_edge_30d,
+        "mean_spread_bps_30d": snapshot.mean_spread_bps_30d,
+        "edge_trend_slope_90d": snapshot.edge_trend_slope_90d,
+        "spread_trend_slope_90d": snapshot.spread_trend_slope_90d,
+        "trend_status": snapshot.trend_status,
+        "days_collected": snapshot.days_collected,
+        "interpretation": snapshot.interpretation,
+        "sample_count_30d": snapshot.sample_count_30d,
+        "last_snapshot_date": snapshot.snapshot_date.isoformat(),
+    }

--- a/src/pms/api/routes/decay.py
+++ b/src/pms/api/routes/decay.py
@@ -43,6 +43,22 @@ async def get_strategy_decay_status(
                 raise LookupError(msg)
             active_version_id = cast(str, row["active_version_id"])
 
+        version_row = await connection.fetchrow(
+            """
+            SELECT 1
+            FROM strategy_versions
+            WHERE strategy_id = $1 AND strategy_version_id = $2
+            """,
+            strategy_id,
+            active_version_id,
+        )
+        if version_row is None:
+            msg = (
+                "strategy version not found for "
+                f"strategy_id={strategy_id!r}, strategy_version_id={active_version_id!r}"
+            )
+            raise LookupError(msg)
+
         peak_row = await connection.fetchrow(
             """
             SELECT

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -133,6 +133,10 @@ class PMSSettings(BaseSettings):
     api_token: str | None = None
     live_account_reconciliation_required: bool = True
     live_emergency_audit_path: str = ".data/live-emergency-audit.jsonl"
+    regime_volatility_threshold: float = Field(default=0.15, ge=0.0)
+    regime_drift_threshold: float = Field(default=0.02, ge=0.0)
+    regime_min_resolved_samples: int = Field(default=5, ge=0)
+    decay_min_resolved_samples: int = Field(default=10, ge=0)
     polymarket: PolymarketSettings = Field(default_factory=PolymarketSettings)
     llm: LLMSettings = Field(default_factory=LLMSettings)
     risk: RiskSettings = Field(default_factory=RiskSettings)

--- a/src/pms/controller/_price_utils.py
+++ b/src/pms/controller/_price_utils.py
@@ -28,9 +28,56 @@ def best_ask(signal: MarketSignal) -> float | None:
     return min(asks)
 
 
+def best_bid(signal: MarketSignal) -> float | None:
+    raw_external_bid = signal.external_signal.get("best_bid")
+    external_bid = open_probability_or_none(raw_external_bid)
+    if external_bid is not None:
+        return external_bid
+
+    raw_bids = signal.orderbook.get("bids")
+    if not isinstance(raw_bids, list):
+        return None
+    bids: list[float] = []
+    for raw_level in raw_bids:
+        if not isinstance(raw_level, dict):
+            continue
+        price = open_probability_or_none(raw_level.get("price"))
+        size = positive_float_or_none(raw_level.get("size"))
+        if price is not None and size is not None:
+            bids.append(price)
+    if not bids:
+        return None
+    return max(bids)
+
+
+def spread_bps_at_decision(signal: MarketSignal) -> int | None:
+    explicit_spread = nonnegative_float_or_none(signal.external_signal.get("spread_bps"))
+    if explicit_spread is not None:
+        return int(round(explicit_spread))
+
+    bid = best_bid(signal)
+    ask = best_ask(signal)
+    if bid is None or ask is None or ask < bid:
+        return None
+    mid = (ask + bid) / 2.0
+    if mid <= 0.0:
+        return None
+    return int(round((ask - bid) / mid * 10_000))
+
+
 def open_probability_or_none(value: Any) -> float | None:
     parsed = positive_float_or_none(value)
     if parsed is None or parsed >= 1.0:
+        return None
+    return parsed
+
+
+def nonnegative_float_or_none(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not isfinite(parsed) or parsed < 0.0:
         return None
     return parsed
 

--- a/src/pms/controller/_price_utils.py
+++ b/src/pms/controller/_price_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation, ROUND_HALF_EVEN
 from math import isfinite
 from typing import Any
 
@@ -50,19 +51,33 @@ def best_bid(signal: MarketSignal) -> float | None:
     return max(bids)
 
 
-def spread_bps_at_decision(signal: MarketSignal) -> int | None:
+def spread_bps_at_decision(
+    signal: MarketSignal,
+    *,
+    token_id: str | None = None,
+    outcome: str | None = None,
+    yes_token_id: str | None = None,
+) -> int | None:
+    target_token_id = token_id or signal.token_id
+    uses_signal_token = target_token_id is None or target_token_id == signal.token_id
+
     explicit_spread = nonnegative_float_or_none(signal.external_signal.get("spread_bps"))
-    if explicit_spread is not None:
-        return int(round(explicit_spread))
+    if uses_signal_token and explicit_spread is not None:
+        return _rounded_decimal_int(Decimal(str(explicit_spread)))
 
     bid = best_bid(signal)
     ask = best_ask(signal)
     if bid is None or ask is None or ask < bid:
         return None
-    mid = (ask + bid) / 2.0
-    if mid <= 0.0:
-        return None
-    return int(round((ask - bid) / mid * 10_000))
+
+    if not uses_signal_token:
+        if outcome != "NO" or (yes_token_id is not None and signal.token_id != yes_token_id):
+            return None
+        no_bid = 1.0 - ask
+        no_ask = 1.0 - bid
+        return _spread_bps_from_bid_ask(no_bid, no_ask)
+
+    return _spread_bps_from_bid_ask(bid, ask)
 
 
 def open_probability_or_none(value: Any) -> float | None:
@@ -90,3 +105,29 @@ def positive_float_or_none(value: Any) -> float | None:
     if not isfinite(parsed) or parsed <= 0.0:
         return None
     return parsed
+
+
+def _spread_bps_from_bid_ask(bid: float, ask: float) -> int | None:
+    bid_dec = _decimal_or_none(bid)
+    ask_dec = _decimal_or_none(ask)
+    if bid_dec is None or ask_dec is None or ask_dec < bid_dec:
+        return None
+    mid = (ask_dec + bid_dec) / Decimal("2")
+    if mid <= 0:
+        return None
+    spread_bps = (ask_dec - bid_dec) / mid * Decimal("10000")
+    return _rounded_decimal_int(spread_bps)
+
+
+def _decimal_or_none(value: object) -> Decimal | None:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    if not parsed.is_finite():
+        return None
+    return parsed
+
+
+def _rounded_decimal_int(value: Decimal) -> int:
+    return int(value.to_integral_value(rounding=ROUND_HALF_EVEN))

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -251,6 +251,7 @@ class ControllerPipeline:
         now = datetime.now(tz=UTC)
         opportunity_side: Literal["yes", "no"] = "yes"
         decision_token_id = signal.token_id
+        decision_yes_token_id: str | None = signal.token_id
         decision_outcome: Literal["YES", "NO"] = "YES"
         decision_probability = yes_probability
         decision_price = yes_reference_price
@@ -284,6 +285,7 @@ class ControllerPipeline:
                     extra={"controller_diagnostic": self.last_diagnostic},
                 )
                 return None
+            decision_yes_token_id = outcome_tokens.yes_token_id
             decision_token_id = outcome_tokens.no_token_id
             decision_outcome = "NO"
             opportunity_side = "no"
@@ -365,7 +367,12 @@ class ControllerPipeline:
             outcome=decision_outcome,
             model_id=_decision_model_id(model_ids),
             intent_key=intent_key,
-            spread_bps_at_decision=spread_bps_at_decision(signal),
+            spread_bps_at_decision=spread_bps_at_decision(
+                signal,
+                token_id=decision_token_id,
+                outcome=decision_outcome,
+                yes_token_id=decision_yes_token_id,
+            ),
         )
 
     async def decide(

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from typing import Literal, TypeVar
 
 from pms.config import PMSSettings
-from pms.controller._price_utils import best_ask
+from pms.controller._price_utils import best_ask, spread_bps_at_decision
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.diagnostics import ControllerDiagnostic
 from pms.controller.factor_snapshot import (
@@ -365,6 +365,7 @@ class ControllerPipeline:
             outcome=decision_outcome,
             model_id=_decision_model_id(model_ids),
             intent_key=intent_key,
+            spread_bps_at_decision=spread_bps_at_decision(signal),
         )
 
     async def decide(

--- a/src/pms/core/models.py
+++ b/src/pms/core/models.py
@@ -85,6 +85,7 @@ class TradeDecision:
     outcome: Outcome = "YES"
     model_id: str | None = None
     intent_key: str | None = None
+    spread_bps_at_decision: int | None = None
 
     def __post_init__(self) -> None:
         if self.action is not None and self.side != self.action:
@@ -297,6 +298,8 @@ class EvalRecord:
     pnl: float = 0.0
     slippage_bps: float = 0.0
     filled: bool = True
+    edge_at_decision: float = 0.0
+    spread_bps_at_decision: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/pms/evaluation/adapters/scoring.py
+++ b/src/pms/evaluation/adapters/scoring.py
@@ -40,6 +40,8 @@ class Scorer:
             pnl=_pnl(fill, decision),
             slippage_bps=_slippage_bps(fill, decision),
             filled=fill.status == OrderStatus.MATCHED.value,
+            edge_at_decision=decision.expected_edge,
+            spread_bps_at_decision=decision.spread_bps_at_decision,
         )
 
 

--- a/src/pms/meta_evidence/__init__.py
+++ b/src/pms/meta_evidence/__init__.py
@@ -1,0 +1,1 @@
+"""Execution-passive strategy meta-evidence analytics."""

--- a/src/pms/meta_evidence/competition.py
+++ b/src/pms/meta_evidence/competition.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+import uuid
+
+from pms.core.models import EvalRecord
+from pms.meta_evidence.models import CompetitionSnapshot, TrendStatus
+
+
+def compute_competition_snapshot(
+    records: list[EvalRecord],
+    *,
+    strategy_id: str,
+    strategy_version_id: str,
+    snapshot_date: date,
+) -> CompetitionSnapshot:
+    window_records = [
+        record
+        for record in records
+        if (snapshot_date.toordinal() - record.recorded_at.date().toordinal()) < 30
+        and record.recorded_at.date() <= snapshot_date
+    ]
+    edge_values = [record.edge_at_decision for record in window_records]
+    spread_values = [
+        float(record.spread_bps_at_decision)
+        for record in window_records
+        if record.spread_bps_at_decision is not None
+    ]
+    collected_days = _days_collected(records, snapshot_date=snapshot_date)
+    trend_status: TrendStatus = "active" if collected_days >= 90 else "warming_up"
+    edge_slope_90d = _slope_by_day(
+        [
+            (record.recorded_at.date(), record.edge_at_decision)
+            for record in records
+            if (snapshot_date.toordinal() - record.recorded_at.date().toordinal()) < 90
+            and record.recorded_at.date() <= snapshot_date
+        ]
+    ) if collected_days >= 90 else None
+    spread_slope_90d = _slope_by_day(
+        [
+            (record.recorded_at.date(), float(record.spread_bps_at_decision))
+            for record in records
+            if record.spread_bps_at_decision is not None
+            and (snapshot_date.toordinal() - record.recorded_at.date().toordinal()) < 90
+            and record.recorded_at.date() <= snapshot_date
+        ]
+    ) if collected_days >= 90 else None
+
+    interpretation = (
+        "warming_up"
+        if trend_status == "warming_up"
+        else interpret_trends(
+            edge_trend_slope_90d=edge_slope_90d,
+            spread_trend_slope_90d=spread_slope_90d,
+        )
+    )
+    return CompetitionSnapshot(
+        snapshot_id=f"alpha-competition-{uuid.uuid4().hex}",
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        snapshot_date=snapshot_date,
+        mean_edge_30d=_mean(edge_values),
+        mean_spread_bps_30d=_mean(spread_values),
+        edge_trend_slope_90d=edge_slope_90d,
+        spread_trend_slope_90d=spread_slope_90d,
+        sample_count_30d=len(window_records),
+        trend_status=trend_status,
+        days_collected=collected_days,
+        short_term_slope_30d=None,
+        short_term_slope_60d=None,
+        interpretation=interpretation,
+        created_at=datetime.now(tz=UTC),
+    )
+
+
+def interpret_trends(
+    *,
+    edge_trend_slope_90d: float | None,
+    spread_trend_slope_90d: float | None,
+) -> str:
+    if edge_trend_slope_90d is None or spread_trend_slope_90d is None:
+        return "insufficient_trend_data"
+    if edge_trend_slope_90d < 0.0 and spread_trend_slope_90d < 0.0:
+        return "market_getting_efficient_edge_compressing"
+    if edge_trend_slope_90d < 0.0 and spread_trend_slope_90d >= 0.0:
+        return "strategy_edge_compressing"
+    if edge_trend_slope_90d >= 0.0 and spread_trend_slope_90d < 0.0:
+        return "edge_resilient_despite_tighter_spreads"
+    return "edge_and_spreads_expanding"
+
+
+def _mean(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _days_collected(records: list[EvalRecord], *, snapshot_date: date) -> int:
+    if not records:
+        return 0
+    first_day = min(record.recorded_at.date() for record in records)
+    return max(0, snapshot_date.toordinal() - first_day.toordinal() + 1)
+
+
+def _slope_by_day(points: list[tuple[date, float]]) -> float | None:
+    if len(points) < 2:
+        return None
+    x_values = [float(day.toordinal()) for day, _ in points]
+    y_values = [value for _, value in points]
+    x_mean = sum(x_values) / len(x_values)
+    y_mean = sum(y_values) / len(y_values)
+    denominator = sum((x_value - x_mean) ** 2 for x_value in x_values)
+    if denominator == 0.0:
+        return None
+    numerator = sum(
+        (x_value - x_mean) * (y_value - y_mean)
+        for x_value, y_value in zip(x_values, y_values, strict=True)
+    )
+    return numerator / denominator

--- a/src/pms/meta_evidence/competition.py
+++ b/src/pms/meta_evidence/competition.py
@@ -20,10 +20,15 @@ def compute_competition_snapshot(
         if (snapshot_date.toordinal() - record.recorded_at.date().toordinal()) < 30
         and record.recorded_at.date() <= snapshot_date
     ]
-    edge_values = [record.edge_at_decision for record in window_records]
+    edge_window_records = [
+        record
+        for record in window_records
+        if _has_captured_edge(record)
+    ]
+    edge_values = [record.edge_at_decision for record in edge_window_records]
     spread_values = [
         float(record.spread_bps_at_decision)
-        for record in window_records
+        for record in edge_window_records
         if record.spread_bps_at_decision is not None
     ]
     collected_days = _days_collected(records, snapshot_date=snapshot_date)
@@ -32,7 +37,8 @@ def compute_competition_snapshot(
         [
             (record.recorded_at.date(), record.edge_at_decision)
             for record in records
-            if (snapshot_date.toordinal() - record.recorded_at.date().toordinal()) < 90
+            if _has_captured_edge(record)
+            and (snapshot_date.toordinal() - record.recorded_at.date().toordinal()) < 90
             and record.recorded_at.date() <= snapshot_date
         ]
     ) if collected_days >= 90 else None
@@ -63,7 +69,7 @@ def compute_competition_snapshot(
         mean_spread_bps_30d=_mean(spread_values),
         edge_trend_slope_90d=edge_slope_90d,
         spread_trend_slope_90d=spread_slope_90d,
-        sample_count_30d=len(window_records),
+        sample_count_30d=len(edge_window_records),
         trend_status=trend_status,
         days_collected=collected_days,
         short_term_slope_30d=None,
@@ -93,6 +99,13 @@ def _mean(values: list[float]) -> float | None:
     if not values:
         return None
     return sum(values) / len(values)
+
+
+def _has_captured_edge(record: EvalRecord) -> bool:
+    # The 0015 migration backfills legacy eval rows with 0.0 because the column
+    # is NOT NULL. Controller decisions only emit positive edge decisions, so a
+    # zero value is the legacy/missing sentinel for this metric.
+    return record.edge_at_decision != 0.0
 
 
 def _days_collected(records: list[EvalRecord], *, snapshot_date: date) -> int:

--- a/src/pms/meta_evidence/decay.py
+++ b/src/pms/meta_evidence/decay.py
@@ -45,11 +45,14 @@ def compute_decay_status(
     if existing_peak is None or existing_peak.peak_sharpe_7d <= 0.0:
         status: DecayStatusValue = "insufficient_peak_data"
         ratio = None
+    elif sharpe_7d is None:
+        status = "insufficient_resolved_outcomes"
+        ratio = None
     else:
-        ratio = None if sharpe_7d is None else sharpe_7d / existing_peak.peak_sharpe_7d
-        if sharpe_7d is not None and sharpe_7d < 0.0:
+        ratio = sharpe_7d / existing_peak.peak_sharpe_7d
+        if sharpe_7d < 0.0:
             status = "negative"
-        elif ratio is not None and ratio < 0.5:
+        elif ratio < 0.5:
             status = "degraded"
         else:
             status = "healthy"

--- a/src/pms/meta_evidence/decay.py
+++ b/src/pms/meta_evidence/decay.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from math import sqrt
+
+from pms.core.models import EvalRecord
+from pms.meta_evidence.models import DecayStatus, DecayStatusValue, PerformancePeak
+
+
+def compute_decay_status(
+    records: list[EvalRecord],
+    *,
+    strategy_id: str,
+    strategy_version_id: str,
+    now: datetime,
+    min_resolved_samples: int = 10,
+    existing_peak: PerformancePeak | None = None,
+) -> DecayStatus:
+    resolved_records = [record for record in records if record.filled]
+    if len(resolved_records) < min_resolved_samples:
+        return DecayStatus(
+            strategy_id=strategy_id,
+            strategy_version_id=strategy_version_id,
+            decay_status="insufficient_resolved_outcomes",
+            rolling_sharpe_7d=None,
+            peak_sharpe_7d=None if existing_peak is None else existing_peak.peak_sharpe_7d,
+            sharpe_ratio_vs_peak=None,
+            rolling_sharpe_30d=None,
+            hit_rate_7d=None,
+            peak_hit_rate=None if existing_peak is None else existing_peak.peak_hit_rate,
+            trading_days_in_window=0,
+            resolved_sample_count=len(resolved_records),
+            min_resolved_samples=min_resolved_samples,
+            last_updated=now,
+        )
+
+    daily_pnl = _daily_pnl(resolved_records)
+    rolling_7d = _window_values(daily_pnl, end_date=now.date(), window_days=7)
+    rolling_30d = _window_values(daily_pnl, end_date=now.date(), window_days=30)
+    sharpe_7d = _sharpe(rolling_7d)
+    sharpe_30d = _sharpe(rolling_30d)
+    hit_rate_7d = _hit_rate(resolved_records, end_date=now.date(), window_days=7)
+
+    if existing_peak is None or existing_peak.peak_sharpe_7d <= 0.0:
+        status: DecayStatusValue = "insufficient_peak_data"
+        ratio = None
+    else:
+        ratio = None if sharpe_7d is None else sharpe_7d / existing_peak.peak_sharpe_7d
+        if sharpe_7d is not None and sharpe_7d < 0.0:
+            status = "negative"
+        elif ratio is not None and ratio < 0.5:
+            status = "degraded"
+        else:
+            status = "healthy"
+
+    return DecayStatus(
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        decay_status=status,
+        rolling_sharpe_7d=sharpe_7d,
+        peak_sharpe_7d=None if existing_peak is None else existing_peak.peak_sharpe_7d,
+        sharpe_ratio_vs_peak=ratio,
+        rolling_sharpe_30d=sharpe_30d,
+        hit_rate_7d=hit_rate_7d,
+        peak_hit_rate=None if existing_peak is None else existing_peak.peak_hit_rate,
+        trading_days_in_window=len(rolling_7d),
+        resolved_sample_count=len(resolved_records),
+        min_resolved_samples=min_resolved_samples,
+        last_updated=now,
+    )
+
+
+def _daily_pnl(records: list[EvalRecord]) -> dict[date, float]:
+    grouped: dict[date, float] = defaultdict(float)
+    for record in records:
+        grouped[record.recorded_at.date()] += record.pnl
+    return dict(grouped)
+
+
+def _window_values(
+    daily_pnl: dict[date, float],
+    *,
+    end_date: date,
+    window_days: int,
+) -> list[float]:
+    start_date = end_date - timedelta(days=window_days - 1)
+    return [
+        pnl
+        for day, pnl in sorted(daily_pnl.items())
+        if start_date <= day <= end_date
+    ]
+
+
+def _sharpe(values: list[float]) -> float | None:
+    if not values:
+        return None
+    mean = sum(values) / len(values)
+    if len(values) < 2:
+        return mean
+    variance = sum((value - mean) ** 2 for value in values) / (len(values) - 1)
+    if variance == 0.0:
+        return mean if mean >= 0.0 else -abs(mean)
+    return mean / sqrt(variance)
+
+
+def _hit_rate(records: list[EvalRecord], *, end_date: date, window_days: int) -> float | None:
+    start_date = end_date - timedelta(days=window_days - 1)
+    window_records = [
+        record
+        for record in records
+        if start_date <= record.recorded_at.date() <= end_date
+    ]
+    if not window_records:
+        return None
+    wins = sum(1 for record in window_records if record.pnl > 0.0)
+    return wins / len(window_records)

--- a/src/pms/meta_evidence/models.py
+++ b/src/pms/meta_evidence/models.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Literal
+
+
+ValidationRegime = Literal[
+    "low_vol_bull",
+    "high_vol_bear",
+    "election",
+    "range_bound",
+    "other",
+]
+RegimeSource = Literal["eval_records", "price_changes", "insufficient_data"]
+DecayStatusValue = Literal[
+    "healthy",
+    "degraded",
+    "negative",
+    "insufficient_resolved_outcomes",
+    "insufficient_peak_data",
+    "insufficient_data",
+]
+TrendStatus = Literal["warming_up", "active"]
+
+
+@dataclass(frozen=True)
+class RegimeClassification:
+    validation_regime: ValidationRegime
+    regime_source: RegimeSource
+    regime_sample_count: int
+    volatility: float | None
+    drift: float | None
+
+
+@dataclass(frozen=True)
+class PerformancePeak:
+    strategy_id: str
+    strategy_version_id: str
+    peak_sharpe_7d: float
+    peak_sharpe_30d: float
+    peak_hit_rate: float
+    recorded_at: datetime
+
+
+@dataclass(frozen=True)
+class DecayStatus:
+    strategy_id: str
+    strategy_version_id: str
+    decay_status: DecayStatusValue
+    rolling_sharpe_7d: float | None
+    peak_sharpe_7d: float | None
+    sharpe_ratio_vs_peak: float | None
+    rolling_sharpe_30d: float | None
+    hit_rate_7d: float | None
+    peak_hit_rate: float | None
+    trading_days_in_window: int
+    resolved_sample_count: int
+    min_resolved_samples: int
+    last_updated: datetime
+
+
+@dataclass(frozen=True)
+class CompetitionSnapshot:
+    snapshot_id: str
+    strategy_id: str
+    strategy_version_id: str
+    snapshot_date: date
+    mean_edge_30d: float | None
+    mean_spread_bps_30d: float | None
+    edge_trend_slope_90d: float | None
+    spread_trend_slope_90d: float | None
+    sample_count_30d: int
+    trend_status: TrendStatus
+    days_collected: int
+    short_term_slope_30d: float | None
+    short_term_slope_60d: float | None
+    interpretation: str
+    created_at: datetime

--- a/src/pms/meta_evidence/regime.py
+++ b/src/pms/meta_evidence/regime.py
@@ -18,7 +18,7 @@ def classify_regime(
     if len(resolved_records) >= min_resolved_samples:
         pnl_values = [record.pnl for record in resolved_records]
         volatility = _sample_stddev(pnl_values)
-        drift = pnl_values[-1] - pnl_values[0] if len(pnl_values) >= 2 else 0.0
+        drift = sum(pnl_values)
         return RegimeClassification(
             validation_regime=_classify(
                 volatility=volatility,
@@ -40,7 +40,7 @@ def classify_regime(
             if prices[index - 1] > 0.0
         ]
         volatility = _sample_stddev(returns)
-        drift = prices[-1] - prices[0]
+        drift = sum(returns)
         return RegimeClassification(
             validation_regime=_classify(
                 volatility=volatility,

--- a/src/pms/meta_evidence/regime.py
+++ b/src/pms/meta_evidence/regime.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from math import sqrt
+
+from pms.core.models import EvalRecord, PriceChange
+from pms.meta_evidence.models import RegimeClassification, ValidationRegime
+
+
+def classify_regime(
+    *,
+    eval_records: list[EvalRecord],
+    price_changes: list[PriceChange],
+    volatility_threshold: float,
+    drift_threshold: float,
+    min_resolved_samples: int,
+) -> RegimeClassification:
+    resolved_records = [record for record in eval_records if record.filled]
+    if len(resolved_records) >= min_resolved_samples:
+        pnl_values = [record.pnl for record in resolved_records]
+        volatility = _sample_stddev(pnl_values)
+        drift = pnl_values[-1] - pnl_values[0] if len(pnl_values) >= 2 else 0.0
+        return RegimeClassification(
+            validation_regime=_classify(
+                volatility=volatility,
+                drift=drift,
+                volatility_threshold=volatility_threshold,
+                drift_threshold=drift_threshold,
+            ),
+            regime_source="eval_records",
+            regime_sample_count=len(resolved_records),
+            volatility=volatility,
+            drift=drift,
+        )
+
+    prices = [change.price for change in sorted(price_changes, key=lambda item: item.ts)]
+    if len(prices) >= 2:
+        returns = [
+            (prices[index] - prices[index - 1]) / prices[index - 1]
+            for index in range(1, len(prices))
+            if prices[index - 1] > 0.0
+        ]
+        volatility = _sample_stddev(returns)
+        drift = prices[-1] - prices[0]
+        return RegimeClassification(
+            validation_regime=_classify(
+                volatility=volatility,
+                drift=drift,
+                volatility_threshold=volatility_threshold,
+                drift_threshold=drift_threshold,
+            ),
+            regime_source="price_changes",
+            regime_sample_count=len(prices),
+            volatility=volatility,
+            drift=drift,
+        )
+
+    return RegimeClassification(
+        validation_regime="other",
+        regime_source="insufficient_data",
+        regime_sample_count=len(prices),
+        volatility=None,
+        drift=None,
+    )
+
+
+def _classify(
+    *,
+    volatility: float,
+    drift: float,
+    volatility_threshold: float,
+    drift_threshold: float,
+) -> ValidationRegime:
+    low_volatility = volatility < volatility_threshold
+    if low_volatility and drift > drift_threshold:
+        return "low_vol_bull"
+    if not low_volatility and drift < -drift_threshold:
+        return "high_vol_bear"
+    if low_volatility and abs(drift) <= drift_threshold:
+        return "range_bound"
+    return "other"
+
+
+def _sample_stddev(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / (len(values) - 1)
+    return sqrt(variance)

--- a/src/pms/storage/decision_store.py
+++ b/src/pms/storage/decision_store.py
@@ -441,4 +441,10 @@ def _string_list(value: object) -> list[str]:
 def _optional_int(value: object) -> int | None:
     if value is None:
         return None
-    return int(cast(int | float | str, value))
+    if isinstance(value, bool):
+        return None
+    try:
+        numeric = float(cast(int | float | str, value))
+    except (TypeError, ValueError):
+        return None
+    return int(round(numeric))

--- a/src/pms/storage/decision_store.py
+++ b/src/pms/storage/decision_store.py
@@ -342,6 +342,7 @@ def _decision_payload(decision: TradeDecision) -> dict[str, object]:
         "outcome": decision.outcome,
         "model_id": decision.model_id,
         "intent_key": decision.intent_key,
+        "spread_bps_at_decision": decision.spread_bps_at_decision,
     }
 
 
@@ -388,6 +389,7 @@ def _decision_from_payload(payload: Mapping[str, Any]) -> TradeDecision:
         outcome=cast(Literal["YES", "NO"], payload.get("outcome", "YES")),
         model_id=cast(str | None, payload.get("model_id")),
         intent_key=cast(str | None, payload.get("intent_key")),
+        spread_bps_at_decision=_optional_int(payload.get("spread_bps_at_decision")),
     )
 
 
@@ -434,3 +436,9 @@ def _string_list(value: object) -> list[str]:
     if isinstance(value, list):
         return [str(item) for item in value]
     return []
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    return int(cast(int | float | str, value))

--- a/src/pms/storage/eval_store.py
+++ b/src/pms/storage/eval_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 import json
-from typing import cast
+from typing import SupportsFloat, cast
 
 import asyncpg
 
@@ -73,9 +73,12 @@ async def insert_eval_record_row(
             slippage_bps,
             filled,
             strategy_id,
-            strategy_version_id
+            strategy_version_id,
+            edge_at_decision,
+            spread_bps_at_decision
         ) VALUES (
-            $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14, $15
+            $1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11, $12, $13, $14, $15,
+            $16, $17
         )
         """,
         record.decision_id,
@@ -93,6 +96,8 @@ async def insert_eval_record_row(
         record.filled,
         record.strategy_id,
         record.strategy_version_id,
+        record.edge_at_decision,
+        record.spread_bps_at_decision,
     )
 
 
@@ -112,7 +117,9 @@ SELECT
     model_id,
     pnl,
     slippage_bps,
-    filled
+    filled,
+    edge_at_decision,
+    spread_bps_at_decision
 FROM eval_records
 ORDER BY recorded_at ASC, decision_id ASC
 """
@@ -134,7 +141,9 @@ SELECT
     model_id,
     pnl,
     slippage_bps,
-    filled
+    filled,
+    edge_at_decision,
+    spread_bps_at_decision
 FROM eval_records
 WHERE strategy_id = $1 AND strategy_version_id = $2
 ORDER BY recorded_at ASC, decision_id ASC
@@ -168,4 +177,19 @@ def _eval_record_from_row(row: asyncpg.Record) -> EvalRecord:
         pnl=cast(float, row["pnl"]),
         slippage_bps=cast(float, row["slippage_bps"]),
         filled=cast(bool, row["filled"]),
+        edge_at_decision=float(
+            cast(SupportsFloat, _row_value(row, "edge_at_decision", 0.0))
+        ),
+        spread_bps_at_decision=cast(
+            int | None,
+            _row_value(row, "spread_bps_at_decision", None),
+        ),
     )
+
+
+def _row_value(row: asyncpg.Record, key: str, default: object) -> object:
+    try:
+        value = row[key]
+    except (KeyError, IndexError):
+        return default
+    return default if value is None and default is not None else value

--- a/src/pms/storage/meta_evidence_store.py
+++ b/src/pms/storage/meta_evidence_store.py
@@ -62,7 +62,7 @@ class MetaEvidenceStore:
             )
         if row is None:
             return None
-        return _performance_peak_from_row(row)
+        return performance_peak_from_row(row)
 
     async def upsert_competition_snapshot(
         self,
@@ -154,10 +154,10 @@ class MetaEvidenceStore:
             )
         if row is None:
             return None
-        return _competition_snapshot_from_row(row)
+        return competition_snapshot_from_row(row)
 
 
-def _performance_peak_from_row(row: asyncpg.Record) -> PerformancePeak:
+def performance_peak_from_row(row: asyncpg.Record) -> PerformancePeak:
     return PerformancePeak(
         strategy_id=cast(str, row["strategy_id"]),
         strategy_version_id=cast(str, row["strategy_version_id"]),
@@ -168,7 +168,7 @@ def _performance_peak_from_row(row: asyncpg.Record) -> PerformancePeak:
     )
 
 
-def _competition_snapshot_from_row(row: asyncpg.Record) -> CompetitionSnapshot:
+def competition_snapshot_from_row(row: asyncpg.Record) -> CompetitionSnapshot:
     return CompetitionSnapshot(
         snapshot_id=cast(str, row["snapshot_id"]),
         strategy_id=cast(str, row["strategy_id"]),

--- a/src/pms/storage/meta_evidence_store.py
+++ b/src/pms/storage/meta_evidence_store.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import cast
+
+import asyncpg
+
+from pms.meta_evidence.models import CompetitionSnapshot, PerformancePeak, TrendStatus
+
+
+@dataclass
+class MetaEvidenceStore:
+    pool: asyncpg.Pool
+
+    async def upsert_performance_peak(self, peak: PerformancePeak) -> None:
+        async with self.pool.acquire() as connection:
+            await connection.execute(
+                """
+                INSERT INTO strategy_performance_peaks (
+                    strategy_id,
+                    strategy_version_id,
+                    peak_sharpe_7d,
+                    peak_sharpe_30d,
+                    peak_hit_rate,
+                    recorded_at
+                ) VALUES ($1, $2, $3, $4, $5, $6)
+                ON CONFLICT (strategy_id, strategy_version_id) DO UPDATE
+                SET peak_sharpe_7d = EXCLUDED.peak_sharpe_7d,
+                    peak_sharpe_30d = EXCLUDED.peak_sharpe_30d,
+                    peak_hit_rate = EXCLUDED.peak_hit_rate,
+                    recorded_at = EXCLUDED.recorded_at
+                """,
+                peak.strategy_id,
+                peak.strategy_version_id,
+                peak.peak_sharpe_7d,
+                peak.peak_sharpe_30d,
+                peak.peak_hit_rate,
+                peak.recorded_at,
+            )
+
+    async def get_performance_peak(
+        self,
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> PerformancePeak | None:
+        async with self.pool.acquire() as connection:
+            row = await connection.fetchrow(
+                """
+                SELECT
+                    strategy_id,
+                    strategy_version_id,
+                    peak_sharpe_7d,
+                    peak_sharpe_30d,
+                    peak_hit_rate,
+                    recorded_at
+                FROM strategy_performance_peaks
+                WHERE strategy_id = $1 AND strategy_version_id = $2
+                """,
+                strategy_id,
+                strategy_version_id,
+            )
+        if row is None:
+            return None
+        return _performance_peak_from_row(row)
+
+    async def upsert_competition_snapshot(
+        self,
+        snapshot: CompetitionSnapshot,
+    ) -> None:
+        async with self.pool.acquire() as connection:
+            await connection.execute(
+                """
+                INSERT INTO alpha_competition_snapshots (
+                    snapshot_id,
+                    strategy_id,
+                    strategy_version_id,
+                    snapshot_date,
+                    mean_edge_30d,
+                    mean_spread_bps_30d,
+                    edge_trend_slope_90d,
+                    spread_trend_slope_90d,
+                    sample_count_30d,
+                    trend_status,
+                    days_collected,
+                    short_term_slope_30d,
+                    short_term_slope_60d,
+                    interpretation,
+                    created_at
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+                )
+                ON CONFLICT (strategy_id, strategy_version_id, snapshot_date) DO UPDATE
+                SET mean_edge_30d = EXCLUDED.mean_edge_30d,
+                    mean_spread_bps_30d = EXCLUDED.mean_spread_bps_30d,
+                    edge_trend_slope_90d = EXCLUDED.edge_trend_slope_90d,
+                    spread_trend_slope_90d = EXCLUDED.spread_trend_slope_90d,
+                    sample_count_30d = EXCLUDED.sample_count_30d,
+                    trend_status = EXCLUDED.trend_status,
+                    days_collected = EXCLUDED.days_collected,
+                    short_term_slope_30d = EXCLUDED.short_term_slope_30d,
+                    short_term_slope_60d = EXCLUDED.short_term_slope_60d,
+                    interpretation = EXCLUDED.interpretation,
+                    created_at = EXCLUDED.created_at
+                """,
+                snapshot.snapshot_id,
+                snapshot.strategy_id,
+                snapshot.strategy_version_id,
+                snapshot.snapshot_date,
+                snapshot.mean_edge_30d,
+                snapshot.mean_spread_bps_30d,
+                snapshot.edge_trend_slope_90d,
+                snapshot.spread_trend_slope_90d,
+                snapshot.sample_count_30d,
+                snapshot.trend_status,
+                snapshot.days_collected,
+                snapshot.short_term_slope_30d,
+                snapshot.short_term_slope_60d,
+                snapshot.interpretation,
+                snapshot.created_at,
+            )
+
+    async def get_latest_competition_snapshot(
+        self,
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> CompetitionSnapshot | None:
+        async with self.pool.acquire() as connection:
+            row = await connection.fetchrow(
+                """
+                SELECT
+                    snapshot_id,
+                    strategy_id,
+                    strategy_version_id,
+                    snapshot_date,
+                    mean_edge_30d,
+                    mean_spread_bps_30d,
+                    edge_trend_slope_90d,
+                    spread_trend_slope_90d,
+                    sample_count_30d,
+                    trend_status,
+                    days_collected,
+                    short_term_slope_30d,
+                    short_term_slope_60d,
+                    interpretation,
+                    created_at
+                FROM alpha_competition_snapshots
+                WHERE strategy_id = $1 AND strategy_version_id = $2
+                ORDER BY snapshot_date DESC
+                LIMIT 1
+                """,
+                strategy_id,
+                strategy_version_id,
+            )
+        if row is None:
+            return None
+        return _competition_snapshot_from_row(row)
+
+
+def _performance_peak_from_row(row: asyncpg.Record) -> PerformancePeak:
+    return PerformancePeak(
+        strategy_id=cast(str, row["strategy_id"]),
+        strategy_version_id=cast(str, row["strategy_version_id"]),
+        peak_sharpe_7d=float(cast(float, row["peak_sharpe_7d"])),
+        peak_sharpe_30d=float(cast(float, row["peak_sharpe_30d"])),
+        peak_hit_rate=float(cast(float, row["peak_hit_rate"])),
+        recorded_at=cast(datetime, row["recorded_at"]),
+    )
+
+
+def _competition_snapshot_from_row(row: asyncpg.Record) -> CompetitionSnapshot:
+    return CompetitionSnapshot(
+        snapshot_id=cast(str, row["snapshot_id"]),
+        strategy_id=cast(str, row["strategy_id"]),
+        strategy_version_id=cast(str, row["strategy_version_id"]),
+        snapshot_date=cast(date, row["snapshot_date"]),
+        mean_edge_30d=cast(float | None, row["mean_edge_30d"]),
+        mean_spread_bps_30d=cast(float | None, row["mean_spread_bps_30d"]),
+        edge_trend_slope_90d=cast(float | None, row["edge_trend_slope_90d"]),
+        spread_trend_slope_90d=cast(float | None, row["spread_trend_slope_90d"]),
+        sample_count_30d=cast(int, row["sample_count_30d"]),
+        trend_status=cast(TrendStatus, row["trend_status"]),
+        days_collected=cast(int, row["days_collected"]),
+        short_term_slope_30d=cast(float | None, row["short_term_slope_30d"]),
+        short_term_slope_60d=cast(float | None, row["short_term_slope_60d"]),
+        interpretation=cast(str, row["interpretation"]),
+        created_at=cast(datetime, row["created_at"]),
+    )

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -161,12 +161,19 @@ class PostgresStrategyRegistry:
         WHERE strategy_id = $1 AND strategy_version_id = $2
         """
         async with self._pool.acquire() as connection:
-            await connection.execute(
+            status = await connection.execute(
                 query,
                 strategy_id,
                 strategy_version_id,
                 metadata_json,
             )
+        updated = _command_tag_row_count(status)
+        if updated != 1:
+            msg = (
+                "No strategy_versions row matched "
+                f"strategy_id={strategy_id!r}, strategy_version_id={strategy_version_id!r}"
+            )
+            raise LookupError(msg)
 
     async def get_by_id(self, strategy_id: str) -> Strategy | None:
         query = """
@@ -571,6 +578,13 @@ def _json_string(value: object, field_name: str) -> str:
         msg = f"{field_name} must decode to a string"
         raise TypeError(msg)
     return value
+
+
+def _command_tag_row_count(status: str) -> int | None:
+    try:
+        return int(status.rsplit(" ", 1)[-1])
+    except (IndexError, ValueError):
+        return None
 
 
 def _json_required_field(

--- a/src/pms/storage/strategy_registry.py
+++ b/src/pms/storage/strategy_registry.py
@@ -143,6 +143,31 @@ class PostgresStrategyRegistry:
             created_at=_ensure_utc(created_at),
         )
 
+    async def set_version_metadata(
+        self,
+        strategy_id: str,
+        strategy_version_id: str,
+        metadata: dict[str, object],
+    ) -> None:
+        metadata_json = json.dumps(
+            metadata,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        query = """
+        UPDATE strategy_versions
+        SET metadata_json = metadata_json || $3::jsonb
+        WHERE strategy_id = $1 AND strategy_version_id = $2
+        """
+        async with self._pool.acquire() as connection:
+            await connection.execute(
+                query,
+                strategy_id,
+                strategy_version_id,
+                metadata_json,
+            )
+
     async def get_by_id(self, strategy_id: str) -> Strategy | None:
         query = """
         SELECT versions.config_json

--- a/tests/fixtures/family_f_evalrecord_schema.json
+++ b/tests/fixtures/family_f_evalrecord_schema.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "family_f_evalrecord_schema_v1",
+  "table": "eval_records",
+  "source": "Family F pms-strategy-meta-evidence-v1 CP01a",
+  "tables": [
+    {
+      "table": "eval_records",
+      "columns": [
+        {"column_name": "decision_id", "data_type": "text", "is_nullable": "NO"},
+        {"column_name": "market_id", "data_type": "text", "is_nullable": "NO"},
+        {"column_name": "prob_estimate", "data_type": "double precision", "is_nullable": "NO"},
+        {"column_name": "resolved_outcome", "data_type": "double precision", "is_nullable": "NO"},
+        {"column_name": "brier_score", "data_type": "double precision", "is_nullable": "NO"},
+        {"column_name": "fill_status", "data_type": "text", "is_nullable": "NO"},
+        {"column_name": "recorded_at", "data_type": "timestamp with time zone", "is_nullable": "NO"},
+        {"column_name": "citations", "data_type": "jsonb", "is_nullable": "NO", "column_default": "'[]'::jsonb"},
+        {"column_name": "category", "data_type": "text", "is_nullable": "YES"},
+        {"column_name": "model_id", "data_type": "text", "is_nullable": "YES"},
+        {"column_name": "pnl", "data_type": "double precision", "is_nullable": "NO", "column_default": "0.0"},
+        {"column_name": "slippage_bps", "data_type": "double precision", "is_nullable": "NO", "column_default": "0.0"},
+        {"column_name": "filled", "data_type": "boolean", "is_nullable": "NO", "column_default": "true"},
+        {"column_name": "strategy_id", "data_type": "text", "is_nullable": "NO"},
+        {"column_name": "strategy_version_id", "data_type": "text", "is_nullable": "NO"},
+        {"column_name": "edge_at_decision", "data_type": "double precision", "is_nullable": "NO", "column_default": "0.0"},
+        {"column_name": "spread_bps_at_decision", "data_type": "integer", "is_nullable": "YES"}
+      ]
+    },
+    {
+      "table": "strategy_versions",
+      "columns": [
+        {"column_name": "strategy_version_id", "data_type": "text", "is_nullable": "NO"},
+        {"column_name": "strategy_id", "data_type": "text", "is_nullable": "NO"},
+        {"column_name": "config_json", "data_type": "jsonb", "is_nullable": "NO"},
+        {"column_name": "metadata_json", "data_type": "jsonb", "is_nullable": "NO", "column_default": "'{}'::jsonb"},
+        {"column_name": "created_at", "data_type": "timestamp with time zone", "is_nullable": "NO"}
+      ],
+      "namespace_contracts": {
+        "promotion": "Family A writes scorecard artifacts under metadata_json.promotion"
+      }
+    }
+  ],
+  "columns": [
+    {"column_name": "decision_id", "data_type": "text", "is_nullable": "NO"},
+    {"column_name": "market_id", "data_type": "text", "is_nullable": "NO"},
+    {"column_name": "prob_estimate", "data_type": "double precision", "is_nullable": "NO"},
+    {"column_name": "resolved_outcome", "data_type": "double precision", "is_nullable": "NO"},
+    {"column_name": "brier_score", "data_type": "double precision", "is_nullable": "NO"},
+    {"column_name": "fill_status", "data_type": "text", "is_nullable": "NO"},
+    {"column_name": "recorded_at", "data_type": "timestamp with time zone", "is_nullable": "NO"},
+    {"column_name": "citations", "data_type": "jsonb", "is_nullable": "NO", "column_default": "'[]'::jsonb"},
+    {"column_name": "category", "data_type": "text", "is_nullable": "YES"},
+    {"column_name": "model_id", "data_type": "text", "is_nullable": "YES"},
+    {"column_name": "pnl", "data_type": "double precision", "is_nullable": "NO", "column_default": "0.0"},
+    {"column_name": "slippage_bps", "data_type": "double precision", "is_nullable": "NO", "column_default": "0.0"},
+    {"column_name": "filled", "data_type": "boolean", "is_nullable": "NO", "column_default": "true"},
+    {"column_name": "strategy_id", "data_type": "text", "is_nullable": "NO"},
+    {"column_name": "strategy_version_id", "data_type": "text", "is_nullable": "NO"},
+    {"column_name": "edge_at_decision", "data_type": "double precision", "is_nullable": "NO", "column_default": "0.0"},
+    {"column_name": "spread_bps_at_decision", "data_type": "integer", "is_nullable": "YES"}
+  ]
+}

--- a/tests/integration/test_schema_apply_aggregate.py
+++ b/tests/integration/test_schema_apply_aggregate.py
@@ -27,6 +27,7 @@ EXPECTED_COLUMNS: dict[str, list[tuple[str, str]]] = {
         ("strategy_version_id", "text"),
         ("strategy_id", "text"),
         ("config_json", "jsonb"),
+        ("metadata_json", "jsonb"),
         ("created_at", "timestamp with time zone"),
     ],
     "strategy_factors": [

--- a/tests/integration/test_schema_apply_inner.py
+++ b/tests/integration/test_schema_apply_inner.py
@@ -43,6 +43,8 @@ STRATEGY_INDEXES = [
 ]
 INNER_RING_NOT_NULL_TABLES = [
     *STRATEGY_TABLES,
+    "alpha_competition_snapshots",
+    "strategy_performance_peaks",
     "strategy_runs",
     "backtest_live_comparisons",
 ]

--- a/tests/unit/test_meta_evidence_analytics.py
+++ b/tests/unit/test_meta_evidence_analytics.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from pms.core.enums import OrderStatus
+from pms.core.models import EvalRecord, PriceChange
+from pms.meta_evidence.competition import (
+    compute_competition_snapshot,
+    interpret_trends,
+)
+from pms.meta_evidence.decay import compute_decay_status
+from pms.meta_evidence.models import PerformancePeak
+from pms.meta_evidence.regime import classify_regime
+
+
+def _eval_record(
+    *,
+    decision_id: str,
+    recorded_at: datetime,
+    pnl: float,
+    edge_at_decision: float = 0.05,
+    spread_bps_at_decision: int | None = 200,
+    strategy_id: str = "meta-strategy",
+    strategy_version_id: str = "meta-v1",
+) -> EvalRecord:
+    return EvalRecord(
+        market_id="market-meta",
+        decision_id=decision_id,
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        prob_estimate=0.7,
+        resolved_outcome=1.0,
+        brier_score=0.09,
+        fill_status=OrderStatus.MATCHED.value,
+        recorded_at=recorded_at,
+        citations=["unit"],
+        pnl=pnl,
+        slippage_bps=10.0,
+        filled=True,
+        edge_at_decision=edge_at_decision,
+        spread_bps_at_decision=spread_bps_at_decision,
+    )
+
+
+def _price_change(index: int, *, price: float) -> PriceChange:
+    return PriceChange(
+        id=index,
+        market_id="market-meta",
+        token_id="token-meta",
+        ts=datetime(2026, 5, 1 + index, tzinfo=UTC),
+        side="BUY",
+        price=price,
+        size=10.0,
+        best_bid=price - 0.01,
+        best_ask=price + 0.01,
+        hash=None,
+    )
+
+
+def test_regime_classifier_uses_price_changes_fallback_for_sparse_eval_records() -> None:
+    result = classify_regime(
+        eval_records=[],
+        price_changes=[
+            _price_change(0, price=0.40),
+            _price_change(1, price=0.405),
+            _price_change(2, price=0.41),
+        ],
+        volatility_threshold=0.15,
+        drift_threshold=0.005,
+        min_resolved_samples=5,
+    )
+
+    assert result.validation_regime == "low_vol_bull"
+    assert result.regime_source == "price_changes"
+    assert result.regime_sample_count == 3
+
+
+def test_decay_status_reports_insufficient_resolved_outcomes_before_sample_gate() -> None:
+    now = datetime(2026, 5, 30, tzinfo=UTC)
+    records = [
+        _eval_record(decision_id=f"record-{index}", recorded_at=now, pnl=1.0)
+        for index in range(3)
+    ]
+
+    status = compute_decay_status(
+        records,
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        now=now,
+        min_resolved_samples=10,
+    )
+
+    assert status.decay_status == "insufficient_resolved_outcomes"
+    assert status.resolved_sample_count == 3
+    assert status.min_resolved_samples == 10
+
+
+def test_decay_status_flags_degraded_when_rolling_sharpe_halves_from_peak() -> None:
+    now = datetime(2026, 5, 30, tzinfo=UTC)
+    records = [
+        _eval_record(
+            decision_id=f"record-{index}",
+            recorded_at=now - timedelta(days=19 - index),
+            pnl=10.0 if index < 10 else -1.0,
+        )
+        for index in range(20)
+    ]
+    peak = PerformancePeak(
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        peak_sharpe_7d=4.0,
+        peak_sharpe_30d=4.0,
+        peak_hit_rate=1.0,
+        recorded_at=now - timedelta(days=1),
+    )
+
+    status = compute_decay_status(
+        records,
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        now=now,
+        min_resolved_samples=3,
+        existing_peak=peak,
+    )
+
+    assert status.decay_status in {"degraded", "negative"}
+    assert status.sharpe_ratio_vs_peak is not None
+    assert status.sharpe_ratio_vs_peak < 0.5
+
+
+def test_competition_snapshot_warmup_and_interpretation_matrix() -> None:
+    snapshot_date = date(2026, 5, 30)
+    records = [
+        _eval_record(
+            decision_id=f"record-{index}",
+            recorded_at=datetime(2026, 5, 1 + index, tzinfo=UTC),
+            pnl=1.0,
+            edge_at_decision=0.05 - index * 0.001,
+            spread_bps_at_decision=200 - index,
+        )
+        for index in range(10)
+    ]
+
+    snapshot = compute_competition_snapshot(
+        records,
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        snapshot_date=snapshot_date,
+    )
+
+    assert snapshot.trend_status == "warming_up"
+    assert snapshot.sample_count_30d == 10
+    assert snapshot.mean_edge_30d == pytest.approx(0.0455)
+    assert snapshot.mean_spread_bps_30d == pytest.approx(195.5)
+    assert (
+        interpret_trends(edge_trend_slope_90d=-0.01, spread_trend_slope_90d=-0.01)
+        == "market_getting_efficient_edge_compressing"
+    )

--- a/tests/unit/test_meta_evidence_analytics.py
+++ b/tests/unit/test_meta_evidence_analytics.py
@@ -75,6 +75,7 @@ def test_regime_classifier_uses_price_changes_fallback_for_sparse_eval_records()
     assert result.validation_regime == "low_vol_bull"
     assert result.regime_source == "price_changes"
     assert result.regime_sample_count == 3
+    assert result.drift == pytest.approx(0.024845679012345644)
 
 
 def test_decay_status_reports_insufficient_resolved_outcomes_before_sample_gate() -> None:
@@ -130,6 +131,40 @@ def test_decay_status_flags_degraded_when_rolling_sharpe_halves_from_peak() -> N
     assert status.sharpe_ratio_vs_peak < 0.5
 
 
+def test_decay_status_reports_insufficient_when_trailing_window_is_empty() -> None:
+    now = datetime(2026, 5, 30, tzinfo=UTC)
+    records = [
+        _eval_record(
+            decision_id=f"record-{index}",
+            recorded_at=now - timedelta(days=30 + index),
+            pnl=1.0,
+        )
+        for index in range(12)
+    ]
+    peak = PerformancePeak(
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        peak_sharpe_7d=4.0,
+        peak_sharpe_30d=4.0,
+        peak_hit_rate=1.0,
+        recorded_at=now - timedelta(days=10),
+    )
+
+    status = compute_decay_status(
+        records,
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        now=now,
+        min_resolved_samples=10,
+        existing_peak=peak,
+    )
+
+    assert status.decay_status == "insufficient_resolved_outcomes"
+    assert status.rolling_sharpe_7d is None
+    assert status.sharpe_ratio_vs_peak is None
+    assert status.trading_days_in_window == 0
+
+
 def test_competition_snapshot_warmup_and_interpretation_matrix() -> None:
     snapshot_date = date(2026, 5, 30)
     records = [
@@ -158,3 +193,64 @@ def test_competition_snapshot_warmup_and_interpretation_matrix() -> None:
         interpret_trends(edge_trend_slope_90d=-0.01, spread_trend_slope_90d=-0.01)
         == "market_getting_efficient_edge_compressing"
     )
+
+
+def test_competition_snapshot_excludes_legacy_defaulted_edges() -> None:
+    snapshot_date = date(2026, 5, 30)
+    records = [
+        _eval_record(
+            decision_id="legacy-default-edge",
+            recorded_at=datetime(2026, 5, 29, tzinfo=UTC),
+            pnl=1.0,
+            edge_at_decision=0.0,
+            spread_bps_at_decision=500,
+        ),
+        _eval_record(
+            decision_id="captured-edge",
+            recorded_at=datetime(2026, 5, 30, tzinfo=UTC),
+            pnl=1.0,
+            edge_at_decision=0.08,
+            spread_bps_at_decision=120,
+        ),
+    ]
+
+    snapshot = compute_competition_snapshot(
+        records,
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        snapshot_date=snapshot_date,
+    )
+
+    assert snapshot.sample_count_30d == 1
+    assert snapshot.mean_edge_30d == pytest.approx(0.08)
+    assert snapshot.mean_spread_bps_30d == pytest.approx(120.0)
+
+
+def test_regime_classifier_uses_cumulative_pnl_drift_for_eval_records() -> None:
+    result = classify_regime(
+        eval_records=[
+            _eval_record(
+                decision_id="first-loss",
+                recorded_at=datetime(2026, 5, 1, tzinfo=UTC),
+                pnl=-1.0,
+            ),
+            _eval_record(
+                decision_id="second-win",
+                recorded_at=datetime(2026, 5, 2, tzinfo=UTC),
+                pnl=1.0,
+            ),
+            _eval_record(
+                decision_id="third-win",
+                recorded_at=datetime(2026, 5, 3, tzinfo=UTC),
+                pnl=1.0,
+            ),
+        ],
+        price_changes=[],
+        volatility_threshold=2.0,
+        drift_threshold=0.5,
+        min_resolved_samples=3,
+    )
+
+    assert result.regime_source == "eval_records"
+    assert result.drift == pytest.approx(1.0)
+    assert result.validation_regime == "low_vol_bull"

--- a/tests/unit/test_meta_evidence_api.py
+++ b/tests/unit/test_meta_evidence_api.py
@@ -11,9 +11,15 @@ from pms.core.enums import OrderStatus
 
 
 class _Connection:
+    def __init__(self, *, version_exists: bool = True) -> None:
+        self.version_exists = version_exists
+
     async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
         if "SELECT active_version_id" in query:
             return {"active_version_id": "meta-v1"}
+        if "FROM strategy_versions" in query:
+            assert args == ("meta-strategy", "meta-v1")
+            return {"exists": 1} if self.version_exists else None
         if "FROM strategy_performance_peaks" in query:
             return {
                 "strategy_id": "meta-strategy",
@@ -77,16 +83,22 @@ class _Connection:
 
 
 class _Acquire:
+    def __init__(self, connection: _Connection | None = None) -> None:
+        self.connection = connection or _Connection()
+
     async def __aenter__(self) -> _Connection:
-        return _Connection()
+        return self.connection
 
     async def __aexit__(self, *_: object) -> None:
         return None
 
 
 class _Pool:
+    def __init__(self, connection: _Connection | None = None) -> None:
+        self.connection = connection or _Connection()
+
     def acquire(self) -> _Acquire:
-        return _Acquire()
+        return _Acquire(self.connection)
 
 
 @pytest.mark.asyncio
@@ -111,3 +123,15 @@ async def test_decay_status_route_payload_includes_decay_and_competition_metrics
         "sample_count_30d": 12,
         "last_snapshot_date": "2026-05-06",
     }
+
+
+@pytest.mark.asyncio
+async def test_decay_status_route_rejects_unknown_explicit_strategy_version() -> None:
+    pool = _Pool(_Connection(version_exists=False))
+
+    with pytest.raises(LookupError, match="strategy version not found"):
+        await get_strategy_decay_status(
+            cast(asyncpg.Pool, pool),
+            strategy_id="meta-strategy",
+            strategy_version_id="meta-v1",
+        )

--- a/tests/unit/test_meta_evidence_api.py
+++ b/tests/unit/test_meta_evidence_api.py
@@ -46,7 +46,8 @@ class _Connection:
 
     async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
         assert "FROM eval_records" in query
-        del args
+        assert "recorded_at >= $3" in query
+        assert len(args) == 3
         return [
             {
                 "market_id": "market-meta",

--- a/tests/unit/test_meta_evidence_api.py
+++ b/tests/unit/test_meta_evidence_api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import cast
+
+import asyncpg
+import pytest
+
+from pms.api.routes.decay import get_strategy_decay_status
+from pms.core.enums import OrderStatus
+
+
+class _Connection:
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
+        if "SELECT active_version_id" in query:
+            return {"active_version_id": "meta-v1"}
+        if "FROM strategy_performance_peaks" in query:
+            return {
+                "strategy_id": "meta-strategy",
+                "strategy_version_id": "meta-v1",
+                "peak_sharpe_7d": 1.0,
+                "peak_sharpe_30d": 1.0,
+                "peak_hit_rate": 1.0,
+                "recorded_at": datetime(2026, 5, 5, tzinfo=UTC),
+            }
+        if "FROM alpha_competition_snapshots" in query:
+            return {
+                "snapshot_id": "snapshot-meta",
+                "strategy_id": "meta-strategy",
+                "strategy_version_id": "meta-v1",
+                "snapshot_date": date(2026, 5, 6),
+                "mean_edge_30d": 0.05,
+                "mean_spread_bps_30d": 120.0,
+                "edge_trend_slope_90d": None,
+                "spread_trend_slope_90d": None,
+                "sample_count_30d": 12,
+                "trend_status": "warming_up",
+                "days_collected": 12,
+                "short_term_slope_30d": None,
+                "short_term_slope_60d": None,
+                "interpretation": "warming_up",
+                "created_at": datetime(2026, 5, 6, tzinfo=UTC),
+            }
+        del query, args
+        return None
+
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+        assert "FROM eval_records" in query
+        del args
+        return [
+            {
+                "market_id": "market-meta",
+                "decision_id": f"decision-{index}",
+                "strategy_id": "meta-strategy",
+                "strategy_version_id": "meta-v1",
+                "prob_estimate": 0.7,
+                "resolved_outcome": 1.0,
+                "brier_score": 0.09,
+                "fill_status": OrderStatus.MATCHED.value,
+                "recorded_at": datetime(2026, 5, 1 + index, tzinfo=UTC),
+                "citations": ["unit"],
+                "category": None,
+                "model_id": None,
+                "pnl": 1.0,
+                "slippage_bps": 10.0,
+                "filled": True,
+                "edge_at_decision": 0.05,
+                "spread_bps_at_decision": 120,
+            }
+            for index in range(10)
+        ]
+
+    async def execute(self, query: str, *args: object) -> str:
+        del query, args
+        return "OK"
+
+
+class _Acquire:
+    async def __aenter__(self) -> _Connection:
+        return _Connection()
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class _Pool:
+    def acquire(self) -> _Acquire:
+        return _Acquire()
+
+
+@pytest.mark.asyncio
+async def test_decay_status_route_payload_includes_decay_and_competition_metrics() -> None:
+    payload = await get_strategy_decay_status(
+        cast(asyncpg.Pool, _Pool()),
+        strategy_id="meta-strategy",
+    )
+
+    assert payload["strategy_id"] == "meta-strategy"
+    assert payload["strategy_version_id"] == "meta-v1"
+    assert payload["decay_status"] in {"healthy", "insufficient_peak_data"}
+    assert payload["resolved_sample_count"] == 10
+    assert payload["alpha_competition"] == {
+        "mean_edge_30d": 0.05,
+        "mean_spread_bps_30d": 120.0,
+        "edge_trend_slope_90d": None,
+        "spread_trend_slope_90d": None,
+        "trend_status": "warming_up",
+        "days_collected": 12,
+        "interpretation": "warming_up",
+        "sample_count_30d": 12,
+        "last_snapshot_date": "2026-05-06",
+    }

--- a/tests/unit/test_meta_evidence_capture.py
+++ b/tests/unit/test_meta_evidence_capture.py
@@ -8,6 +8,7 @@ import asyncpg
 import pytest
 
 from pms.config import ControllerSettings, PMSSettings
+from pms.controller.outcome_tokens import OutcomeTokens
 from pms.controller.pipeline import ControllerPipeline
 from pms.core.enums import OrderStatus, Side, TimeInForce
 from pms.core.interfaces import IForecaster
@@ -27,6 +28,17 @@ class ConstantForecaster:
     async def forecast(self, signal: MarketSignal) -> float:
         del signal
         return self.probability
+
+
+class StaticOutcomeTokenResolver:
+    async def resolve(
+        self,
+        *,
+        market_id: str,
+        signal_token_id: str | None,
+    ) -> OutcomeTokens:
+        del market_id
+        return OutcomeTokens(yes_token_id=signal_token_id, no_token_id="token-meta-no")
 
 
 class _RecordingConnection:
@@ -186,6 +198,22 @@ async def test_controller_computes_spread_bps_from_orderbook_when_missing() -> N
     assert decision.spread_bps_at_decision == 500
 
 
+@pytest.mark.asyncio
+async def test_controller_captures_buy_no_spread_for_traded_token() -> None:
+    pipeline = ControllerPipeline(
+        forecasters=(cast(IForecaster, ConstantForecaster(0.3)),),
+        outcome_token_resolver=StaticOutcomeTokenResolver(),
+        settings=PMSSettings(),
+    )
+
+    decision = await pipeline.decide(_signal(), portfolio=_portfolio())
+
+    assert decision is not None
+    assert decision.outcome == "NO"
+    assert decision.token_id == "token-meta-no"
+    assert decision.spread_bps_at_decision == 333
+
+
 def test_scorer_copies_decision_edge_and_spread_to_eval_record() -> None:
     record = Scorer().score(_fill(), _decision(spread_bps_at_decision=321))
 
@@ -206,7 +234,11 @@ async def test_decision_store_round_trips_spread_bps_in_payload() -> None:
         expires_at=created_at + timedelta(minutes=15),
     )
 
-    payload_args = connection.execute_calls[2][1]
+    payload_args = next(
+        args
+        for query, args, _ in connection.execute_calls
+        if "INSERT INTO decision_payloads" in query
+    )
     payload = json.loads(cast(str, payload_args[1]))
     assert payload["spread_bps_at_decision"] == 456
 
@@ -253,3 +285,72 @@ async def test_decision_store_round_trips_spread_bps_in_payload() -> None:
     rows = await store.read_decisions(limit=1)
 
     assert rows[0].decision.spread_bps_at_decision == 789
+
+
+@pytest.mark.asyncio
+async def test_decision_store_tolerates_float_string_and_malformed_spread_payload() -> None:
+    connection = _RecordingConnection()
+    store = DecisionStore(cast(asyncpg.Pool, _Pool(connection)))
+    created_at = datetime(2026, 5, 6, tzinfo=UTC)
+
+    base_payload = {
+        "decision_id": "decision-meta-capture",
+        "market_id": "market-meta-capture",
+        "token_id": "token-meta-yes",
+        "venue": "polymarket",
+        "side": "BUY",
+        "notional_usdc": 25.0,
+        "order_type": "limit",
+        "max_slippage_bps": 50,
+        "stop_conditions": ["unit"],
+        "prob_estimate": 0.7,
+        "expected_edge": 0.3,
+        "time_in_force": "GTC",
+        "opportunity_id": "opportunity-meta-capture",
+        "strategy_id": "default",
+        "strategy_version_id": "default-v1",
+        "limit_price": 0.4,
+        "action": "BUY",
+        "outcome": "YES",
+        "model_id": "unit",
+        "intent_key": None,
+    }
+    connection.fetch_rows = [
+        {
+            "decision_id": "decision-meta-capture",
+            "opportunity_id": "opportunity-meta-capture",
+            "strategy_id": "default",
+            "strategy_version_id": "default-v1",
+            "status": "pending",
+            "factor_snapshot_hash": "snapshot",
+            "created_at": created_at,
+            "updated_at": created_at,
+            "expires_at": created_at + timedelta(minutes=15),
+            "payload": json.dumps({**base_payload, "spread_bps_at_decision": "120.0"}),
+            "opportunity_row_id": None,
+        },
+        {
+            "decision_id": "decision-meta-capture-bad",
+            "opportunity_id": "opportunity-meta-capture",
+            "strategy_id": "default",
+            "strategy_version_id": "default-v1",
+            "status": "pending",
+            "factor_snapshot_hash": "snapshot",
+            "created_at": created_at,
+            "updated_at": created_at,
+            "expires_at": created_at + timedelta(minutes=15),
+            "payload": json.dumps(
+                {
+                    **base_payload,
+                    "decision_id": "decision-meta-capture-bad",
+                    "spread_bps_at_decision": "bad-data",
+                }
+            ),
+            "opportunity_row_id": None,
+        },
+    ]
+
+    rows = await store.read_decisions(limit=2)
+
+    assert rows[0].decision.spread_bps_at_decision == 120
+    assert rows[1].decision.spread_bps_at_decision is None

--- a/tests/unit/test_meta_evidence_capture.py
+++ b/tests/unit/test_meta_evidence_capture.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import asyncpg
+import pytest
+
+from pms.config import ControllerSettings, PMSSettings
+from pms.controller.pipeline import ControllerPipeline
+from pms.core.enums import OrderStatus, Side, TimeInForce
+from pms.core.models import FillRecord, MarketSignal, Portfolio, TradeDecision
+from pms.evaluation.adapters.scoring import Scorer
+from pms.storage.decision_store import DecisionStore
+
+
+class ConstantForecaster:
+    def __init__(self, probability: float) -> None:
+        self.probability = probability
+
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return (self.probability, 0.8, "constant")
+
+
+class _RecordingConnection:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, tuple[object, ...], bool]] = []
+        self.fetch_rows: list[dict[str, object]] = []
+        self.in_transaction = False
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.execute_calls.append((query, args, self.in_transaction))
+        return "OK"
+
+    async def fetch(self, query: str, *args: object) -> list[dict[str, object]]:
+        del query, args
+        return list(self.fetch_rows)
+
+    def transaction(self) -> _Transaction:
+        return _Transaction(self)
+
+
+class _Transaction:
+    def __init__(self, connection: _RecordingConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> _Transaction:
+        self._connection.in_transaction = True
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        self._connection.in_transaction = False
+
+
+class _Acquire:
+    def __init__(self, connection: _RecordingConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> _RecordingConnection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class _Pool:
+    def __init__(self, connection: _RecordingConnection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self._connection)
+
+
+def _signal(
+    *,
+    external_signal: dict[str, Any] | None = None,
+    orderbook: dict[str, Any] | None = None,
+) -> MarketSignal:
+    return MarketSignal(
+        market_id="market-meta-capture",
+        token_id="token-meta-yes",
+        venue="polymarket",
+        title="Will meta evidence capture spread?",
+        yes_price=0.4,
+        volume_24h=1000.0,
+        resolves_at=datetime(2026, 5, 30, tzinfo=UTC),
+        orderbook=orderbook
+        or {
+            "bids": [{"price": 0.39, "size": 10.0}],
+            "asks": [{"price": 0.41, "size": 10.0}],
+        },
+        external_signal=external_signal or {"fair_value": 0.7},
+        fetched_at=datetime(2026, 5, 6, 0, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1000.0,
+        free_usdc=1000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+def _decision(*, spread_bps_at_decision: int | None = 123) -> TradeDecision:
+    return TradeDecision(
+        decision_id="decision-meta-capture",
+        market_id="market-meta-capture",
+        token_id="token-meta-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        notional_usdc=25.0,
+        order_type="limit",
+        max_slippage_bps=50,
+        stop_conditions=["unit"],
+        prob_estimate=0.7,
+        expected_edge=0.3,
+        time_in_force=TimeInForce.GTC,
+        opportunity_id="opportunity-meta-capture",
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        limit_price=0.4,
+        action=Side.BUY.value,
+        model_id="unit",
+        spread_bps_at_decision=spread_bps_at_decision,
+    )
+
+
+def _fill() -> FillRecord:
+    return FillRecord(
+        trade_id="trade-meta-capture",
+        order_id="order-meta-capture",
+        decision_id="decision-meta-capture",
+        market_id="market-meta-capture",
+        token_id="token-meta-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        fill_price=0.41,
+        fill_notional_usdc=25.0,
+        fill_quantity=60.9756,
+        executed_at=datetime(2026, 5, 6, tzinfo=UTC),
+        filled_at=datetime(2026, 5, 6, tzinfo=UTC),
+        status=OrderStatus.MATCHED.value,
+        anomaly_flags=[],
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        resolved_outcome=1.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_controller_captures_spread_bps_from_explicit_signal_field() -> None:
+    pipeline = ControllerPipeline(
+        forecasters=(ConstantForecaster(0.7),),
+        settings=PMSSettings(controller=ControllerSettings(max_spread_bps=200.0)),
+    )
+
+    decision = await pipeline.decide(
+        _signal(external_signal={"fair_value": 0.7, "spread_bps": 123}),
+        portfolio=_portfolio(),
+    )
+
+    assert decision is not None
+    assert decision.spread_bps_at_decision == 123
+
+
+@pytest.mark.asyncio
+async def test_controller_computes_spread_bps_from_orderbook_when_missing() -> None:
+    pipeline = ControllerPipeline(
+        forecasters=(ConstantForecaster(0.7),),
+        settings=PMSSettings(),
+    )
+
+    decision = await pipeline.decide(_signal(), portfolio=_portfolio())
+
+    assert decision is not None
+    assert decision.spread_bps_at_decision == 500
+
+
+def test_scorer_copies_decision_edge_and_spread_to_eval_record() -> None:
+    record = Scorer().score(_fill(), _decision(spread_bps_at_decision=321))
+
+    assert record.edge_at_decision == pytest.approx(0.3)
+    assert record.spread_bps_at_decision == 321
+
+
+@pytest.mark.asyncio
+async def test_decision_store_round_trips_spread_bps_in_payload() -> None:
+    connection = _RecordingConnection()
+    store = DecisionStore(cast(asyncpg.Pool, _Pool(connection)))
+    created_at = datetime(2026, 5, 6, tzinfo=UTC)
+
+    await store.insert(
+        _decision(spread_bps_at_decision=456),
+        factor_snapshot_hash="snapshot",
+        created_at=created_at,
+        expires_at=created_at + timedelta(minutes=15),
+    )
+
+    payload_args = connection.execute_calls[2][1]
+    payload = json.loads(cast(str, payload_args[1]))
+    assert payload["spread_bps_at_decision"] == 456
+
+    connection.fetch_rows = [
+        {
+            "decision_id": "decision-meta-capture",
+            "opportunity_id": "opportunity-meta-capture",
+            "strategy_id": "default",
+            "strategy_version_id": "default-v1",
+            "status": "pending",
+            "factor_snapshot_hash": "snapshot",
+            "created_at": created_at,
+            "updated_at": created_at,
+            "expires_at": created_at + timedelta(minutes=15),
+            "payload": json.dumps(
+                {
+                    "decision_id": "decision-meta-capture",
+                    "market_id": "market-meta-capture",
+                    "token_id": "token-meta-yes",
+                    "venue": "polymarket",
+                    "side": "BUY",
+                    "notional_usdc": 25.0,
+                    "order_type": "limit",
+                    "max_slippage_bps": 50,
+                    "stop_conditions": ["unit"],
+                    "prob_estimate": 0.7,
+                    "expected_edge": 0.3,
+                    "time_in_force": "GTC",
+                    "opportunity_id": "opportunity-meta-capture",
+                    "strategy_id": "default",
+                    "strategy_version_id": "default-v1",
+                    "limit_price": 0.4,
+                    "action": "BUY",
+                    "outcome": "YES",
+                    "model_id": "unit",
+                    "intent_key": None,
+                    "spread_bps_at_decision": 789,
+                }
+            ),
+            "opportunity_row_id": None,
+        }
+    ]
+
+    rows = await store.read_decisions(limit=1)
+
+    assert rows[0].decision.spread_bps_at_decision == 789

--- a/tests/unit/test_meta_evidence_capture.py
+++ b/tests/unit/test_meta_evidence_capture.py
@@ -10,6 +10,7 @@ import pytest
 from pms.config import ControllerSettings, PMSSettings
 from pms.controller.pipeline import ControllerPipeline
 from pms.core.enums import OrderStatus, Side, TimeInForce
+from pms.core.interfaces import IForecaster
 from pms.core.models import FillRecord, MarketSignal, Portfolio, TradeDecision
 from pms.evaluation.adapters.scoring import Scorer
 from pms.storage.decision_store import DecisionStore
@@ -22,6 +23,10 @@ class ConstantForecaster:
     def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
         del signal
         return (self.probability, 0.8, "constant")
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        del signal
+        return self.probability
 
 
 class _RecordingConnection:
@@ -155,7 +160,7 @@ def _fill() -> FillRecord:
 @pytest.mark.asyncio
 async def test_controller_captures_spread_bps_from_explicit_signal_field() -> None:
     pipeline = ControllerPipeline(
-        forecasters=(ConstantForecaster(0.7),),
+        forecasters=(cast(IForecaster, ConstantForecaster(0.7)),),
         settings=PMSSettings(controller=ControllerSettings(max_spread_bps=200.0)),
     )
 
@@ -171,7 +176,7 @@ async def test_controller_captures_spread_bps_from_explicit_signal_field() -> No
 @pytest.mark.asyncio
 async def test_controller_computes_spread_bps_from_orderbook_when_missing() -> None:
     pipeline = ControllerPipeline(
-        forecasters=(ConstantForecaster(0.7),),
+        forecasters=(cast(IForecaster, ConstantForecaster(0.7)),),
         settings=PMSSettings(),
     )
 

--- a/tests/unit/test_meta_evidence_schema.py
+++ b/tests/unit/test_meta_evidence_schema.py
@@ -43,6 +43,7 @@ def test_schema_sql_declares_strategy_meta_evidence_surfaces() -> None:
     assert "CREATE TABLE IF NOT EXISTS strategy_performance_peaks" in schema_sql
     assert "CREATE TABLE IF NOT EXISTS alpha_competition_snapshots" in schema_sql
     assert "UNIQUE (strategy_id, strategy_version_id, snapshot_date)" in schema_sql
+    assert "idx_eval_records_strategy_identity_recorded_at" in schema_sql
 
 
 def test_family_f_evalrecord_schema_fixture_declares_persisted_columns() -> None:
@@ -88,6 +89,7 @@ def test_strategy_meta_evidence_migration_creates_columns_and_tables(
     assert "ALTER TABLE eval_records" in statements
     assert "ADD COLUMN IF NOT EXISTS edge_at_decision DOUBLE PRECISION NOT NULL DEFAULT 0.0" in statements
     assert "ADD COLUMN IF NOT EXISTS spread_bps_at_decision INTEGER" in statements
+    assert "idx_eval_records_strategy_identity_recorded_at" in statements
     assert "CREATE TABLE IF NOT EXISTS strategy_performance_peaks" in statements
     assert "CREATE TABLE IF NOT EXISTS alpha_competition_snapshots" in statements
 
@@ -104,6 +106,7 @@ def test_strategy_meta_evidence_migration_downgrade_drops_surfaces(
     statements = "\n".join(fake_connection.statements)
     assert "DROP TABLE IF EXISTS alpha_competition_snapshots" in statements
     assert "DROP TABLE IF EXISTS strategy_performance_peaks" in statements
+    assert "DROP INDEX IF EXISTS idx_eval_records_strategy_identity_recorded_at" in statements
     assert "DROP COLUMN IF EXISTS spread_bps_at_decision" in statements
     assert "DROP COLUMN IF EXISTS edge_at_decision" in statements
     assert "DROP COLUMN IF EXISTS metadata_json" in statements

--- a/tests/unit/test_meta_evidence_schema.py
+++ b/tests/unit/test_meta_evidence_schema.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = ROOT / "alembic" / "versions" / "0015_strategy_meta_evidence.py"
+
+
+def _load_migration_module() -> ModuleType:
+    assert MIGRATION_PATH.exists(), f"migration file missing: {MIGRATION_PATH}"
+    module_name = "test_alembic_0015_strategy_meta_evidence"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MIGRATION_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    def exec_driver_sql(self, statement: str) -> None:
+        self.statements.append(statement)
+
+
+def test_schema_sql_declares_strategy_meta_evidence_surfaces() -> None:
+    schema_sql = (ROOT / "schema.sql").read_text(encoding="utf-8")
+
+    assert "metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb" in schema_sql
+    assert "edge_at_decision DOUBLE PRECISION NOT NULL DEFAULT 0.0" in schema_sql
+    assert "spread_bps_at_decision INTEGER" in schema_sql
+    assert "CREATE TABLE IF NOT EXISTS strategy_performance_peaks" in schema_sql
+    assert "CREATE TABLE IF NOT EXISTS alpha_competition_snapshots" in schema_sql
+    assert "UNIQUE (strategy_id, strategy_version_id, snapshot_date)" in schema_sql
+
+
+def test_family_f_evalrecord_schema_fixture_declares_persisted_columns() -> None:
+    fixture = ROOT / "tests" / "fixtures" / "family_f_evalrecord_schema.json"
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+    tables = {table["table"]: table for table in payload["tables"]}
+
+    eval_columns = {
+        column["column_name"]: column
+        for column in tables["eval_records"]["columns"]
+    }
+    assert eval_columns["edge_at_decision"]["data_type"] == "double precision"
+    assert eval_columns["edge_at_decision"]["is_nullable"] == "NO"
+    assert eval_columns["spread_bps_at_decision"]["data_type"] == "integer"
+    assert eval_columns["spread_bps_at_decision"]["is_nullable"] == "YES"
+
+    strategy_version_columns = {
+        column["column_name"]: column
+        for column in tables["strategy_versions"]["columns"]
+    }
+    assert strategy_version_columns["metadata_json"]["data_type"] == "jsonb"
+    assert strategy_version_columns["metadata_json"]["is_nullable"] == "NO"
+    assert (
+        tables["strategy_versions"]["namespace_contracts"]["promotion"]
+        == "Family A writes scorecard artifacts under metadata_json.promotion"
+    )
+
+
+def test_strategy_meta_evidence_migration_creates_columns_and_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration_module()
+    fake_connection = _FakeConnection()
+    monkeypatch.setattr(module.op, "get_bind", lambda: fake_connection)
+
+    module.upgrade()
+
+    statements = "\n".join(fake_connection.statements)
+    assert module.revision == "0015_strategy_meta_evidence"
+    assert module.down_revision == "0014_strategy_artifacts"
+    assert "ALTER TABLE strategy_versions" in statements
+    assert "ADD COLUMN IF NOT EXISTS metadata_json JSONB NOT NULL DEFAULT '{}'::jsonb" in statements
+    assert "ALTER TABLE eval_records" in statements
+    assert "ADD COLUMN IF NOT EXISTS edge_at_decision DOUBLE PRECISION NOT NULL DEFAULT 0.0" in statements
+    assert "ADD COLUMN IF NOT EXISTS spread_bps_at_decision INTEGER" in statements
+    assert "CREATE TABLE IF NOT EXISTS strategy_performance_peaks" in statements
+    assert "CREATE TABLE IF NOT EXISTS alpha_competition_snapshots" in statements
+
+
+def test_strategy_meta_evidence_migration_downgrade_drops_surfaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_migration_module()
+    fake_connection = _FakeConnection()
+    monkeypatch.setattr(module.op, "get_bind", lambda: fake_connection)
+
+    module.downgrade()
+
+    statements = "\n".join(fake_connection.statements)
+    assert "DROP TABLE IF EXISTS alpha_competition_snapshots" in statements
+    assert "DROP TABLE IF EXISTS strategy_performance_peaks" in statements
+    assert "DROP COLUMN IF EXISTS spread_bps_at_decision" in statements
+    assert "DROP COLUMN IF EXISTS edge_at_decision" in statements
+    assert "DROP COLUMN IF EXISTS metadata_json" in statements

--- a/tests/unit/test_meta_evidence_store.py
+++ b/tests/unit/test_meta_evidence_store.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from typing import cast
+
+import asyncpg
+import pytest
+
+from pms.meta_evidence.models import CompetitionSnapshot, PerformancePeak
+from pms.storage.meta_evidence_store import MetaEvidenceStore
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+
+
+@dataclass
+class _RecordingConnection:
+    execute_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
+    fetchrow_rows: list[dict[str, object] | None] = field(default_factory=list)
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.execute_calls.append((query, args))
+        return "OK"
+
+    async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
+        del query, args
+        if not self.fetchrow_rows:
+            return None
+        return self.fetchrow_rows.pop(0)
+
+
+class _Acquire:
+    def __init__(self, connection: _RecordingConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> _RecordingConnection:
+        return self._connection
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class _Pool:
+    def __init__(self, connection: _RecordingConnection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> _Acquire:
+        return _Acquire(self._connection)
+
+
+@pytest.mark.asyncio
+async def test_strategy_registry_set_version_metadata_targets_one_version_row() -> None:
+    connection = _RecordingConnection()
+    registry = PostgresStrategyRegistry(cast(asyncpg.Pool, _Pool(connection)))
+
+    await registry.set_version_metadata(
+        "meta-strategy",
+        "meta-v1",
+        {"validation_regime": "low_vol_bull", "regime_source": "price_changes"},
+    )
+
+    query, args = connection.execute_calls[0]
+    assert "UPDATE strategy_versions" in query
+    assert "metadata_json = metadata_json || $3::jsonb" in query
+    assert args[:2] == ("meta-strategy", "meta-v1")
+    assert json.loads(cast(str, args[2])) == {
+        "validation_regime": "low_vol_bull",
+        "regime_source": "price_changes",
+    }
+
+
+@pytest.mark.asyncio
+async def test_meta_evidence_store_round_trips_performance_peak() -> None:
+    now = datetime(2026, 5, 6, tzinfo=UTC)
+    connection = _RecordingConnection(
+        fetchrow_rows=[
+            {
+                "strategy_id": "meta-strategy",
+                "strategy_version_id": "meta-v1",
+                "peak_sharpe_7d": 1.5,
+                "peak_sharpe_30d": 1.8,
+                "peak_hit_rate": 0.6,
+                "recorded_at": now,
+            }
+        ]
+    )
+    store = MetaEvidenceStore(cast(asyncpg.Pool, _Pool(connection)))
+    peak = PerformancePeak(
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        peak_sharpe_7d=1.5,
+        peak_sharpe_30d=1.8,
+        peak_hit_rate=0.6,
+        recorded_at=now,
+    )
+
+    await store.upsert_performance_peak(peak)
+    stored = await store.get_performance_peak("meta-strategy", "meta-v1")
+
+    query, args = connection.execute_calls[0]
+    assert "ON CONFLICT (strategy_id, strategy_version_id) DO UPDATE" in query
+    assert args == ("meta-strategy", "meta-v1", 1.5, 1.8, 0.6, now)
+    assert stored == peak
+
+
+@pytest.mark.asyncio
+async def test_meta_evidence_store_upserts_competition_snapshot_idempotently() -> None:
+    now = datetime(2026, 5, 6, tzinfo=UTC)
+    snapshot = CompetitionSnapshot(
+        snapshot_id="snapshot-meta",
+        strategy_id="meta-strategy",
+        strategy_version_id="meta-v1",
+        snapshot_date=date(2026, 5, 6),
+        mean_edge_30d=0.05,
+        mean_spread_bps_30d=120.0,
+        edge_trend_slope_90d=None,
+        spread_trend_slope_90d=None,
+        sample_count_30d=12,
+        trend_status="warming_up",
+        days_collected=12,
+        short_term_slope_30d=None,
+        short_term_slope_60d=None,
+        interpretation="warming_up",
+        created_at=now,
+    )
+    connection = _RecordingConnection()
+    store = MetaEvidenceStore(cast(asyncpg.Pool, _Pool(connection)))
+
+    await store.upsert_competition_snapshot(snapshot)
+
+    query, args = connection.execute_calls[0]
+    assert "ON CONFLICT (strategy_id, strategy_version_id, snapshot_date) DO UPDATE" in query
+    assert args[:4] == (
+        "snapshot-meta",
+        "meta-strategy",
+        "meta-v1",
+        date(2026, 5, 6),
+    )

--- a/tests/unit/test_meta_evidence_store.py
+++ b/tests/unit/test_meta_evidence_store.py
@@ -17,10 +17,11 @@ from pms.storage.strategy_registry import PostgresStrategyRegistry
 class _RecordingConnection:
     execute_calls: list[tuple[str, tuple[object, ...]]] = field(default_factory=list)
     fetchrow_rows: list[dict[str, object] | None] = field(default_factory=list)
+    execute_status: str = "UPDATE 1"
 
     async def execute(self, query: str, *args: object) -> str:
         self.execute_calls.append((query, args))
-        return "OK"
+        return self.execute_status
 
     async def fetchrow(self, query: str, *args: object) -> dict[str, object] | None:
         del query, args
@@ -67,6 +68,19 @@ async def test_strategy_registry_set_version_metadata_targets_one_version_row() 
         "validation_regime": "low_vol_bull",
         "regime_source": "price_changes",
     }
+
+
+@pytest.mark.asyncio
+async def test_strategy_registry_set_version_metadata_raises_when_no_row_matches() -> None:
+    connection = _RecordingConnection(execute_status="UPDATE 0")
+    registry = PostgresStrategyRegistry(cast(asyncpg.Pool, _Pool(connection)))
+
+    with pytest.raises(LookupError, match="No strategy_versions row matched"):
+        await registry.set_version_metadata(
+            "meta-strategy",
+            "missing-v1",
+            {"validation_regime": "low_vol_bull"},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add Family F strategy meta-evidence capture fields on decisions/eval records and persist them through scoring, decision payloads, and EvalStore
- add strategy meta-evidence analytics modules for regime tagging, decay status, alpha competition snapshots, plus store/API surfaces
- add Alembic/schema surfaces and the Family F DB-column contract fixture consumed by Family A
- update existing PostgreSQL schema integration expectations for the new `strategy_versions.metadata_json` column and meta-evidence tables

## Spec Source
- Approved harness task: `pms-strategy-meta-evidence-v1` v0.4
- Source spec copied locally from `/Users/stometa/dev/prediction-market-system-p0-1-llm-forecaster-clean/.harness/pms-strategy-meta-evidence-v1/spec.md`
- Local copied spec path: `.harness/pms-strategy-meta-evidence-v1/spec.md` in this worktree, ignored by repo policy and not included in the production diff

## Scope Notes
- CP01-CP05 implemented: schema/models, capture chain, meta-evidence store, regime classifier, decay detector, competition snapshots, and decay API endpoint
- CP06 remains guarded by design: Family A `promote_strategy.py` is not implemented in this PR
- Active paper-soak runner was not touched or restarted
- Family A coordination: `tests/fixtures/family_f_evalrecord_schema.json` includes persisted `eval_records` columns and `strategy_versions.metadata_json` shape; Family A writes its `promotion` namespace under `metadata_json` after this lands

## Verification
```bash
uv run pytest tests/unit/test_meta_evidence_capture.py tests/unit/test_meta_evidence_schema.py tests/unit/test_meta_evidence_analytics.py tests/unit/test_meta_evidence_store.py tests/unit/test_meta_evidence_api.py -q
# 16 passed in 0.49s

uv run pytest tests/unit/test_meta_evidence_capture.py tests/unit/test_meta_evidence_schema.py tests/unit/test_meta_evidence_analytics.py tests/unit/test_meta_evidence_store.py tests/unit/test_meta_evidence_api.py tests/unit/test_decision_store_cp07.py tests/unit/test_evaluation_cp07.py tests/unit/test_strategy_registry.py tests/unit/test_schema_check.py -q
# 59 passed in 0.74s

uv run pytest tests/integration/test_schema_apply_aggregate.py::test_schema_sql_applies_strategy_identity_tables tests/integration/test_schema_apply_inner.py::test_schema_sql_applies_inner_ring_strategy_identity_constraints -q
# 2 skipped locally because PMS_RUN_INTEGRATION is unset; forced local run cannot connect to local Postgres due password auth, but these were patched for the exact GitHub failures

uv run pytest tests/unit -q
# 977 passed in 9.89s

uv run pytest -q
# 1059 passed, 161 skipped in 12.94s

uv run ruff check .
# All checks passed!

uv run mypy src/ tests/ --strict
# Success: no issues found in 374 source files

git diff --check
# no output
```
