### PR TITLE
[PMS ENG] Family B supervision and alerting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ target/
 
 # OpenViking memory (per-user, not committed)
 .openviking/
+.alerts/
 
 # Claude worktrees (created by agent skills; local only)
 .claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN uv sync --frozen --no-dev
 
 EXPOSE 8000
 
-CMD ["uv", "run", "--no-dev", "pms-api", "--config", "/app/config.live-soak.yaml", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "--no-dev", "pms-api", "--config", "/app/config.live-soak.yaml", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.13-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+COPY pyproject.toml uv.lock README.md ./
+COPY src ./src
+COPY scripts ./scripts
+COPY config.live-soak.yaml ./config.live-soak.yaml
+
+RUN uv sync --frozen --no-dev
+
+EXPOSE 8000
+
+CMD ["uv", "run", "--no-dev", "pms-api", "--config", "/app/config.live-soak.yaml", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update \
 ENV PATH="/root/.local/bin:${PATH}"
 
 COPY pyproject.toml uv.lock README.md ./
+COPY alembic.ini ./alembic.ini
+COPY alembic ./alembic
 COPY src ./src
 COPY scripts ./scripts
 COPY config.live-soak.yaml ./config.live-soak.yaml

--- a/docs/operations/fly-deploy-runbook.md
+++ b/docs/operations/fly-deploy-runbook.md
@@ -20,6 +20,7 @@ Inject secrets through Fly, never through config files or chat:
 
 ```bash
 fly secrets set \
+  PMS_API_TOKEN='...' \
   PMS_DISCORD__WEBHOOK_URL='https://discord.com/api/webhooks/...' \
   PMS_POLYMARKET__PRIVATE_KEY='...' \
   PMS_POLYMARKET__API_KEY='...' \

--- a/docs/operations/fly-deploy-runbook.md
+++ b/docs/operations/fly-deploy-runbook.md
@@ -1,0 +1,76 @@
+# PMS Fly.io Deployment Runbook
+
+This runbook is for the supervised paper-soak `pms-api` process. PR verification
+does not deploy this machine and does not restart the active runner.
+
+## Launch
+
+Run the one-time Fly bootstrap interactively:
+
+```bash
+fly launch --no-deploy
+```
+
+Keep the generated app name aligned with `fly.toml` or update `fly.toml` in the
+same change.
+
+## Secrets
+
+Inject secrets through Fly, never through config files or chat:
+
+```bash
+fly secrets set \
+  PMS_DISCORD__WEBHOOK_URL='https://discord.com/api/webhooks/...' \
+  PMS_POLYMARKET__PRIVATE_KEY='...' \
+  PMS_POLYMARKET__API_KEY='...' \
+  PMS_POLYMARKET__API_SECRET='...' \
+  PMS_POLYMARKET__API_PASSPHRASE='...' \
+  PMS_POLYMARKET__SIGNATURE_TYPE='...' \
+  PMS_POLYMARKET__FUNDER_ADDRESS='...'
+```
+
+## Deploy
+
+```bash
+fly deploy
+```
+
+The Fly health check targets `/readiness`, not `/health`. A process that is
+alive but has not started the runner and halt subscriber should stay unready.
+
+## Logs
+
+```bash
+fly logs
+```
+
+Use logs to confirm `PMS_AUTO_START=1` started the runner and that the Discord
+alert subscriber started.
+
+## Restart
+
+```bash
+fly machine restart <machine-id>
+```
+
+## Rollback
+
+Redeploy the previous image tag from Fly releases:
+
+```bash
+fly releases
+fly deploy --image <previous-image>
+```
+
+## Credential Rotation
+
+Rotate a compromised or expired secret with `fly secrets set`, then force a
+restart so the process reads the updated environment:
+
+```bash
+fly secrets set PMS_DISCORD__WEBHOOK_URL='https://discord.com/api/webhooks/...'
+fly machine restart <machine-id>
+```
+
+For Polymarket credential rotation, set all six Polymarket fields together to
+avoid partial credential state.

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,7 @@ primary_region = "iad"
 
 [env]
   PMS_AUTO_START = "1"
+  PMS_API_HOST = "0.0.0.0"
   PMS_CONFIG_PATH = "/app/config.live-soak.yaml"
 
 [http_service]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,28 @@
+app = "pms-paper-soak"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PMS_AUTO_START = "1"
+  PMS_CONFIG_PATH = "/app/config.live-soak.yaml"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "20s"
+    method = "GET"
+    path = "/readiness"
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,18 @@ source_modules = ["pms.market_selection"]
 forbidden_modules = ["pms.strategies.aggregate"]
 
 [[tool.importlinter.contracts]]
+name = "Alerting stays out of strategy and IO adapter rings"
+type = "forbidden"
+source_modules = ["pms.alerting"]
+forbidden_modules = [
+    "pms.strategies",
+    "pms.controller",
+    "pms.market_selection",
+    "pms.actuator.adapters",
+    "pms.sensor.adapters",
+]
+
+[[tool.importlinter.contracts]]
 name = "Kalshi stub helper stays at runtime boundaries"
 type = "protected"
 protected_modules = ["pms.core.venue_support"]

--- a/src/pms/actuator/executor.py
+++ b/src/pms/actuator/executor.py
@@ -9,11 +9,13 @@ from uuid import uuid4
 from pms.actuator.adapters.polymarket import PolymarketSubmissionUnknownError
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import InsufficientLiquidityError, RiskManager
+from pms.alerting.events import HaltEvent as AlertHaltEvent
 from pms.core.enums import OrderStatus, Venue
 from pms.core.exceptions import KalshiStubError
 from pms.core.interfaces import DedupStore
 from pms.core.models import OrderState, Portfolio, TradeDecision
 from pms.core.venue_support import kalshi_stub_error
+from pms.event_stream import RuntimeEventBus
 from pms.storage.dedup_store import InMemoryDedupStore
 
 
@@ -35,6 +37,8 @@ class ActuatorExecutor:
     risk: RiskManager
     feedback: ActuatorFeedback
     dedup_store: DedupStore = field(default_factory=InMemoryDedupStore)
+    event_bus: RuntimeEventBus | None = None
+    _missing_event_bus_warned: bool = field(default=False, init=False)
 
     async def execute(
         self,
@@ -56,6 +60,7 @@ class ActuatorExecutor:
         try:
             halt_state = self.risk.check_auto_halt(portfolio)
             if halt_state.halted:
+                await self._publish_halt_event(decision, halt_state)
                 final_state = _rejected_order_state(decision, halt_state.trigger_kind)
                 await self.feedback.generate(
                     final_state,
@@ -139,6 +144,34 @@ class ActuatorExecutor:
                 "Failed to release dedup state for decision_id=%s",
                 decision_id,
             )
+
+    async def _publish_halt_event(
+        self,
+        decision: TradeDecision,
+        halt_state: object,
+    ) -> None:
+        if self.event_bus is None:
+            if not self._missing_event_bus_warned:
+                logger.warning("Auto-halt detected but no RuntimeEventBus is attached")
+                self._missing_event_bus_warned = True
+            return
+        trigger_kind = getattr(halt_state, "trigger_kind")
+        reason = getattr(halt_state, "reason")
+        triggered_at = getattr(halt_state, "triggered_at")
+        halt_event = AlertHaltEvent(
+            reason=reason,
+            trigger_kind=trigger_kind,
+            triggered_at=triggered_at,
+            market_id=decision.market_id,
+            decision_id=decision.decision_id,
+        )
+        await self.event_bus.publish(
+            halt_event.event_type,
+            halt_event.summary,
+            created_at=halt_event.triggered_at,
+            market_id=decision.market_id,
+            decision_id=decision.decision_id,
+        )
 
 
 def _rejected_order_state(decision: TradeDecision, reason: str) -> OrderState:

--- a/src/pms/alerting/__init__.py
+++ b/src/pms/alerting/__init__.py
@@ -1,0 +1,4 @@
+from pms.alerting.discord import DiscordWebhookClient
+from pms.alerting.events import AlertEvent, HaltEvent
+
+__all__ = ["AlertEvent", "DiscordWebhookClient", "HaltEvent"]

--- a/src/pms/alerting/discord.py
+++ b/src/pms/alerting/discord.py
@@ -136,13 +136,16 @@ def _write_fallback(alert_dir: Path, payload: dict[str, Any], *, prefix: str) ->
 
 
 def _sanitize_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    sanitized: dict[str, Any] = {}
-    for key, value in payload.items():
+    def sanitize(value: Any) -> Any:
         if isinstance(value, str):
-            sanitized[key] = _redact_url_like(value)
-        else:
-            sanitized[key] = value
-    return sanitized
+            return _redact_url_like(value)
+        if isinstance(value, dict):
+            return {key: sanitize(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [sanitize(item) for item in value]
+        return value
+
+    return {key: sanitize(value) for key, value in payload.items()}
 
 
 def _redact_url_like(value: str) -> str:
@@ -156,9 +159,12 @@ def _retry_after(response: httpx.Response) -> float | None:
     if value is None:
         return None
     try:
-        return float(value)
+        parsed = float(value.strip())
     except ValueError:
         return None
+    if parsed < 0:
+        return None
+    return parsed
 
 
 def redact_webhook_url(url: str) -> str:

--- a/src/pms/alerting/discord.py
+++ b/src/pms/alerting/discord.py
@@ -1,0 +1,166 @@
+"""DiscordWebhookClient - frozen public API for v1+.
+
+`send(content: str, *, embed: dict | None = None) -> bool` is the stable
+entrypoint. Family E (`pms-funding-runbook-v1`) imports this signature for
+balance-monitor alerts; breaking changes require a v2 spec and coordination
+with all consumers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from pydantic import SecretStr
+
+
+logger = logging.getLogger(__name__)
+SleepFunc = Callable[[float], Awaitable[None] | None]
+
+
+class DiscordWebhookClient:
+    def __init__(
+        self,
+        webhook_url: str | SecretStr,
+        *,
+        alert_dir: str | Path = ".alerts",
+        http_client: httpx.AsyncClient | None = None,
+        sleep: SleepFunc = asyncio.sleep,
+        max_retry_after_s: float = 60.0,
+    ) -> None:
+        self._webhook_url = (
+            webhook_url.get_secret_value()
+            if isinstance(webhook_url, SecretStr)
+            else webhook_url
+        )
+        self._alert_dir = Path(alert_dir)
+        self._client = http_client
+        self._owns_client = http_client is None
+        self._sleep = sleep
+        self._max_retry_after_s = max_retry_after_s
+
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool:
+        payload: dict[str, Any] = {"content": content}
+        if embed is not None:
+            payload["embeds"] = [embed]
+
+        delays = [1.0, 2.0]
+        client = self._client or httpx.AsyncClient(timeout=10.0)
+        try:
+            for attempt in range(3):
+                try:
+                    response = await client.post(self._webhook_url, json=payload)
+                except httpx.HTTPError as exc:
+                    if attempt == 2:
+                        return await self._drop(payload, exc)
+                    await self._sleep_for(delays[attempt])
+                    continue
+
+                if 200 <= response.status_code < 300:
+                    return True
+
+                retry_after = _retry_after(response)
+                if response.status_code == 429 and retry_after is not None:
+                    if retry_after > self._max_retry_after_s:
+                        return await self._drop(
+                            payload,
+                            RuntimeError("discord retry-after exceeded max wait"),
+                        )
+                    if attempt == 2:
+                        return await self._drop(
+                            payload,
+                            RuntimeError("discord 429 retry exhausted"),
+                        )
+                    await self._sleep_for(retry_after)
+                    continue
+
+                if attempt == 2:
+                    return await self._drop(
+                        payload,
+                        RuntimeError(f"discord webhook returned {response.status_code}"),
+                    )
+                await self._sleep_for(delays[attempt])
+        finally:
+            if self._owns_client:
+                await client.aclose()
+        return False
+
+    async def aclose(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+
+    async def write_fallback(
+        self,
+        payload: dict[str, Any],
+        *,
+        prefix: str = "dropped",
+    ) -> Path:
+        return _write_fallback(self._alert_dir, payload, prefix=prefix)
+
+    async def _sleep_for(self, delay: float) -> None:
+        slept = self._sleep(delay)
+        if slept is not None:
+            await slept
+
+    async def _drop(self, payload: dict[str, Any], exc: BaseException) -> bool:
+        path = await self.write_fallback(payload)
+        logger.error(
+            "Discord webhook send failed; wrote fallback=%s error_type=%s",
+            path,
+            type(exc).__name__,
+        )
+        return False
+
+
+def _write_fallback(alert_dir: Path, payload: dict[str, Any], *, prefix: str) -> Path:
+    alert_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=UTC).isoformat().replace(":", "-")
+    target = alert_dir / f"{prefix}-{timestamp}.json"
+    tmp = target.with_suffix(".tmp")
+    sanitized = _sanitize_payload(payload)
+    tmp.write_text(json.dumps(sanitized, sort_keys=True), encoding="utf-8")
+    tmp.replace(target)
+    return target
+
+
+def _sanitize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, str):
+            sanitized[key] = _redact_url_like(value)
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
+def _redact_url_like(value: str) -> str:
+    if "http://" not in value and "https://" not in value:
+        return value
+    return value.replace(value, "<redacted-url>")
+
+
+def _retry_after(response: httpx.Response) -> float | None:
+    value = response.headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def redact_webhook_url(url: str) -> str:
+    split = urlsplit(url)
+    return urlunsplit((split.scheme, split.netloc, "/webhooks/<redacted>", "", ""))

--- a/src/pms/alerting/events.py
+++ b/src/pms/alerting/events.py
@@ -44,7 +44,7 @@ def halt_event_from_runtime(event: RuntimeEvent) -> HaltEvent | None:
     if not event.event_type.startswith(HALT_EVENT_PREFIX):
         return None
     trigger_kind = event.event_type.removeprefix(HALT_EVENT_PREFIX)
-    reason = event.summary.rsplit(": ", maxsplit=1)[-1]
+    reason = event.summary.split(": ", maxsplit=1)[-1]
     return HaltEvent(
         reason=reason,
         trigger_kind=_coerce_trigger_kind(trigger_kind),

--- a/src/pms/alerting/events.py
+++ b/src/pms/alerting/events.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pms.actuator.risk import HaltTriggerKind
+from pms.event_stream import RuntimeEvent
+
+
+Severity = Literal["info", "warning", "critical"]
+HALT_EVENT_PREFIX = "pms.halt."
+
+
+@dataclass(frozen=True)
+class HaltEvent:
+    reason: str
+    trigger_kind: HaltTriggerKind
+    triggered_at: datetime
+    market_id: str | None = None
+    decision_id: str | None = None
+    trace_id: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def event_type(self) -> str:
+        return f"{HALT_EVENT_PREFIX}{self.trigger_kind}"
+
+    @property
+    def summary(self) -> str:
+        return f"Auto-halt {self.trigger_kind}: {self.reason}"
+
+
+@dataclass(frozen=True)
+class AlertEvent:
+    event_type: str
+    severity: Severity
+    message: str
+    emitted_at: datetime
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def halt_event_from_runtime(event: RuntimeEvent) -> HaltEvent | None:
+    if not event.event_type.startswith(HALT_EVENT_PREFIX):
+        return None
+    trigger_kind = event.event_type.removeprefix(HALT_EVENT_PREFIX)
+    reason = event.summary.rsplit(": ", maxsplit=1)[-1]
+    return HaltEvent(
+        reason=reason,
+        trigger_kind=_coerce_trigger_kind(trigger_kind),
+        triggered_at=event.created_at,
+        market_id=event.market_id,
+        decision_id=event.decision_id,
+        details={"runtime_event_id": event.event_id, "summary": event.summary},
+    )
+
+
+def alert_from_halt(halt: HaltEvent) -> AlertEvent:
+    message = (
+        f"PMS auto-halt: `{halt.trigger_kind}`\n"
+        f"Reason: `{halt.reason}`\n"
+        f"Market: `{halt.market_id or 'unknown'}`\n"
+        f"Decision: `{halt.decision_id or 'unknown'}`"
+    )
+    return AlertEvent(
+        event_type=halt.event_type,
+        severity="critical",
+        message=message,
+        emitted_at=datetime.now(tz=UTC),
+        details={
+            "reason": halt.reason,
+            "trigger_kind": halt.trigger_kind,
+            "market_id": halt.market_id,
+            "decision_id": halt.decision_id,
+        },
+    )
+
+
+def _coerce_trigger_kind(value: str) -> HaltTriggerKind:
+    allowed: set[str] = {
+        "none",
+        "consecutive_losses",
+        "slippage_spike",
+        "credential_failure",
+        "order_without_fill",
+        "rate_limit_exceeded",
+        "drawdown_circuit_breaker",
+    }
+    if value not in allowed:
+        return "none"
+    return value  # type: ignore[return-value]

--- a/src/pms/alerting/lifecycle.py
+++ b/src/pms/alerting/lifecycle.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from pms.alerting.discord import _write_fallback
+
+
+logger = logging.getLogger(__name__)
+
+
+class AlertClient(Protocol):
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool: ...
+
+
+async def emit_shutdown_alert(
+    client: AlertClient,
+    *,
+    reason: str,
+    alert_dir: str | Path = ".alerts",
+    timeout_s: float = 10.0,
+) -> bool:
+    content = f"pms-api exiting ({reason})"
+    try:
+        return await asyncio.wait_for(client.send(content), timeout=timeout_s)
+    except TimeoutError:
+        _write_shutdown_fallback(alert_dir, reason=reason, error="timeout")
+        logger.error("Shutdown alert timed out; wrote dropped shutdown fallback")
+        return False
+
+
+async def flush_alerts(client: object) -> None:
+    close = getattr(client, "aclose", None)
+    if callable(close):
+        await close()
+
+
+def _write_shutdown_fallback(
+    alert_dir: str | Path,
+    *,
+    reason: str,
+    error: str,
+) -> Path:
+    payload = {
+        "reason": reason,
+        "error": error,
+        "created_at": datetime.now(tz=UTC).isoformat(),
+    }
+    return _write_fallback(Path(alert_dir), payload, prefix="dropped-shutdown")

--- a/src/pms/alerting/lifecycle.py
+++ b/src/pms/alerting/lifecycle.py
@@ -35,6 +35,10 @@ async def emit_shutdown_alert(
         _write_shutdown_fallback(alert_dir, reason=reason, error="timeout")
         logger.error("Shutdown alert timed out; wrote dropped shutdown fallback")
         return False
+    except Exception as exc:
+        _write_shutdown_fallback(alert_dir, reason=reason, error=str(exc))
+        logger.exception("Shutdown alert failed; wrote dropped shutdown fallback")
+        return False
 
 
 async def flush_alerts(client: object) -> None:

--- a/src/pms/alerting/scheduler.py
+++ b/src/pms/alerting/scheduler.py
@@ -25,6 +25,7 @@ class EODClient(Protocol):
 
 RunReport = Callable[[str], Awaitable[None]]
 Clock = Callable[[], datetime]
+NextTrigger = Callable[[ZoneInfo, datetime], datetime]
 
 
 def next_trigger(tz: ZoneInfo, now: datetime) -> datetime:
@@ -42,24 +43,32 @@ class EODScheduler:
         *,
         clock: Clock | None = None,
         report_root: str | Path = "docs/paper-reports",
+        run_report: RunReport | None = None,
+        next_trigger_fn: NextTrigger = next_trigger,
     ) -> None:
         self._client = client
         self._clock = clock or (lambda: datetime.now(tz=SHANGHAI_TZ))
         self._report_root = Path(report_root)
+        self._run_report = run_report
+        self._next_trigger = next_trigger_fn
 
     async def run(self, stop_event: asyncio.Event) -> None:
         while not stop_event.is_set():
             now = self._clock()
-            trigger = next_trigger(SHANGHAI_TZ, now)
+            trigger = self._next_trigger(SHANGHAI_TZ, now)
             delay = max((trigger - now.astimezone(SHANGHAI_TZ)).total_seconds(), 0.0)
             try:
                 await asyncio.wait_for(stop_event.wait(), timeout=delay)
             except TimeoutError:
-                await run_eod_report_once(
-                    self._client,
-                    now=self._clock(),
-                    report_root=self._report_root,
-                )
+                try:
+                    await run_eod_report_once(
+                        self._client,
+                        now=self._clock(),
+                        report_root=self._report_root,
+                        run_report=self._run_report,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.exception("EOD scheduler iteration failed; continuing")
 
 
 async def run_eod_report_once(

--- a/src/pms/alerting/scheduler.py
+++ b/src/pms/alerting/scheduler.py
@@ -107,6 +107,7 @@ async def _run_paper_report(report_date: str) -> None:
     process = await asyncio.create_subprocess_exec(
         "uv",
         "run",
+        "--no-dev",
         "python",
         "scripts/paper-report.py",
         "--date",

--- a/src/pms/alerting/scheduler.py
+++ b/src/pms/alerting/scheduler.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime, time, timedelta
+from pathlib import Path
+from typing import Protocol
+from zoneinfo import ZoneInfo
+
+
+logger = logging.getLogger(__name__)
+SHANGHAI_TZ = ZoneInfo("Asia/Shanghai")
+DISCORD_MESSAGE_LIMIT = 2000
+
+
+class EODClient(Protocol):
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool: ...
+
+
+RunReport = Callable[[str], Awaitable[None]]
+Clock = Callable[[], datetime]
+
+
+def next_trigger(tz: ZoneInfo, now: datetime) -> datetime:
+    local_now = now.astimezone(tz)
+    candidate = datetime.combine(local_now.date(), time(22, 0), tzinfo=tz)
+    if local_now >= candidate:
+        candidate = candidate + timedelta(days=1)
+    return candidate
+
+
+class EODScheduler:
+    def __init__(
+        self,
+        client: EODClient,
+        *,
+        clock: Clock | None = None,
+        report_root: str | Path = "docs/paper-reports",
+    ) -> None:
+        self._client = client
+        self._clock = clock or (lambda: datetime.now(tz=SHANGHAI_TZ))
+        self._report_root = Path(report_root)
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        while not stop_event.is_set():
+            now = self._clock()
+            trigger = next_trigger(SHANGHAI_TZ, now)
+            delay = max((trigger - now.astimezone(SHANGHAI_TZ)).total_seconds(), 0.0)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=delay)
+            except TimeoutError:
+                await run_eod_report_once(
+                    self._client,
+                    now=self._clock(),
+                    report_root=self._report_root,
+                )
+
+
+async def run_eod_report_once(
+    client: EODClient,
+    *,
+    now: datetime,
+    report_root: str | Path = "docs/paper-reports",
+    run_report: RunReport | None = None,
+) -> None:
+    report_date = now.astimezone(SHANGHAI_TZ).date().isoformat()
+    runner = run_report or _run_paper_report
+    try:
+        await runner(report_date)
+        report_path = Path(report_root) / f"{report_date}.md"
+        if not report_path.exists():
+            raise FileNotFoundError(str(report_path))
+        content = report_path.read_text(encoding="utf-8")
+        for index, chunk in enumerate(_paginate(content), start=1):
+            total = len(_paginate(content))
+            await client.send(
+                f"PMS Daily Report - {report_date} 22:00 CST ({index}/{total})\n\n"
+                f"{chunk}"
+            )
+    except Exception as exc:
+        message = (
+            f"EOD report generation failed for {report_date} - {exc}.\n"
+            "Severity: warning.\n"
+            "Operator action: investigate manually."
+        )
+        await client.send(message)
+        logger.error("EOD report generation failed for %s: %s", report_date, exc)
+        raise
+
+
+async def _run_paper_report(report_date: str) -> None:
+    process = await asyncio.create_subprocess_exec(
+        "uv",
+        "run",
+        "python",
+        "scripts/paper-report.py",
+        "--date",
+        report_date,
+    )
+    return_code = await process.wait()
+    if return_code != 0:
+        raise RuntimeError(f"paper-report.py exited {return_code}")
+
+
+def _paginate(content: str) -> list[str]:
+    if len(content) <= DISCORD_MESSAGE_LIMIT:
+        return [content]
+    return [
+        content[index : index + DISCORD_MESSAGE_LIMIT]
+        for index in range(0, len(content), DISCORD_MESSAGE_LIMIT)
+    ]

--- a/src/pms/alerting/scheduler.py
+++ b/src/pms/alerting/scheduler.py
@@ -86,11 +86,12 @@ async def run_eod_report_once(
         if not report_path.exists():
             raise FileNotFoundError(str(report_path))
         content = report_path.read_text(encoding="utf-8")
-        for index, chunk in enumerate(_paginate(content), start=1):
-            total = len(_paginate(content))
+        chunks = _paginate_report(content, report_date)
+        total = len(chunks)
+        for index, chunk in enumerate(chunks, start=1):
+            header = _report_header(report_date, index=index, total=total)
             await client.send(
-                f"PMS Daily Report - {report_date} 22:00 CST ({index}/{total})\n\n"
-                f"{chunk}"
+                f"{header}\n\n{chunk}"
             )
     except Exception as exc:
         message = (
@@ -118,10 +119,27 @@ async def _run_paper_report(report_date: str) -> None:
         raise RuntimeError(f"paper-report.py exited {return_code}")
 
 
-def _paginate(content: str) -> list[str]:
-    if len(content) <= DISCORD_MESSAGE_LIMIT:
+def _report_header(report_date: str, *, index: int, total: int) -> str:
+    return f"PMS Daily Report - {report_date} 22:00 CST ({index}/{total})"
+
+
+def _paginate_report(content: str, report_date: str) -> list[str]:
+    total = 1
+    while True:
+        max_header = _report_header(report_date, index=total, total=total)
+        limit = DISCORD_MESSAGE_LIMIT - len(max_header) - 2
+        if limit <= 0:
+            raise ValueError("Discord report header exceeds message limit")
+        chunks = _paginate(content, limit=limit)
+        if len(chunks) == total:
+            return chunks
+        total = len(chunks)
+
+
+def _paginate(content: str, *, limit: int = DISCORD_MESSAGE_LIMIT) -> list[str]:
+    if len(content) <= limit:
         return [content]
     return [
-        content[index : index + DISCORD_MESSAGE_LIMIT]
-        for index in range(0, len(content), DISCORD_MESSAGE_LIMIT)
+        content[index : index + limit]
+        for index in range(0, len(content), limit)
     ]

--- a/src/pms/alerting/subscriber.py
+++ b/src/pms/alerting/subscriber.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import suppress
 from typing import Protocol
 
 from pms.alerting.events import alert_from_halt, halt_event_from_runtime
 from pms.event_stream import RuntimeEvent, RuntimeEventBus
+
+
+logger = logging.getLogger(__name__)
 
 
 class AlertSender(Protocol):
@@ -27,7 +31,13 @@ async def run_alerting_subscription(
     stop = stop_event or asyncio.Event()
     try:
         for event in replay:
-            await _deliver_if_halt(event, client)
+            try:
+                await _deliver_if_halt(event, client)
+            except Exception:
+                logger.exception(
+                    "alert subscriber replay delivery failed; continuing",
+                    extra={"runtime_event_id": event.event_id},
+                )
         while not stop.is_set():
             get_task = asyncio.create_task(queue.get())
             stop_task = asyncio.create_task(stop.wait())
@@ -42,7 +52,13 @@ async def run_alerting_subscription(
             if stop_task in done:
                 return
             event = get_task.result()
-            await _deliver_if_halt(event, client)
+            try:
+                await _deliver_if_halt(event, client)
+            except Exception:
+                logger.exception(
+                    "alert subscriber live delivery failed; continuing",
+                    extra={"runtime_event_id": event.event_id},
+                )
     finally:
         await event_bus.unsubscribe(queue)
 

--- a/src/pms/alerting/subscriber.py
+++ b/src/pms/alerting/subscriber.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Protocol
+
+from pms.alerting.events import alert_from_halt, halt_event_from_runtime
+from pms.event_stream import RuntimeEvent, RuntimeEventBus
+
+
+class AlertSender(Protocol):
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool: ...
+
+
+async def run_alerting_subscription(
+    event_bus: RuntimeEventBus,
+    client: AlertSender,
+    *,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    replay, queue = await event_bus.subscribe()
+    stop = stop_event or asyncio.Event()
+    try:
+        for event in replay:
+            await _deliver_if_halt(event, client)
+        while not stop.is_set():
+            get_task = asyncio.create_task(queue.get())
+            stop_task = asyncio.create_task(stop.wait())
+            done, pending = await asyncio.wait(
+                {get_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+            if stop_task in done:
+                return
+            event = get_task.result()
+            await _deliver_if_halt(event, client)
+    finally:
+        await event_bus.unsubscribe(queue)
+
+
+async def _deliver_if_halt(event: RuntimeEvent, client: AlertSender) -> None:
+    halt = halt_event_from_runtime(event)
+    if halt is None:
+        return
+    alert = alert_from_halt(halt)
+    await client.send(alert.message)

--- a/src/pms/api/__main__.py
+++ b/src/pms/api/__main__.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 
 import uvicorn
 
-from pms.config import load_settings
+from pms.config import load_settings, normalize_webhook_url
 
 
 LOOPBACK_API_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
@@ -56,7 +56,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(_startup_gate_message(host), file=sys.stderr)
         return 1
     auto_start = os.environ.get("PMS_AUTO_START", "").lower() in {"1", "true", "yes"}
-    if auto_start and settings.discord.webhook_url is None:
+    if auto_start and normalize_webhook_url(settings.discord.webhook_url) is None:
         print(_auto_start_fail_closed_message(), file=sys.stderr)
         return 1
 

--- a/src/pms/api/__main__.py
+++ b/src/pms/api/__main__.py
@@ -38,6 +38,13 @@ def _startup_gate_message(host: str) -> str:
     )
 
 
+def _auto_start_fail_closed_message() -> str:
+    return (
+        "Refusing PMS_AUTO_START=1 without PMS_DISCORD__WEBHOOK_URL. "
+        "Set the Discord webhook secret before supervising pms-api."
+    )
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parser().parse_args(list(argv) if argv is not None else None)
     if args.config is not None:
@@ -47,6 +54,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if not settings.api_token and host not in LOOPBACK_API_HOSTS:
         print(_startup_gate_message(host), file=sys.stderr)
+        return 1
+    auto_start = os.environ.get("PMS_AUTO_START", "").lower() in {"1", "true", "yes"}
+    if auto_start and settings.discord.webhook_url is None:
+        print(_auto_start_fail_closed_message(), file=sys.stderr)
         return 1
 
     uvicorn.run(

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -231,6 +231,7 @@ def create_app(
         code, payload = readiness_payload(
             active_runner,
             halt_subscriber_task=getattr(request.app.state, "alerting_task", None),
+            eod_scheduler_task=getattr(request.app.state, "eod_scheduler_task", None),
             forced_running=bool(getattr(request.app.state, "runner_started_for_test", False)),
         )
         return JSONResponse(status_code=code, content=payload)

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from collections.abc import AsyncIterator, Sequence
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -19,6 +19,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from pms.api.auth import require_api_token
+from pms.api.health import health_payload, readiness_payload
 from pms.api.routes.decisions import (
     AcceptDecisionRequest,
     DecisionMarketChangedError,
@@ -66,6 +67,9 @@ from pms.config import (
     load_settings,
     validate_live_mode_ready,
 )
+from pms.alerting.discord import DiscordWebhookClient
+from pms.alerting.scheduler import EODScheduler
+from pms.alerting.subscriber import run_alerting_subscription
 from pms.core.enums import RunMode
 from pms.core.models import EvalRecord, LiveTradingDisabledError, MarketSignal, TradeDecision
 from pms.evaluation.metrics import MetricsCollector, MetricsSnapshot
@@ -122,6 +126,12 @@ def create_app(
         startup_complete = False
         app_inst.state.autostart_attempted = False
         app_inst.state.autostart_error = None
+        app_inst.state.shutting_down = False
+        app_inst.state.alerting_task = None
+        app_inst.state.alerting_stop_event = None
+        app_inst.state.discord_client = None
+        app_inst.state.eod_scheduler_task = None
+        app_inst.state.eod_stop_event = None
         try:
             await _ensure_runner_pool(active_runner)
             runner_pool_initialized = active_runner.pg_pool is not None and not pool_was_bound
@@ -161,9 +171,12 @@ def create_app(
                     )
             if active_runner.pg_pool is not None:
                 await scan_orphaned_backtest_runs(active_runner.pg_pool)
+            _start_alerting_if_configured(app_inst, active_runner)
             startup_complete = True
             yield
         finally:
+            app_inst.state.shutting_down = True
+            await _stop_alerting_if_started(app_inst)
             # Always stop a running runner on shutdown — covers both auto_start
             # and runners launched by callers via POST /run/start, so sensor
             # resources (for example venue HTTP clients) close cleanly.
@@ -205,6 +218,22 @@ def create_app(
                 "brier_overall": metrics_snapshot.brier_overall,
             },
         }
+
+    @app.get("/health")
+    async def health(request: Request) -> JSONResponse:
+        code, payload = health_payload(
+            shutting_down=bool(getattr(request.app.state, "shutting_down", False))
+        )
+        return JSONResponse(status_code=code, content=payload)
+
+    @app.get("/readiness")
+    async def readiness(request: Request) -> JSONResponse:
+        code, payload = readiness_payload(
+            active_runner,
+            halt_subscriber_task=getattr(request.app.state, "alerting_task", None),
+            forced_running=bool(getattr(request.app.state, "runner_started_for_test", False)),
+        )
+        return JSONResponse(status_code=code, content=payload)
 
     @app.get("/signals")
     async def signals(limit: int = 50) -> list[dict[str, Any]]:
@@ -862,6 +891,53 @@ def _last_signal_at(signals: Sequence[MarketSignal]) -> str | None:
     if not signals:
         return None
     return signals[-1].fetched_at.isoformat()
+
+
+def _start_alerting_if_configured(app_inst: FastAPI, runner: Runner) -> None:
+    webhook = runner.config.discord.webhook_url
+    if webhook is None:
+        return
+    client = DiscordWebhookClient(webhook)
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(
+        run_alerting_subscription(runner.event_bus, client, stop_event=stop_event)
+    )
+    app_inst.state.discord_client = client
+    app_inst.state.alerting_stop_event = stop_event
+    app_inst.state.alerting_task = task
+    eod_stop_event = asyncio.Event()
+    eod_task = asyncio.create_task(EODScheduler(client).run(eod_stop_event))
+    app_inst.state.eod_stop_event = eod_stop_event
+    app_inst.state.eod_scheduler_task = eod_task
+
+
+async def _stop_alerting_if_started(app_inst: FastAPI) -> None:
+    eod_stop_event = getattr(app_inst.state, "eod_stop_event", None)
+    if isinstance(eod_stop_event, asyncio.Event):
+        eod_stop_event.set()
+    eod_task = getattr(app_inst.state, "eod_scheduler_task", None)
+    if isinstance(eod_task, asyncio.Task):
+        try:
+            await asyncio.wait_for(eod_task, timeout=2.0)
+        except TimeoutError:
+            eod_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await eod_task
+    stop_event = getattr(app_inst.state, "alerting_stop_event", None)
+    if isinstance(stop_event, asyncio.Event):
+        stop_event.set()
+    task = getattr(app_inst.state, "alerting_task", None)
+    if isinstance(task, asyncio.Task):
+        try:
+            await asyncio.wait_for(task, timeout=2.0)
+        except TimeoutError:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+    client = getattr(app_inst.state, "discord_client", None)
+    close = getattr(client, "aclose", None)
+    if callable(close):
+        await close()
 
 
 def _forecaster(decision: TradeDecision) -> str:

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -65,6 +65,7 @@ from pms.config import (
     MissingPolymarketCredentialsError,
     PMSSettings,
     load_settings,
+    normalize_webhook_url,
     validate_live_mode_ready,
 )
 from pms.alerting.discord import DiscordWebhookClient
@@ -232,7 +233,8 @@ def create_app(
             active_runner,
             halt_subscriber_task=getattr(request.app.state, "alerting_task", None),
             eod_scheduler_task=getattr(request.app.state, "eod_scheduler_task", None),
-            forced_running=bool(getattr(request.app.state, "runner_started_for_test", False)),
+            shutting_down=bool(getattr(request.app.state, "shutting_down", False)),
+            forced_running=bool(getattr(request.app.state, "runner_readiness_forced", False)),
         )
         return JSONResponse(status_code=code, content=payload)
 
@@ -895,7 +897,7 @@ def _last_signal_at(signals: Sequence[MarketSignal]) -> str | None:
 
 
 def _start_alerting_if_configured(app_inst: FastAPI, runner: Runner) -> None:
-    webhook = runner.config.discord.webhook_url
+    webhook = normalize_webhook_url(runner.config.discord.webhook_url)
     if webhook is None:
         return
     client = DiscordWebhookClient(webhook)
@@ -913,6 +915,7 @@ def _start_alerting_if_configured(app_inst: FastAPI, runner: Runner) -> None:
 
 
 async def _stop_alerting_if_started(app_inst: FastAPI) -> None:
+    first_exc: BaseException | None = None
     eod_stop_event = getattr(app_inst.state, "eod_stop_event", None)
     if isinstance(eod_stop_event, asyncio.Event):
         eod_stop_event.set()
@@ -924,6 +927,9 @@ async def _stop_alerting_if_started(app_inst: FastAPI) -> None:
             eod_task.cancel()
             with suppress(asyncio.CancelledError):
                 await eod_task
+        except Exception as exc:
+            logger.exception("EOD scheduler shutdown failed")
+            first_exc = first_exc or exc
     stop_event = getattr(app_inst.state, "alerting_stop_event", None)
     if isinstance(stop_event, asyncio.Event):
         stop_event.set()
@@ -935,10 +941,19 @@ async def _stop_alerting_if_started(app_inst: FastAPI) -> None:
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
+        except Exception as exc:
+            logger.exception("Alert subscriber shutdown failed")
+            first_exc = first_exc or exc
     client = getattr(app_inst.state, "discord_client", None)
     close = getattr(client, "aclose", None)
     if callable(close):
-        await close()
+        try:
+            await close()
+        except Exception as exc:
+            logger.exception("Discord client close failed")
+            first_exc = first_exc or exc
+    if first_exc is not None:
+        raise first_exc
 
 
 def _forecaster(decision: TradeDecision) -> str:

--- a/src/pms/api/health.py
+++ b/src/pms/api/health.py
@@ -16,12 +16,14 @@ def readiness_payload(
     runner: Runner,
     *,
     halt_subscriber_task: asyncio.Task[None] | None,
+    eod_scheduler_task: asyncio.Task[None] | None,
     forced_running: bool = False,
 ) -> tuple[int, dict[str, Any]]:
     checks = {
         "sensors": _sensor_readiness(runner, forced_running=forced_running),
         "event_loop": _event_loop_readiness(runner, forced_running=forced_running),
         "halt_subscriber": _task_readiness(halt_subscriber_task),
+        "eod_scheduler": _task_readiness(eod_scheduler_task),
     }
     status = "ready" if all(value == "ready" for value in checks.values()) else "not_ready"
     code = 200 if status == "ready" else 503

--- a/src/pms/api/health.py
+++ b/src/pms/api/health.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from pms.runner import Runner
+
+
+def health_payload(*, shutting_down: bool) -> tuple[int, dict[str, Any]]:
+    if shutting_down:
+        return 503, {"status": "shutting_down"}
+    return 200, {"status": "ok"}
+
+
+def readiness_payload(
+    runner: Runner,
+    *,
+    halt_subscriber_task: asyncio.Task[None] | None,
+    forced_running: bool = False,
+) -> tuple[int, dict[str, Any]]:
+    checks = {
+        "sensors": _sensor_readiness(runner, forced_running=forced_running),
+        "event_loop": _event_loop_readiness(runner, forced_running=forced_running),
+        "halt_subscriber": _task_readiness(halt_subscriber_task),
+    }
+    status = "ready" if all(value == "ready" for value in checks.values()) else "not_ready"
+    code = 200 if status == "ready" else 503
+    return code, {"status": status, "checks": checks}
+
+
+def _sensor_readiness(runner: Runner, *, forced_running: bool) -> str:
+    if forced_running:
+        return "ready"
+    if not runner.active_sensors:
+        return "not_started"
+    if any(not task.done() for task in runner.sensor_stream.tasks):
+        return "ready"
+    return "not_started"
+
+
+def _event_loop_readiness(runner: Runner, *, forced_running: bool) -> str:
+    if forced_running:
+        return "ready"
+    if any(not task.done() for task in runner.tasks):
+        return "ready"
+    return "not_started"
+
+
+def _task_readiness(task: asyncio.Task[None] | None) -> str:
+    if task is None:
+        return "not_started"
+    if task.done():
+        return "stopped"
+    return "ready"

--- a/src/pms/api/health.py
+++ b/src/pms/api/health.py
@@ -8,7 +8,7 @@ from pms.runner import Runner
 
 def health_payload(*, shutting_down: bool) -> tuple[int, dict[str, Any]]:
     if shutting_down:
-        return 503, {"status": "shutting_down"}
+        return 200, {"status": "shutting_down"}
     return 200, {"status": "ok"}
 
 
@@ -17,15 +17,19 @@ def readiness_payload(
     *,
     halt_subscriber_task: asyncio.Task[None] | None,
     eod_scheduler_task: asyncio.Task[None] | None,
+    shutting_down: bool = False,
     forced_running: bool = False,
 ) -> tuple[int, dict[str, Any]]:
+    if shutting_down:
+        return 503, {"status": "shutting_down", "checks": {}}
     checks = {
         "sensors": _sensor_readiness(runner, forced_running=forced_running),
         "event_loop": _event_loop_readiness(runner, forced_running=forced_running),
         "halt_subscriber": _task_readiness(halt_subscriber_task),
         "eod_scheduler": _task_readiness(eod_scheduler_task),
     }
-    status = "ready" if all(value == "ready" for value in checks.values()) else "not_ready"
+    ready_values = {"ready", "disabled"}
+    status = "ready" if all(value in ready_values for value in checks.values()) else "not_ready"
     code = 200 if status == "ready" else 503
     return code, {"status": status, "checks": checks}
 
@@ -50,7 +54,7 @@ def _event_loop_readiness(runner: Runner, *, forced_running: bool) -> str:
 
 def _task_readiness(task: asyncio.Task[None] | None) -> str:
     if task is None:
-        return "not_started"
+        return "disabled"
     if task.done():
         return "stopped"
     return "ready"

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -87,7 +87,6 @@ class DiscordSettings(BaseModel):
                     {
                         "type": "value_error",
                         "loc": ("webhook_url",),
-                        "msg": "webhook_url is required",
                         "input": None,
                         "ctx": {"error": ValueError("webhook_url is required")},
                     }

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -71,13 +71,12 @@ class DiscordSettings(BaseModel):
     @field_validator("webhook_url", mode="before")
     @classmethod
     def _validate_webhook_url(cls, value: object) -> object:
-        if value in {None, ""}:
+        normalized = normalize_webhook_url(value)
+        if normalized is None:
             return None
-        if not isinstance(value, str):
-            return value
-        if not value.startswith(("https://", "http://")):
-            raise ValueError("webhook_url must be an HTTP(S) URL")
-        return value
+        if not normalized.startswith("https://"):
+            raise ValueError("webhook_url must be an HTTPS URL")
+        return normalized
 
     def require_webhook_url(self) -> SecretStr:
         if self.webhook_url is None:
@@ -93,6 +92,19 @@ class DiscordSettings(BaseModel):
                 ],
             )
         return self.webhook_url
+
+
+def normalize_webhook_url(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, SecretStr):
+        raw_value = value.get_secret_value()
+    elif isinstance(value, str):
+        raw_value = value
+    else:
+        return str(value)
+    stripped = raw_value.strip()
+    return stripped or None
 
 
 class ControllerSettings(BaseModel):

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Literal, Self
 
 import yaml
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SecretStr, ValidationError, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pms.core.enums import RunMode
@@ -63,6 +63,37 @@ class LLMSettings(BaseModel):
         if not self.api_key:
             raise ValueError("api_key is required when LLM is enabled")
         return self
+
+
+class DiscordSettings(BaseModel):
+    webhook_url: SecretStr | None = None
+
+    @field_validator("webhook_url", mode="before")
+    @classmethod
+    def _validate_webhook_url(cls, value: object) -> object:
+        if value in {None, ""}:
+            return None
+        if not isinstance(value, str):
+            return value
+        if not value.startswith(("https://", "http://")):
+            raise ValueError("webhook_url must be an HTTP(S) URL")
+        return value
+
+    def require_webhook_url(self) -> SecretStr:
+        if self.webhook_url is None:
+            raise ValidationError.from_exception_data(
+                "DiscordSettings",
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("webhook_url",),
+                        "msg": "webhook_url is required",
+                        "input": None,
+                        "ctx": {"error": ValueError("webhook_url is required")},
+                    }
+                ],
+            )
+        return self.webhook_url
 
 
 class ControllerSettings(BaseModel):
@@ -135,6 +166,7 @@ class PMSSettings(BaseSettings):
     live_emergency_audit_path: str = ".data/live-emergency-audit.jsonl"
     polymarket: PolymarketSettings = Field(default_factory=PolymarketSettings)
     llm: LLMSettings = Field(default_factory=LLMSettings)
+    discord: DiscordSettings = Field(default_factory=DiscordSettings)
     risk: RiskSettings = Field(default_factory=RiskSettings)
     sensor: SensorSettings = Field(default_factory=SensorSettings)
     controller: ControllerSettings = Field(default_factory=ControllerSettings)

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -906,6 +906,7 @@ class Runner:
             risk=RiskManager(self.config.risk),
             feedback=ActuatorFeedback(self.feedback_store),
             dedup_store=self._build_dedup_store(),
+            event_bus=self.event_bus,
         )
 
     def _build_dedup_store(self) -> PgDedupStore | InMemoryDedupStore:

--- a/tests/integration/test_alerting_chain.py
+++ b/tests/integration/test_alerting_chain.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from pathlib import Path
 from typing import cast
 
 import httpx
@@ -32,7 +33,7 @@ pytestmark = [
 ]
 
 
-async def test_alerting_chain_real_auto_halt_to_discord(tmp_path) -> None:
+async def test_alerting_chain_real_auto_halt_to_discord(tmp_path: Path) -> None:
     posts: list[httpx.Request] = []
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -49,6 +50,7 @@ async def test_alerting_chain_real_auto_halt_to_discord(tmp_path) -> None:
     )
     stop = asyncio.Event()
     subscriber_task = asyncio.create_task(run_alerting_subscription(bus, client, stop_event=stop))
+    await asyncio.sleep(0)
     manager = RiskManager(RiskSettings(max_drawdown_pct=20.0))
     executor = ActuatorExecutor(
         adapter=RecordingAdapter(),

--- a/tests/integration/test_alerting_chain.py
+++ b/tests/integration/test_alerting_chain.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import cast
+
+import httpx
+import pytest
+
+from pms.actuator.executor import ActuatorExecutor
+from pms.actuator.feedback import ActuatorFeedback
+from pms.actuator.risk import RiskManager
+from pms.alerting.discord import DiscordWebhookClient
+from pms.alerting.subscriber import run_alerting_subscription
+from pms.config import RiskSettings
+from pms.event_stream import RuntimeEventBus
+from pms.storage.feedback_store import FeedbackStore
+from tests.support.fake_stores import InMemoryFeedbackStore
+from tests.unit.test_executor_publishes_halt import (
+    RecordingAdapter,
+    _decision,
+    _portfolio,
+)
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run integration tests",
+    ),
+]
+
+
+async def test_alerting_chain_real_auto_halt_to_discord(tmp_path) -> None:
+    posts: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        posts.append(request)
+        return httpx.Response(204)
+
+    bus = RuntimeEventBus()
+    replay, capture = await bus.subscribe()
+    assert replay == []
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    stop = asyncio.Event()
+    subscriber_task = asyncio.create_task(run_alerting_subscription(bus, client, stop_event=stop))
+    manager = RiskManager(RiskSettings(max_drawdown_pct=20.0))
+    executor = ActuatorExecutor(
+        adapter=RecordingAdapter(),
+        risk=manager,
+        feedback=ActuatorFeedback(cast(FeedbackStore, InMemoryFeedbackStore())),
+        event_bus=bus,
+    )
+
+    try:
+        await executor.execute(_decision(), _portfolio())
+        event = capture.get_nowait()
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while not posts:
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError("discord post not received")
+            await asyncio.sleep(0.01)
+    finally:
+        stop.set()
+        await asyncio.wait_for(subscriber_task, timeout=1.0)
+
+    assert manager.halt_events[-1].state.reason == "drawdown_circuit_breaker"
+    assert event.event_type == "pms.halt.drawdown_circuit_breaker"
+    assert len(posts) == 1
+    assert "drawdown_circuit_breaker" in posts[0].content.decode()

--- a/tests/integration/test_executor_halt_publish.py
+++ b/tests/integration/test_executor_halt_publish.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import os
+from typing import cast
 
 import pytest
 
-from tests.unit.test_executor_publishes_halt import (
-    test_executor_publishes_halt_event_from_real_auto_halt_path,
-)
+from pms.actuator.executor import ActuatorExecutor
+from pms.actuator.feedback import ActuatorFeedback
+from pms.actuator.risk import RiskManager
+from pms.config import RiskSettings
+from pms.core.enums import OrderStatus
+from pms.event_stream import RuntimeEventBus
+from pms.storage.feedback_store import FeedbackStore
+from tests.support.fake_stores import InMemoryFeedbackStore
+from tests.unit.test_executor_publishes_halt import RecordingAdapter, _decision, _portfolio
 
 
 pytestmark = [
@@ -19,4 +26,19 @@ pytestmark = [
 
 
 async def test_executor_halt_publish_integration() -> None:
-    await test_executor_publishes_halt_event_from_real_auto_halt_path()
+    bus = RuntimeEventBus()
+    _, queue = await bus.subscribe()
+    manager = RiskManager(RiskSettings(max_drawdown_pct=20.0))
+    executor = ActuatorExecutor(
+        adapter=RecordingAdapter(),
+        risk=manager,
+        feedback=ActuatorFeedback(cast(FeedbackStore, InMemoryFeedbackStore())),
+        event_bus=bus,
+    )
+
+    state = await executor.execute(_decision(), _portfolio())
+    event = queue.get_nowait()
+
+    assert state.status == OrderStatus.INVALID.value
+    assert manager.halt_events[-1].state.reason == "drawdown_circuit_breaker"
+    assert event.event_type == "pms.halt.drawdown_circuit_breaker"

--- a/tests/integration/test_executor_halt_publish.py
+++ b/tests/integration/test_executor_halt_publish.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.unit.test_executor_publishes_halt import (
+    test_executor_publishes_halt_event_from_real_auto_halt_path,
+)
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("PMS_RUN_INTEGRATION") != "1",
+        reason="set PMS_RUN_INTEGRATION=1 to run integration tests",
+    ),
+]
+
+
+async def test_executor_halt_publish_integration() -> None:
+    await test_executor_publishes_halt_event_from_real_auto_halt_path()

--- a/tests/unit/test_alert_events.py
+++ b/tests/unit/test_alert_events.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pms.alerting.events import halt_event_from_runtime
+from pms.event_stream import RuntimeEvent
+
+
+def test_halt_event_reason_preserves_inner_colons() -> None:
+    event = RuntimeEvent(
+        event_id=1,
+        event_type="pms.halt.drawdown_circuit_breaker",
+        created_at=datetime(2026, 5, 6, 8, 0, tzinfo=UTC),
+        summary="Auto-halt drawdown_circuit_breaker: drawdown 15%: above 10% limit",
+    )
+
+    halt = halt_event_from_runtime(event)
+
+    assert halt is not None
+    assert halt.reason == "drawdown 15%: above 10% limit"

--- a/tests/unit/test_alert_shutdown_bound.py
+++ b/tests/unit/test_alert_shutdown_bound.py
@@ -22,6 +22,17 @@ class HangingClient:
         return True
 
 
+class FailingClient:
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool:
+        del content, embed
+        raise RuntimeError("discord unavailable")
+
+
 @pytest.mark.asyncio
 async def test_alert_shutdown_bound(tmp_path: Path) -> None:
     started = time.monotonic()
@@ -39,3 +50,20 @@ async def test_alert_shutdown_bound(tmp_path: Path) -> None:
     assert len(dropped) == 1
     payload = json.loads(dropped[0].read_text())
     assert payload["reason"] == "SIGTERM"
+
+
+@pytest.mark.asyncio
+async def test_alert_shutdown_exception_writes_fallback(tmp_path: Path) -> None:
+    delivered = await emit_shutdown_alert(
+        FailingClient(),
+        reason="exception",
+        alert_dir=tmp_path,
+        timeout_s=0.5,
+    )
+
+    assert delivered is False
+    dropped = list(tmp_path.glob("dropped-shutdown-*.json"))
+    assert len(dropped) == 1
+    payload = json.loads(dropped[0].read_text())
+    assert payload["reason"] == "exception"
+    assert "discord unavailable" in payload["error"]

--- a/tests/unit/test_alert_shutdown_bound.py
+++ b/tests/unit/test_alert_shutdown_bound.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from pms.alerting.lifecycle import emit_shutdown_alert
+
+
+class HangingClient:
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool:
+        del content, embed
+        await asyncio.sleep(60)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_alert_shutdown_bound(tmp_path: Path) -> None:
+    started = time.monotonic()
+
+    delivered = await emit_shutdown_alert(
+        HangingClient(),
+        reason="SIGTERM",
+        alert_dir=tmp_path,
+        timeout_s=0.05,
+    )
+
+    assert delivered is False
+    assert time.monotonic() - started < 0.5
+    dropped = list(tmp_path.glob("dropped-shutdown-*.json"))
+    assert len(dropped) == 1
+    payload = json.loads(dropped[0].read_text())
+    assert payload["reason"] == "SIGTERM"

--- a/tests/unit/test_alert_subscriber.py
+++ b/tests/unit/test_alert_subscriber.py
@@ -30,6 +30,7 @@ async def test_alert_subscriber_converts_halt_event_to_discord_message() -> None
     client = RecordingDiscordClient()
     stop = asyncio.Event()
     task = asyncio.create_task(run_alerting_subscription(bus, client, stop_event=stop))
+    await asyncio.sleep(0)
 
     try:
         await bus.publish(

--- a/tests/unit/test_alert_subscriber.py
+++ b/tests/unit/test_alert_subscriber.py
@@ -24,6 +24,23 @@ class RecordingDiscordClient:
         return True
 
 
+class FailsFirstDiscordClient(RecordingDiscordClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attempts = 0
+
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool:
+        self.attempts += 1
+        if self.attempts == 1:
+            raise RuntimeError("one bad event")
+        return await super().send(content, embed=embed)
+
+
 @pytest.mark.asyncio
 async def test_alert_subscriber_converts_halt_event_to_discord_message() -> None:
     bus = RuntimeEventBus()
@@ -51,3 +68,35 @@ async def test_alert_subscriber_converts_halt_event_to_discord_message() -> None
 
     assert "drawdown_circuit_breaker" in client.messages[0]
     assert "decision-alert" in client.messages[0]
+
+
+@pytest.mark.asyncio
+async def test_alert_subscriber_survives_single_delivery_failure() -> None:
+    bus = RuntimeEventBus()
+    client = FailsFirstDiscordClient()
+    stop = asyncio.Event()
+    task = asyncio.create_task(run_alerting_subscription(bus, client, stop_event=stop))
+    await asyncio.sleep(0)
+
+    try:
+        await bus.publish(
+            "pms.halt.drawdown_circuit_breaker",
+            "Auto-halt drawdown_circuit_breaker: first failure",
+            created_at=datetime(2026, 5, 6, 8, 0, tzinfo=UTC),
+        )
+        await bus.publish(
+            "pms.halt.drawdown_circuit_breaker",
+            "Auto-halt drawdown_circuit_breaker: second success",
+            created_at=datetime(2026, 5, 6, 8, 1, tzinfo=UTC),
+        )
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while not client.messages:
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError("subscriber did not recover after failure")
+            await asyncio.sleep(0.01)
+    finally:
+        stop.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert client.attempts == 2
+    assert "second success" in client.messages[0]

--- a/tests/unit/test_alert_subscriber.py
+++ b/tests/unit/test_alert_subscriber.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.alerting.subscriber import run_alerting_subscription
+from pms.event_stream import RuntimeEventBus
+
+
+class RecordingDiscordClient:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool:
+        del embed
+        self.messages.append(content)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_alert_subscriber_converts_halt_event_to_discord_message() -> None:
+    bus = RuntimeEventBus()
+    client = RecordingDiscordClient()
+    stop = asyncio.Event()
+    task = asyncio.create_task(run_alerting_subscription(bus, client, stop_event=stop))
+
+    try:
+        await bus.publish(
+            "pms.halt.drawdown_circuit_breaker",
+            "Auto-halt drawdown_circuit_breaker: drawdown_circuit_breaker",
+            created_at=datetime(2026, 5, 6, 8, 0, tzinfo=UTC),
+            market_id="market-alert",
+            decision_id="decision-alert",
+        )
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while not client.messages:
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError("subscriber did not deliver alert")
+            await asyncio.sleep(0.01)
+    finally:
+        stop.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert "drawdown_circuit_breaker" in client.messages[0]
+    assert "decision-alert" in client.messages[0]

--- a/tests/unit/test_alerting_lifespan.py
+++ b/tests/unit/test_alerting_lifespan.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pms.api.app import create_app
+from pms.config import DiscordSettings, PMSSettings
+from pms.runner import Runner
+
+
+@pytest.mark.asyncio
+async def test_alerting_lifespan_spawns_and_cancels_subscription_task() -> None:
+    runner = Runner(
+        config=PMSSettings(
+            auto_migrate_default_v2=False,
+            discord=DiscordSettings(webhook_url="https://discord.example/webhooks/a/b"),
+        )
+    )
+    app = create_app(runner, auto_start=False)
+
+    async with app.router.lifespan_context(app):
+        task = app.state.alerting_task
+        assert isinstance(task, asyncio.Task)
+        assert not task.done()
+
+    assert task.done()

--- a/tests/unit/test_alerting_lifespan.py
+++ b/tests/unit/test_alerting_lifespan.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from pydantic import SecretStr
 
-from pms.api.app import create_app
+from pms.api.app import _stop_alerting_if_started, create_app
 from pms.config import DiscordSettings, PMSSettings
 from pms.runner import Runner
 
@@ -28,3 +30,38 @@ async def test_alerting_lifespan_spawns_and_cancels_subscription_task() -> None:
         assert not task.done()
 
     assert task.done()
+
+
+class _ClosableClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_alerting_shutdown_runs_remaining_cleanup_after_task_failure() -> None:
+    async def boom() -> None:
+        raise RuntimeError("eod failed")
+
+    app = SimpleNamespace()
+    client = _ClosableClient()
+    alerting_stop_event = asyncio.Event()
+    eod_stop_event = asyncio.Event()
+    app.state = SimpleNamespace(
+        alerting_stop_event=alerting_stop_event,
+        eod_stop_event=eod_stop_event,
+        eod_scheduler_task=asyncio.create_task(boom()),
+        alerting_task=asyncio.create_task(asyncio.sleep(60)),
+        discord_client=client,
+    )
+    await asyncio.sleep(0)
+
+    with pytest.raises(RuntimeError, match="eod failed"):
+        await _stop_alerting_if_started(cast(Any, app))
+
+    assert eod_stop_event.is_set()
+    assert alerting_stop_event.is_set()
+    assert app.state.alerting_task.done()
+    assert client.closed is True

--- a/tests/unit/test_alerting_lifespan.py
+++ b/tests/unit/test_alerting_lifespan.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from pydantic import SecretStr
 
 from pms.api.app import create_app
 from pms.config import DiscordSettings, PMSSettings
@@ -14,7 +15,9 @@ async def test_alerting_lifespan_spawns_and_cancels_subscription_task() -> None:
     runner = Runner(
         config=PMSSettings(
             auto_migrate_default_v2=False,
-            discord=DiscordSettings(webhook_url="https://discord.example/webhooks/a/b"),
+            discord=DiscordSettings(
+                webhook_url=SecretStr("https://discord.example/webhooks/a/b")
+            ),
         )
     )
     app = create_app(runner, auto_start=False)

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -59,6 +59,28 @@ def test_main_refuses_non_loopback_bind_without_api_token(
     assert "PMS_API_HOST" in captured.err
 
 
+def test_main_auto_start_requires_discord_webhook(
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_run(app: str, **kwargs: Any) -> None:
+        calls["app"] = app
+        calls.update(kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    monkeypatch.setenv("PMS_AUTO_START", "1")
+    monkeypatch.delenv("PMS_DISCORD__WEBHOOK_URL", raising=False)
+
+    exit_code = api_main.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert calls == {}
+    assert "PMS_DISCORD__WEBHOOK_URL" in captured.err
+
+
 def test_main_uses_settings_host_even_when_host_flag_is_passed(
     monkeypatch: Any,
 ) -> None:

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -81,6 +81,28 @@ def test_main_auto_start_requires_discord_webhook(
     assert "PMS_DISCORD__WEBHOOK_URL" in captured.err
 
 
+def test_main_auto_start_rejects_blank_discord_webhook(
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    def fake_run(app: str, **kwargs: Any) -> None:
+        calls["app"] = app
+        calls.update(kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    monkeypatch.setenv("PMS_AUTO_START", "1")
+    monkeypatch.setenv("PMS_DISCORD__WEBHOOK_URL", "   ")
+
+    exit_code = api_main.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert calls == {}
+    assert "PMS_DISCORD__WEBHOOK_URL" in captured.err
+
+
 def test_main_uses_settings_host_even_when_host_flag_is_passed(
     monkeypatch: Any,
 ) -> None:

--- a/tests/unit/test_discord_client_retry.py
+++ b/tests/unit/test_discord_client_retry.py
@@ -109,6 +109,62 @@ async def test_discord_client_long_retry_after_falls_back(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_discord_client_ignores_negative_retry_after(tmp_path: Path) -> None:
+    attempts = 0
+    sleeps: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        del request
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "-1"})
+        return httpx.Response(204)
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        sleep=sleep,
+    )
+
+    assert await client.send("payload") is True
+    assert sleeps == [1.0]
+
+
+@pytest.mark.asyncio
+async def test_discord_client_redacts_nested_fallback_values(tmp_path: Path) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(500)
+
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        sleep=lambda _: None,
+    )
+
+    assert await client.send(
+        "payload",
+        embed={
+            "description": "see https://discord.example/webhooks/app/token",
+            "fields": [
+                {"value": "http://discord.example/webhooks/app/token"},
+            ],
+        },
+    ) is False
+
+    [dropped] = list(tmp_path.glob("dropped-*.json"))
+    content = dropped.read_text(encoding="utf-8")
+    assert "webhooks/app/token" not in content
+    assert "<redacted-url>" in content
+
+
+@pytest.mark.asyncio
 async def test_discord_client_network_partition_falls_back(tmp_path: Path) -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("network partition", request=request)

--- a/tests/unit/test_discord_client_retry.py
+++ b/tests/unit/test_discord_client_retry.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import httpx
+import pytest
+
+from pms.alerting.discord import DiscordWebhookClient
+
+
+@pytest.mark.asyncio
+async def test_discord_client_posts_successfully(tmp_path: Path) -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(204)
+
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    assert await client.send("hello") is True
+    assert len(requests) == 1
+    assert json.loads(requests[0].content) == {"content": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_discord_client_retries_then_writes_fallback(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    attempts = 0
+    sleeps: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        del request
+        attempts += 1
+        return httpx.Response(500)
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        sleep=sleep,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        assert await client.send("payload") is False
+
+    assert attempts == 3
+    assert sleeps == [1.0, 2.0]
+    dropped = list(tmp_path.glob("dropped-*.json"))
+    assert len(dropped) == 1
+    assert json.loads(dropped[0].read_text())["content"] == "payload"
+    assert "webhooks/app/token" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_discord_client_respects_short_retry_after(tmp_path: Path) -> None:
+    attempts = 0
+    sleeps: list[float] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        del request
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "5"})
+        return httpx.Response(204)
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        sleep=sleep,
+    )
+
+    assert await client.send("payload") is True
+    assert attempts == 2
+    assert sleeps == [5.0]
+
+
+@pytest.mark.asyncio
+async def test_discord_client_long_retry_after_falls_back(tmp_path: Path) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(429, headers={"Retry-After": "120"})
+
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    assert await client.send("payload") is False
+    assert len(list(tmp_path.glob("dropped-*.json"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_discord_client_network_partition_falls_back(tmp_path: Path) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network partition", request=request)
+
+    client = DiscordWebhookClient(
+        "https://discord.example/webhooks/app/token",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        sleep=lambda _: None,
+    )
+
+    assert await client.send("payload") is False
+    assert len(list(tmp_path.glob("dropped-*.json"))) == 1

--- a/tests/unit/test_discord_settings.py
+++ b/tests/unit/test_discord_settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import SecretStr, ValidationError
+from pydantic import ValidationError
 
 from pms.config import DiscordSettings, PMSSettings
 

--- a/tests/unit/test_discord_settings.py
+++ b/tests/unit/test_discord_settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from pms.config import DiscordSettings, PMSSettings
 
@@ -32,4 +32,4 @@ def test_discord_settings_missing_webhook_fails_when_required() -> None:
 
 def test_discord_settings_rejects_non_url() -> None:
     with pytest.raises(ValidationError):
-        DiscordSettings(webhook_url="not-a-url")
+        DiscordSettings.model_validate({"webhook_url": "not-a-url"})

--- a/tests/unit/test_discord_settings.py
+++ b/tests/unit/test_discord_settings.py
@@ -33,3 +33,16 @@ def test_discord_settings_missing_webhook_fails_when_required() -> None:
 def test_discord_settings_rejects_non_url() -> None:
     with pytest.raises(ValidationError):
         DiscordSettings.model_validate({"webhook_url": "not-a-url"})
+
+
+def test_discord_settings_rejects_plaintext_http_webhook() -> None:
+    with pytest.raises(ValidationError, match="HTTPS"):
+        DiscordSettings.model_validate(
+            {"webhook_url": "http://discord.example/webhooks/abc/secret-token"}
+        )
+
+
+def test_discord_settings_trims_blank_webhook_to_missing() -> None:
+    settings = DiscordSettings.model_validate({"webhook_url": "   "})
+
+    assert settings.webhook_url is None

--- a/tests/unit/test_discord_settings.py
+++ b/tests/unit/test_discord_settings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from pms.config import DiscordSettings, PMSSettings
+
+
+def test_discord_settings_loads_nested_secret_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "PMS_DISCORD__WEBHOOK_URL",
+        "https://discord.example/webhooks/abc/secret-token",
+    )
+
+    settings = PMSSettings()
+
+    assert settings.discord.require_webhook_url().get_secret_value().endswith(
+        "/secret-token"
+    )
+    assert "secret-token" not in repr(settings.discord)
+    assert "**********" in repr(settings.discord)
+
+
+def test_discord_settings_missing_webhook_fails_when_required() -> None:
+    settings = DiscordSettings()
+
+    with pytest.raises(ValidationError, match="webhook_url is required"):
+        settings.require_webhook_url()
+
+
+def test_discord_settings_rejects_non_url() -> None:
+    with pytest.raises(ValidationError):
+        DiscordSettings(webhook_url="not-a-url")

--- a/tests/unit/test_eod_subprocess_failure.py
+++ b/tests/unit/test_eod_subprocess_failure.py
@@ -127,3 +127,26 @@ async def test_paper_report_subprocess_uses_no_dev(
     )
 
     assert captured[:3] == ["uv", "run", "--no-dev"]
+
+
+@pytest.mark.asyncio
+async def test_eod_report_pages_reserve_space_for_discord_header(tmp_path: Path) -> None:
+    report_date = "2026-05-06"
+    (tmp_path / f"{report_date}.md").write_text("x" * 4500, encoding="utf-8")
+    client = RecordingClient()
+
+    async def successful_runner(candidate_date: str) -> None:
+        assert candidate_date == report_date
+
+    await run_eod_report_once(
+        client,
+        now=datetime(2026, 5, 6, 22, 0, tzinfo=ZoneInfo("Asia/Shanghai")),
+        report_root=tmp_path,
+        run_report=successful_runner,
+    )
+
+    assert len(client.messages) > 1
+    assert all(len(message) <= 2000 for message in client.messages)
+    assert client.messages[0].startswith(
+        "PMS Daily Report - 2026-05-06 22:00 CST (1/"
+    )

--- a/tests/unit/test_eod_subprocess_failure.py
+++ b/tests/unit/test_eod_subprocess_failure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -7,7 +8,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from pms.alerting.scheduler import run_eod_report_once
+from pms.alerting.scheduler import EODScheduler, run_eod_report_once
 
 
 class RecordingClient:
@@ -23,6 +24,22 @@ class RecordingClient:
         del embed
         self.messages.append(content)
         return True
+
+
+class StopAfterSendClient(RecordingClient):
+    def __init__(self, stop_event: asyncio.Event) -> None:
+        super().__init__()
+        self._stop_event = stop_event
+
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool:
+        result = await super().send(content, embed=embed)
+        self._stop_event.set()
+        return result
 
 
 @pytest.mark.asyncio
@@ -47,3 +64,34 @@ async def test_eod_subprocess_failure_posts_warning_and_reraises(
     assert "EOD report generation failed for 2026-05-06" in client.messages[0]
     assert "warning" in client.messages[0].lower()
     assert "paper-report exploded" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_eod_scheduler_continues_after_report_failure(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stop_event = asyncio.Event()
+    client = StopAfterSendClient(stop_event)
+    attempts = 0
+
+    async def failing_runner(report_date: str) -> None:
+        nonlocal attempts
+        attempts += 1
+        assert report_date == "2026-05-06"
+        raise RuntimeError("transient report failure")
+
+    scheduler = EODScheduler(
+        client,
+        clock=lambda: datetime(2026, 5, 6, 22, 0, tzinfo=ZoneInfo("Asia/Shanghai")),
+        report_root=tmp_path,
+        run_report=failing_runner,
+        next_trigger_fn=lambda tz, now: now.astimezone(tz),
+    )
+
+    with caplog.at_level(logging.ERROR):
+        await asyncio.wait_for(scheduler.run(stop_event), timeout=1.0)
+
+    assert attempts == 1
+    assert "EOD report generation failed for 2026-05-06" in client.messages[0]
+    assert "EOD scheduler iteration failed; continuing" in caplog.text

--- a/tests/unit/test_eod_subprocess_failure.py
+++ b/tests/unit/test_eod_subprocess_failure.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from pms.alerting.scheduler import run_eod_report_once
+
+
+class RecordingClient:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send(
+        self,
+        content: str,
+        *,
+        embed: dict[str, object] | None = None,
+    ) -> bool:
+        del embed
+        self.messages.append(content)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_eod_subprocess_failure_posts_warning_and_reraises(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = RecordingClient()
+
+    async def failing_runner(report_date: str) -> None:
+        del report_date
+        raise RuntimeError("paper-report exploded")
+
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError):
+        await run_eod_report_once(
+            client,
+            now=datetime(2026, 5, 6, 22, 0, tzinfo=ZoneInfo("Asia/Shanghai")),
+            report_root=tmp_path,
+            run_report=failing_runner,
+        )
+
+    assert "EOD report generation failed for 2026-05-06" in client.messages[0]
+    assert "warning" in client.messages[0].lower()
+    assert "paper-report exploded" in caplog.text

--- a/tests/unit/test_eod_subprocess_failure.py
+++ b/tests/unit/test_eod_subprocess_failure.py
@@ -95,3 +95,35 @@ async def test_eod_scheduler_continues_after_report_failure(
     assert attempts == 1
     assert "EOD report generation failed for 2026-05-06" in client.messages[0]
     assert "EOD scheduler iteration failed; continuing" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_paper_report_subprocess_uses_no_dev(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: list[str] = []
+
+    class _Process:
+        async def wait(self) -> int:
+            return 0
+
+    async def fake_create_subprocess_exec(*args: str) -> _Process:
+        captured.extend(args)
+        return _Process()
+
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+    (tmp_path / "2026-05-06.md").write_text("report", encoding="utf-8")
+
+    await run_eod_report_once(
+        RecordingClient(),
+        now=datetime(2026, 5, 6, 22, 0, tzinfo=ZoneInfo("Asia/Shanghai")),
+        report_root=tmp_path,
+        run_report=None,
+    )
+
+    assert captured[:3] == ["uv", "run", "--no-dev"]

--- a/tests/unit/test_executor_publishes_halt.py
+++ b/tests/unit/test_executor_publishes_halt.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import cast
+
+import pytest
+
+from pms.actuator.executor import ActuatorExecutor
+from pms.actuator.feedback import ActuatorFeedback
+from pms.actuator.risk import RiskManager
+from pms.config import RiskSettings
+from pms.controller.pipeline import _default_portfolio
+from pms.core.enums import OrderStatus, TimeInForce
+from pms.core.models import OrderState, Portfolio, TradeDecision
+from pms.event_stream import RuntimeEventBus
+from pms.storage.feedback_store import FeedbackStore
+from tests.support.fake_stores import InMemoryFeedbackStore
+
+
+NOW = datetime(2026, 5, 6, 8, 0, tzinfo=UTC)
+
+
+class RecordingAdapter:
+    calls = 0
+
+    async def execute(
+        self,
+        decision: TradeDecision,
+        portfolio: Portfolio | None = None,
+    ) -> OrderState:
+        del decision, portfolio
+        self.calls += 1
+        raise AssertionError("adapter should not be called after auto-halt")
+
+
+def _decision() -> TradeDecision:
+    return TradeDecision(
+        decision_id="decision-halt-publish",
+        market_id="market-halt-publish",
+        token_id="token-halt-publish",
+        venue="polymarket",
+        side="BUY",
+        notional_usdc=5.0,
+        order_type="limit",
+        max_slippage_bps=25,
+        stop_conditions=["halt-publish-test"],
+        prob_estimate=0.6,
+        expected_edge=0.1,
+        time_in_force=TimeInForce.GTC,
+        opportunity_id="opportunity-halt-publish",
+        strategy_id="strategy",
+        strategy_version_id="strategy-v1",
+        limit_price=0.5,
+    )
+
+
+def _portfolio() -> Portfolio:
+    return replace(
+        _default_portfolio(),
+        total_usdc=100.0,
+        free_usdc=100.0,
+        locked_usdc=0.0,
+        max_drawdown_pct=21.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_publishes_halt_event_from_real_auto_halt_path() -> None:
+    bus = RuntimeEventBus()
+    replay, queue = await bus.subscribe()
+    assert replay == []
+    manager = RiskManager(RiskSettings(max_drawdown_pct=20.0))
+    executor = ActuatorExecutor(
+        adapter=RecordingAdapter(),
+        risk=manager,
+        feedback=ActuatorFeedback(cast(FeedbackStore, InMemoryFeedbackStore())),
+        event_bus=bus,
+    )
+
+    state = await executor.execute(_decision(), _portfolio())
+    event = queue.get_nowait()
+
+    assert state.status == OrderStatus.INVALID.value
+    assert state.raw_status == "drawdown_circuit_breaker"
+    assert manager.halt_events[-1].state.reason == "drawdown_circuit_breaker"
+    assert event.event_type == "pms.halt.drawdown_circuit_breaker"
+    assert event.market_id == "market-halt-publish"
+    assert event.decision_id == "decision-halt-publish"

--- a/tests/unit/test_fly_config.py
+++ b/tests/unit/test_fly_config.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_fly_binds_api_host_via_env_and_checks_readiness() -> None:
+    fly_config = tomllib.loads(Path("fly.toml").read_text(encoding="utf-8"))
+
+    assert fly_config["env"]["PMS_API_HOST"] == "0.0.0.0"
+    assert fly_config["http_service"]["checks"][0]["path"] == "/readiness"
+
+
+def test_docker_cmd_uses_pms_api_host_env_not_deprecated_host_flag() -> None:
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+
+    assert "--host" not in dockerfile
+    assert "pms-api" in dockerfile

--- a/tests/unit/test_fly_config.py
+++ b/tests/unit/test_fly_config.py
@@ -16,3 +16,5 @@ def test_docker_cmd_uses_pms_api_host_env_not_deprecated_host_flag() -> None:
 
     assert "--host" not in dockerfile
     assert "pms-api" in dockerfile
+    assert "COPY alembic.ini ./alembic.ini" in dockerfile
+    assert "COPY alembic ./alembic" in dockerfile

--- a/tests/unit/test_health_endpoint.py
+++ b/tests/unit/test_health_endpoint.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from pms.api.app import create_app
+from pms.config import PMSSettings
+from pms.runner import Runner
+
+
+@pytest.mark.asyncio
+async def test_health_liveness_is_independent_from_runner_readiness() -> None:
+    runner = Runner(config=PMSSettings(auto_migrate_default_v2=False))
+    app = create_app(runner, auto_start=False)
+    transport = httpx.ASGITransport(app=app)
+
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            health = await client.get("/health")
+            readiness = await client.get("/readiness")
+
+    assert health.status_code == 200
+    assert health.json()["status"] == "ok"
+    assert readiness.status_code == 503
+    assert readiness.json()["status"] == "not_ready"
+    assert readiness.json()["checks"]["halt_subscriber"] == "not_started"
+
+
+@pytest.mark.asyncio
+async def test_readiness_reports_ready_when_runner_and_alerting_are_running() -> None:
+    runner = Runner(config=PMSSettings(auto_migrate_default_v2=False))
+    app = create_app(runner, auto_start=False)
+    app.state.alerting_task = asyncio.create_task(asyncio.sleep(60))
+    app.state.eod_scheduler_task = asyncio.create_task(asyncio.sleep(60))
+    app.state.runner_started_for_test = True
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/readiness")
+    finally:
+        app.state.alerting_task.cancel()
+        app.state.eod_scheduler_task.cancel()
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ready"

--- a/tests/unit/test_health_endpoint.py
+++ b/tests/unit/test_health_endpoint.py
@@ -25,8 +25,8 @@ async def test_health_liveness_is_independent_from_runner_readiness() -> None:
     assert health.json()["status"] == "ok"
     assert readiness.status_code == 503
     assert readiness.json()["status"] == "not_ready"
-    assert readiness.json()["checks"]["halt_subscriber"] == "not_started"
-    assert readiness.json()["checks"]["eod_scheduler"] == "not_started"
+    assert readiness.json()["checks"]["halt_subscriber"] == "disabled"
+    assert readiness.json()["checks"]["eod_scheduler"] == "disabled"
 
 
 @pytest.mark.asyncio
@@ -35,7 +35,7 @@ async def test_readiness_reports_ready_when_runner_and_alerting_are_running() ->
     app = create_app(runner, auto_start=False)
     app.state.alerting_task = asyncio.create_task(asyncio.sleep(60))
     app.state.eod_scheduler_task = asyncio.create_task(asyncio.sleep(60))
-    app.state.runner_started_for_test = True
+    app.state.runner_readiness_forced = True
 
     try:
         transport = httpx.ASGITransport(app=app)
@@ -55,12 +55,29 @@ async def test_readiness_reports_ready_when_runner_and_alerting_are_running() ->
 
 
 @pytest.mark.asyncio
+async def test_readiness_allows_disabled_alerting_when_runner_is_ready() -> None:
+    runner = Runner(config=PMSSettings(auto_migrate_default_v2=False))
+    app = create_app(runner, auto_start=False)
+    app.state.runner_readiness_forced = True
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/readiness")
+
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["status"] == "ready"
+    assert payload["checks"]["halt_subscriber"] == "disabled"
+    assert payload["checks"]["eod_scheduler"] == "disabled"
+
+
+@pytest.mark.asyncio
 async def test_readiness_reports_not_ready_when_eod_scheduler_stopped() -> None:
     runner = Runner(config=PMSSettings(auto_migrate_default_v2=False))
     app = create_app(runner, auto_start=False)
     app.state.alerting_task = asyncio.create_task(asyncio.sleep(60))
     app.state.eod_scheduler_task = asyncio.create_task(asyncio.sleep(0))
-    app.state.runner_started_for_test = True
+    app.state.runner_readiness_forced = True
 
     try:
         await app.state.eod_scheduler_task
@@ -75,3 +92,20 @@ async def test_readiness_reports_not_ready_when_eod_scheduler_stopped() -> None:
     assert response.status_code == 503
     assert payload["status"] == "not_ready"
     assert payload["checks"]["eod_scheduler"] == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_health_stays_live_while_readiness_fails_during_shutdown() -> None:
+    runner = Runner(config=PMSSettings(auto_migrate_default_v2=False))
+    app = create_app(runner, auto_start=False)
+    app.state.shutting_down = True
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        health = await client.get("/health")
+        readiness = await client.get("/readiness")
+
+    assert health.status_code == 200
+    assert health.json()["status"] == "shutting_down"
+    assert readiness.status_code == 503
+    assert readiness.json()["status"] == "shutting_down"

--- a/tests/unit/test_health_endpoint.py
+++ b/tests/unit/test_health_endpoint.py
@@ -26,6 +26,7 @@ async def test_health_liveness_is_independent_from_runner_readiness() -> None:
     assert readiness.status_code == 503
     assert readiness.json()["status"] == "not_ready"
     assert readiness.json()["checks"]["halt_subscriber"] == "not_started"
+    assert readiness.json()["checks"]["eod_scheduler"] == "not_started"
 
 
 @pytest.mark.asyncio
@@ -43,6 +44,34 @@ async def test_readiness_reports_ready_when_runner_and_alerting_are_running() ->
     finally:
         app.state.alerting_task.cancel()
         app.state.eod_scheduler_task.cancel()
+        await asyncio.gather(
+            app.state.alerting_task,
+            app.state.eod_scheduler_task,
+            return_exceptions=True,
+        )
 
     assert response.status_code == 200
     assert response.json()["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_readiness_reports_not_ready_when_eod_scheduler_stopped() -> None:
+    runner = Runner(config=PMSSettings(auto_migrate_default_v2=False))
+    app = create_app(runner, auto_start=False)
+    app.state.alerting_task = asyncio.create_task(asyncio.sleep(60))
+    app.state.eod_scheduler_task = asyncio.create_task(asyncio.sleep(0))
+    app.state.runner_started_for_test = True
+
+    try:
+        await app.state.eod_scheduler_task
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/readiness")
+    finally:
+        app.state.alerting_task.cancel()
+        await asyncio.gather(app.state.alerting_task, return_exceptions=True)
+
+    payload = response.json()
+    assert response.status_code == 503
+    assert payload["status"] == "not_ready"
+    assert payload["checks"]["eod_scheduler"] == "stopped"

--- a/tests/unit/test_next_trigger.py
+++ b/tests/unit/test_next_trigger.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from pms.alerting.scheduler import next_trigger
+
+
+def test_next_trigger_same_day_before_2200_asia_shanghai() -> None:
+    tz = ZoneInfo("Asia/Shanghai")
+
+    assert next_trigger(tz, datetime(2026, 5, 6, 13, 0, tzinfo=tz)) == datetime(
+        2026,
+        5,
+        6,
+        22,
+        0,
+        tzinfo=tz,
+    )
+
+
+def test_next_trigger_exactly_at_2200_moves_to_next_day() -> None:
+    tz = ZoneInfo("Asia/Shanghai")
+
+    assert next_trigger(tz, datetime(2026, 5, 6, 22, 0, tzinfo=tz)) == datetime(
+        2026,
+        5,
+        7,
+        22,
+        0,
+        tzinfo=tz,
+    )
+
+
+def test_next_trigger_after_2200_moves_to_next_day() -> None:
+    tz = ZoneInfo("Asia/Shanghai")
+
+    assert next_trigger(tz, datetime(2026, 5, 6, 23, 0, tzinfo=tz)) == datetime(
+        2026,
+        5,
+        7,
+        22,
+        0,
+        tzinfo=tz,
+    )

--- a/tests/unit/test_webhook_url_redacted.py
+++ b/tests/unit/test_webhook_url_redacted.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import httpx
+import pytest
+
+from pms.alerting.discord import DiscordWebhookClient
+
+
+@pytest.mark.asyncio
+async def test_webhook_url_redacted(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    marker = "secret-marker-12345"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("failed with raw marker should not leak", request=request)
+
+    client = DiscordWebhookClient(
+        f"https://discord.example/webhooks/app/token?token={marker}",
+        alert_dir=tmp_path,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        sleep=lambda _: None,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        assert await client.send("payload") is False
+
+    assert marker not in caplog.text
+    assert "webhooks/app/token" not in caplog.text
+    for dropped in tmp_path.glob("dropped-*.json"):
+        content = dropped.read_text()
+        assert marker not in content
+        assert "webhooks/app/token" not in content


### PR DESCRIPTION
## Summary
- add `pms.alerting` with `DiscordWebhookClient.send()` frozen v1 API, bounded retry/fallback files, redaction, shutdown alert fallback, halt-event models/subscriber, and EOD report scheduler
- publish real auto-halt events from `ActuatorExecutor` to `RuntimeEventBus`, then wire the alert subscriber into `pms-api` lifespan
- add `/health` liveness and `/readiness` runner-readiness endpoints plus `PMS_AUTO_START=1` fail-closed Discord webhook gate
- add Fly/Docker local supervision artifacts and deployment runbook without deploying or touching the active paper runner

## Testing Verification
- Red tests committed first in `5bdc7f2`: missing `DiscordSettings` / `pms.alerting` imports failed as expected.
- `uv run pytest -q` -> `1063 passed, 163 skipped`
- `PMS_RUN_INTEGRATION=1 uv run pytest -q -m integration` -> `20 passed, 144 skipped, 1062 deselected`
- `uv run mypy src/ tests/ --strict` -> `Success: no issues found in 381 source files`
- `uv run ruff check .` -> `All checks passed!`
- `uv run lint-imports` -> `Contracts: 9 kept, 0 broken`
- `git diff --check` -> clean
- `dashboard: npm ci && npm run test:ci` -> `23 passed`, `60 passed`
- `docker build . -t pms-supervision-alerting:local` -> succeeded, image `sha256:a47e1ebee202a05fa5cf355281db6ce2b5de4780c624b015257a618cb74cdde4`
- `docker run --rm pms-supervision-alerting:local uv run --no-dev pms-api --help` -> help rendered successfully
- `docker run --rm -e PMS_AUTO_START=1 pms-supervision-alerting:local uv run --no-dev pms-api --config /app/config.live-soak.yaml` -> exited fail-closed with `Refusing PMS_AUTO_START=1 without PMS_DISCORD__WEBHOOK_URL...` and `exit=1`

## Notes
- No production runner restart performed.
- No Fly deploy or `fly launch` performed; the runbook leaves that as operator-driven bootstrap.
- Discord tests use `httpx.MockTransport`; no real webhook/network delivery was used.
- Spec source copied from `.harness/pms-supervision-alerting-v1/spec.md` in the planning checkout; approved round 2, task `pms-supervision-alerting-v1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Discord webhook integration for trading halt notifications
  * Introduced end-of-day daily report delivery via Discord
  * Added health and readiness check endpoints for monitoring system status

* **Infrastructure**
  * Added Docker containerization support
  * Configured Fly.io deployment with automated orchestration and health checks

* **Documentation**
  * Added deployment runbook for operational reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->