### PR TITLE
[codex] Harden paper soak signal reporting

### DIFF
--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -15,9 +15,18 @@ passphrases into chat, issues, PRs, logs, or config files.
    `uv run pms-api --config config.live-soak.yaml`.
    For process managers that cannot pass CLI args, set
    `PMS_CONFIG_PATH=config.live-soak.yaml`.
-4. Confirm `/status`, `/trades`, `/positions`, and evaluator metrics update.
-5. Review order notional, slippage, rejected orders, and portfolio exposure.
-6. Keep `live_trading_enabled=false` until the 30-day soak and compliance
+4. Confirm `/status` reports every active sensor as `running`, not `stale` or
+   `failed`. `MarketDataSensor` must have a fresh `last_signal_at`; a runner
+   process that is alive but has stale market-data signals is not a valid soak.
+5. Confirm `/strategies` shows the intended active strategy. Use
+   `paper_canary_v1` when the goal is to verify live-data -> controller ->
+   paper-actuator plumbing. Use the real default strategy only after its
+   required factors are populated; 0 decisions from missing factors is not a
+   market signal.
+6. Confirm `/trades`, `/positions`, and evaluator metrics update when the
+   selected strategy emits paper decisions.
+7. Review order notional, slippage, rejected orders, and portfolio exposure.
+8. Keep `live_trading_enabled=false` until the 30-day soak and compliance
    checklist are accepted.
 
 ## Auto-Halt Triggers
@@ -49,6 +58,8 @@ Reports are written under `docs/paper-reports/YYYY-MM-DD.md` by default. Use
 `--dry-run` to print the report in CI or during review. The report includes
 Gate 3 metrics: decisions, fills, slippage, daily and cumulative P&L, drawdown,
 exposure, Brier score, hit rate, average edge, Sharpe ratio, and risk events.
+The strategy row is read from `/strategies`; stale or failed sensors from
+`/status` are recorded as risk events.
 
 ## Credential Setup
 

--- a/scripts/paper_report.py
+++ b/scripts/paper_report.py
@@ -19,7 +19,7 @@ _API_TIMEOUT_S = 5.0
 @dataclass(frozen=True)
 class PaperReportMetrics:
     report_date: date
-    strategy: str = "ripple_v2"
+    strategy: str = "unknown"
     day_of_soak: int = 0
     decisions_made: int = 0
     decisions_accepted: int = 0
@@ -48,9 +48,11 @@ def metrics_from_api_payloads(
     status: dict[str, Any],
     trades: dict[str, Any],
     positions: dict[str, Any],
+    strategies: dict[str, Any] | None = None,
     risk_events: tuple[tuple[str, str, str], ...] = (),
 ) -> PaperReportMetrics:
     events = list(risk_events)
+    events.extend(_sensor_risk_events(status))
     started_at = _parse_datetime(status.get("runner_started_at"))
     if started_at is None:
         events.append(("report generation", "runner_started_at missing", "check /status"))
