### PR TITLE
docs: reconcile risk envelope contradiction between README and config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS — risk-enveloped files
+# Changes to these files require an approved review before merge
+# to prevent accidental drift of production risk parameters.
+
+# Live-soak risk parameters (auto-halt triggers, position limits)
+config.live-soak.yaml	@stone16

--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@ Three things remain between paper soak and real capital:
 1. **Polymarket credentials** — 6 fields (private_key, api_key, api_secret,
    api_passphrase, funder_address, signature_type). Set as env vars, never in
    config files.
-2. **Confirm risk envelope** — Proposed defaults: $100 bankroll, $5/market
-   max, $20 daily max loss. Adjust via `config.live-soak.yaml`.
+2. **Confirm risk envelope** — Ratified defaults from
+   `config.live-soak.yaml`: `max_position_per_market=$5`,
+   `max_total_exposure=$50`, `max_drawdown_pct=20%`,
+   `max_open_positions=5`, `min_order_usdc=$1`,
+   `slippage_threshold_bps=50`, `max_quantity_shares=500`.
+   TODO_DECISION: `$20 daily max loss` was mentioned here previously but
+   has no corresponding config key or enforcement. File a child issue to
+   add `risk.max_daily_loss_usdc` as a 7th auto-halt trigger, or drop
+   it entirely. See [MUL-8](mention://issue/850c30cc-2b18-41cc-8caa-533444b2c6fe).
 3. **24-hour paper soak** — Run with live Polymarket data to verify sensors,
    risk engine, order lifecycle, and auto-halt triggers before risking capital.
    See [Orchestration guide](#orchestration-guide) below.
@@ -108,7 +115,7 @@ uv run alembic upgrade head
 cp config.live-soak.yaml config.local.live-soak.yaml
 # Edit config.local.live-soak.yaml:
 #   - Adjust risk.max_position_per_market (proposed: $5)
-#   - Adjust risk.max_total_exposure (proposed: $100)
+#   - Adjust risk.max_total_exposure (proposed: $50)
 #   - Adjust risk.max_drawdown_pct (proposed: 20)
 
 # 5. Start paper soak (live data, no real orders)


### PR DESCRIPTION
## Summary

- **README.md** amended to match `config.live-soak.yaml` (the runtime source of truth). All 7 risk values now listed explicitly: `$5/market`, `$50 total exposure`, `20% drawdown`, `5 open positions`, `$1 min order`, `50bps slippage`, `500 shares`.
- **README.md** `max_total_exposure` comment corrected from `$100` → `$50`.
- **`.github/CODEOWNERS`** added to protect `config.live-soak.yaml` behind review.

## Decision

Ratified the config numbers since they are what actually load at startup. The `$20 daily max loss` mentioned in the original README was flagged as `TODO_DECISION` — it has no corresponding config key and enforces nothing. CTO decided: do not add a daily loss trigger in this issue; file a child issue later if needed after paper soak evidence.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm `config.live-soak.yaml` is now CODEOWNERS-protected
- [ ] Verify README risk envelope matches config line-by-line:
  - `config.live-soak.yaml:10` → `max_position_per_market: 5.0` ↔ README `$5/market` ✓
  - `config.live-soak.yaml:11` → `max_total_exposure: 50.0` ↔ README `$50 total exposure` ✓
  - `config.live-soak.yaml:12` → `max_drawdown_pct: 20.0` ↔ README `20% drawdown` ✓
  - `config.live-soak.yaml:13` → `max_open_positions: 5` ↔ README `5 open positions` ✓
  - `config.live-soak.yaml:14` → `min_order_usdc: 1.0` ↔ README `$1 min order` ✓
  - `config.live-soak.yaml:15` → `slippage_threshold_bps: 50.0` ↔ README `50bps slippage` ✓
  - `config.live-soak.yaml:16` → `max_quantity_shares: 500.0` ↔ README `500 shares` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)