### PR TITLE
fix: replay buffered halt alerts after PR60

### DIFF
--- a/src/pms/alerting/subscriber.py
+++ b/src/pms/alerting/subscriber.py
@@ -27,7 +27,7 @@ async def run_alerting_subscription(
     *,
     stop_event: asyncio.Event | None = None,
 ) -> None:
-    replay, queue = await event_bus.subscribe()
+    replay, queue = await event_bus.subscribe(last_event_id=0)
     stop = stop_event or asyncio.Event()
     try:
         for event in replay:

--- a/tests/unit/test_alert_subscriber.py
+++ b/tests/unit/test_alert_subscriber.py
@@ -71,6 +71,31 @@ async def test_alert_subscriber_converts_halt_event_to_discord_message() -> None
 
 
 @pytest.mark.asyncio
+async def test_alert_subscriber_replays_buffered_halt_events() -> None:
+    bus = RuntimeEventBus()
+    client = RecordingDiscordClient()
+    stop = asyncio.Event()
+    await bus.publish(
+        "pms.halt.drawdown_circuit_breaker",
+        "Auto-halt drawdown_circuit_breaker: buffered halt",
+        created_at=datetime(2026, 5, 6, 8, 0, tzinfo=UTC),
+    )
+
+    task = asyncio.create_task(run_alerting_subscription(bus, client, stop_event=stop))
+    try:
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while not client.messages:
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError("subscriber did not replay buffered halt")
+            await asyncio.sleep(0.01)
+    finally:
+        stop.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert "buffered halt" in client.messages[0]
+
+
+@pytest.mark.asyncio
 async def test_alert_subscriber_survives_single_delivery_failure() -> None:
     bus = RuntimeEventBus()
     client = FailsFirstDiscordClient()


### PR DESCRIPTION
## Summary
- Follow-up to PR #60 after a final review thread landed during merge.
- Subscribe alerting with `last_event_id=0` so buffered halt events published before subscriber startup are replayed.
- Add a regression proving a pre-existing halt is delivered when the subscriber starts.

## Verification
- `uv run pytest -q` -> `1081 passed, 163 skipped`
- `uv run ruff check .` -> pass
- `uv run mypy src/ tests/ --strict` -> pass (`383 source files`)
- `git diff --check` -> pass

Review thread resolved: <https://github.com/stone16/prediction-market-system/pull/60#discussion_r3193055479>