@@ -69,7 +71,7 @@ def metrics_from_api_payloads(
 
     return PaperReportMetrics(
         report_date=report_date,
-        strategy=str(status.get("strategy") or "ripple_v2"),
+        strategy=_strategy_label(status=status, strategies=strategies or {}),
         day_of_soak=day_of_soak,
         decisions_made=_int_from_dict(controller, "decisions_total"),
         decisions_rejected=_int_from_dict(controller, "diagnostics_total"),
@@ -120,11 +122,21 @@ def load_live_metrics(
         events.append(("report generation", "/positions unavailable", positions_error))
         positions = {}
 
+    strategies, strategies_error = _fetch_api_json(
+        api_base_url=api_base_url,
+        path="/strategies",
+        api_token=api_token,
+    )
+    if strategies_error is not None:
+        events.append(("report generation", "/strategies unavailable", strategies_error))
+        strategies = {}
+
     return metrics_from_api_payloads(
         report_date=report_date,
         status=status,
         trades=trades,
         positions=positions,
+        strategies=strategies,
         risk_events=tuple(events),
     )
 
@@ -266,6 +278,42 @@ def _fmt_ratio_percent(value: float | None) -> str:
     if value is None:
         return "N/A"
     return f"{value * 100.0:.1f}%"
+
+
+def _strategy_label(*, status: dict[str, Any], strategies: dict[str, Any]) -> str:
+    status_strategy = status.get("strategy")
+    if isinstance(status_strategy, str) and status_strategy:
+        return status_strategy
+
+    rows = _list_value(strategies, "strategies")
+    labels: list[str] = []
+    for row in rows:
+        strategy_id = row.get("strategy_id")
+        if not isinstance(strategy_id, str) or not strategy_id:
+            continue
+        active_version_id = row.get("active_version_id")
+        if isinstance(active_version_id, str) and active_version_id:
+            labels.append(f"{strategy_id}@{active_version_id}")
+        else:
+            labels.append(strategy_id)
+    return ", ".join(labels) if labels else "unknown"
+
+
+def _sensor_risk_events(status: dict[str, Any]) -> list[tuple[str, str, str]]:
+    events: list[tuple[str, str, str]] = []
+    for row in _list_value(status, "sensors"):
+        sensor_status = row.get("status")
+        if sensor_status not in {"failed", "stale"}:
+            continue
+        name = str(row.get("name") or "unknown")
+        last_signal_at = row.get("last_signal_at")
+        detail = (
+            f"last_signal_at={last_signal_at}"
+            if isinstance(last_signal_at, str) and last_signal_at
+            else "last_signal_at=none"
+        )
+        events.append(("sensor", f"{name} {sensor_status}", detail))
+    return events
 
 
 def _fetch_api_json(

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager, suppress
 from dataclasses import asdict, is_dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Literal, TypeVar, cast
@@ -883,8 +883,19 @@ def _request_metadata(request: Request) -> dict[str, object]:
     }
 
 
-def _sensor_statuses(runner: Runner) -> list[dict[str, Any]]:
+def _sensor_statuses(
+    runner: Runner,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    current_time = now or datetime.now(tz=UTC)
     last_signal_at = _last_signal_at(runner.state.signals)
+    last_signal_age_seconds = _signal_freshness_age_seconds(
+        runner.state.signals,
+        runner_started_at=runner.state.runner_started_at,
+        now=current_time,
+    )
+    stale_after_seconds = runner.config.dashboard.stale_snapshot_threshold_s
     if not runner.active_sensors:
         return [
             {
@@ -893,18 +904,28 @@ def _sensor_statuses(runner: Runner) -> list[dict[str, Any]]:
                 if runner.state.runner_started_at is None
                 else "idle",
                 "last_signal_at": last_signal_at,
+                "last_signal_age_seconds": last_signal_age_seconds,
+                "stale_after_seconds": stale_after_seconds,
+                "task_done": True,
             }
         ]
 
-    running = any(not task.done() for task in runner.sensor_stream.tasks)
-    status = "running" if running else "idle"
+    tasks = runner.sensor_stream.tasks
     return [
         {
             "name": sensor.__class__.__name__,
-            "status": status,
+            "status": _sensor_status(
+                sensor=sensor,
+                task=tasks[index] if index < len(tasks) else None,
+                last_signal_age_seconds=last_signal_age_seconds,
+                stale_after_seconds=stale_after_seconds,
+            ),
             "last_signal_at": last_signal_at,
+            "last_signal_age_seconds": last_signal_age_seconds,
+            "stale_after_seconds": stale_after_seconds,
+            "task_done": tasks[index].done() if index < len(tasks) else True,
         }
-        for sensor in runner.active_sensors
+        for index, sensor in enumerate(runner.active_sensors)
     ]
 
 
@@ -912,6 +933,52 @@ def _last_signal_at(signals: Sequence[MarketSignal]) -> str | None:
     if not signals:
         return None
     return signals[-1].fetched_at.isoformat()
+
+
+def _signal_freshness_age_seconds(
+    signals: Sequence[MarketSignal],
+    *,
+    runner_started_at: datetime | None,
+    now: datetime,
+) -> float | None:
+    if signals:
+        signal_time = signals[-1].fetched_at
+    elif runner_started_at is not None:
+        signal_time = runner_started_at
+    else:
+        return None
+    if signal_time.tzinfo is None:
+        signal_time = signal_time.replace(tzinfo=UTC)
+    return max(0.0, (now - signal_time).total_seconds())
+
+
+def _sensor_status(
+    *,
+    sensor: object,
+    task: asyncio.Task[None] | None,
+    last_signal_age_seconds: float | None,
+    stale_after_seconds: float,
+) -> str:
+    if task is None:
+        return "idle"
+    if task.cancelled():
+        return "idle"
+    if task.done():
+        return "failed" if task.exception() is not None else "idle"
+    if (
+        _sensor_depends_on_signal_freshness(sensor)
+        and last_signal_age_seconds is not None
+        and last_signal_age_seconds > stale_after_seconds
+    ):
+        return "stale"
+    return "running"
+
+
+def _sensor_depends_on_signal_freshness(sensor: object) -> bool:
+    name = sensor.__class__.__name__
+    return name.startswith("MarketDataSensor") or callable(
+        getattr(sensor, "update_subscription", None)
+    )
 
 
 def _start_alerting_if_configured(app_inst: FastAPI, runner: Runner) -> None:

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -96,6 +97,12 @@ def _signal() -> MarketSignal:
         fetched_at=datetime(2026, 4, 14, tzinfo=UTC),
         market_status="open",
     )
+
+
+async def _empty_signal_stream() -> AsyncIterator[MarketSignal]:
+    signals: tuple[MarketSignal, ...] = ()
+    for signal in signals:
+        yield signal
 
 
 def _decision() -> TradeDecision:
@@ -236,7 +243,8 @@ async def test_api_routes_expose_mock_runner_state() -> None:
 @pytest.mark.asyncio
 async def test_status_marks_running_sensor_stale_when_last_signal_is_old() -> None:
     class MarketDataSensorStub:
-        pass
+        def __aiter__(self) -> AsyncIterator[MarketSignal]:
+            return _empty_signal_stream()
 
     async def _pending() -> None:
         await asyncio.Event().wait()
@@ -277,7 +285,8 @@ async def test_status_marks_running_sensor_stale_when_last_signal_is_old() -> No
 @pytest.mark.asyncio
 async def test_status_marks_market_data_stale_when_no_signal_arrives_after_start() -> None:
     class MarketDataSensorStub:
-        pass
+        def __aiter__(self) -> AsyncIterator[MarketSignal]:
+            return _empty_signal_stream()
 
     async def _pending() -> None:
         await asyncio.Event().wait()

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -192,7 +193,14 @@ async def test_api_routes_expose_mock_runner_state() -> None:
 
     assert status["mode"] == "backtest"
     assert status["runner_started_at"] == "2026-04-14T00:00:00+00:00"
-    assert status["sensors"][0].keys() == {"name", "status", "last_signal_at"}
+    assert status["sensors"][0].keys() == {
+        "name",
+        "status",
+        "last_signal_at",
+        "last_signal_age_seconds",
+        "stale_after_seconds",
+        "task_done",
+    }
     assert status["controller"] == {"decisions_total": 1, "diagnostics_total": 0}
     assert status["actuator"] == {"fills_total": 1, "mode": "backtest"}
     assert status["evaluator"] == {"eval_records_total": 1, "brier_overall": 0.09}
@@ -223,6 +231,80 @@ async def test_api_routes_expose_mock_runner_state() -> None:
         }
     ]
     assert [item["feedback_id"] for item in feedback] == ["fb-pending"]
+
+
+@pytest.mark.asyncio
+async def test_status_marks_running_sensor_stale_when_last_signal_is_old() -> None:
+    class MarketDataSensorStub:
+        pass
+
+    async def _pending() -> None:
+        await asyncio.Event().wait()
+
+    runner = _runner_with_state()
+    runner.config.dashboard.stale_snapshot_threshold_s = 120.0
+    runner._active_sensors = (MarketDataSensorStub(),)  # noqa: SLF001
+    task = asyncio.create_task(_pending())
+    runner.sensor_stream._tasks = (task,)  # noqa: SLF001
+    app = create_app(runner)
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            status = (await client.get("/status")).json()
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        runner.sensor_stream._tasks = ()  # noqa: SLF001
+
+    assert status["running"] is True
+    assert status["sensors"] == [
+        {
+            "name": "MarketDataSensorStub",
+            "status": "stale",
+            "last_signal_at": "2026-04-14T00:00:00+00:00",
+            "last_signal_age_seconds": status["sensors"][0]["last_signal_age_seconds"],
+            "stale_after_seconds": 120.0,
+            "task_done": False,
+        }
+    ]
+    assert status["sensors"][0]["last_signal_age_seconds"] > 120.0
+
+
+@pytest.mark.asyncio
+async def test_status_marks_market_data_stale_when_no_signal_arrives_after_start() -> None:
+    class MarketDataSensorStub:
+        pass
+
+    async def _pending() -> None:
+        await asyncio.Event().wait()
+
+    runner = Runner(config=_settings(), eval_store=cast(EvalStore, InMemoryEvalStore([])))
+    runner.state.runner_started_at = datetime(2026, 4, 14, tzinfo=UTC)
+    runner.config.dashboard.stale_snapshot_threshold_s = 120.0
+    runner._active_sensors = (MarketDataSensorStub(),)  # noqa: SLF001
+    task = asyncio.create_task(_pending())
+    runner.sensor_stream._tasks = (task,)  # noqa: SLF001
+    app = create_app(runner)
+    transport = httpx.ASGITransport(app=app)
+
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            status = (await client.get("/status")).json()
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        runner.sensor_stream._tasks = ()  # noqa: SLF001
+
+    assert status["sensors"][0]["status"] == "stale"
+    assert status["sensors"][0]["last_signal_at"] is None
+    assert status["sensors"][0]["last_signal_age_seconds"] > 120.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_paper_report.py
+++ b/tests/unit/test_paper_report.py
@@ -58,6 +58,13 @@ def test_metrics_from_api_payloads_uses_live_runner_status() -> None:
         status={
             "mode": "paper",
             "runner_started_at": "2026-05-03T09:03:03.240858+00:00",
+            "sensors": [
+                {
+                    "name": "MarketDataSensor",
+                    "status": "stale",
+                    "last_signal_at": "2026-05-04T01:00:00+00:00",
+                }
+            ],
             "controller": {
                 "decisions_total": 17,
                 "diagnostics_total": 3,
@@ -81,8 +88,17 @@ def test_metrics_from_api_payloads_uses_live_runner_status() -> None:
                 {"locked_usdc": 2.0, "unrealized_pnl": -0.25},
             ],
         },
+        strategies={
+            "strategies": [
+                {
+                    "strategy_id": "default",
+                    "active_version_id": "default-v2",
+                }
+            ],
+        },
     )
 
+    assert metrics.strategy == "default@default-v2"
     assert metrics.day_of_soak == 2
     assert metrics.decisions_made == 17
     assert metrics.decisions_rejected == 3
@@ -91,6 +107,11 @@ def test_metrics_from_api_payloads_uses_live_runner_status() -> None:
     assert metrics.total_exposure == 5.0
     assert metrics.cumulative_pnl == 1.0
     assert metrics.brier_score_7d == 0.18
+    assert (
+        "sensor",
+        "MarketDataSensor stale",
+        "last_signal_at=2026-05-04T01:00:00+00:00",
+    ) in metrics.risk_events
 
 
 def test_metrics_from_api_payloads_records_missing_status_as_risk_event() -> None:


### PR DESCRIPTION
## Summary

- Report per-sensor `/status` health with stale detection for MarketDataSensor, including the no-signal-after-start case.
- Make paper reports derive the active strategy from `/strategies` instead of defaulting to `ripple_v2`.
- Record stale or failed sensors as paper-report risk events and update the Polymarket runbook gate language.

## Root Cause

The previous soak could keep showing `running` while market data had stopped producing fresh signals, because `/status` collapsed sensor health to a shared task-level value and reused one global `last_signal_at`. The report also hardcoded `ripple_v2`, masking the actual active strategy.

## Validation

- `uv run pytest tests/unit/test_api_cp09.py tests/unit/test_paper_report.py tests/unit/test_sensor_historical.py -q`
- `uv run mypy src/pms/api/app.py scripts/paper_report.py`
- `uv run pytest -q` (`1106 passed, 163 skipped`)