### PR TITLE
[codex] Add local Polymarket secret file gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,14 @@ uv run python scripts/paper-report.py --date 2026-05-03
 After at least 24 hours of paper soak validating signal quality:
 
 ```bash
-# 1. Set Polymarket credentials (env vars only, never in config)
-export PMS_POLYMARKET_PRIVATE_KEY="<your private key>"
-export PMS_POLYMARKET_API_KEY="<your API key>"
-export PMS_POLYMARKET_API_SECRET="<your API secret>"
-export PMS_POLYMARKET_API_PASSPHRASE="<your API passphrase>"
-export PMS_POLYMARKET_FUNDER_ADDRESS="<your wallet address>"
-export PMS_POLYMARKET_SIGNATURE_TYPE="<your signature type>"
+# 1. Stage Polymarket credentials in a chmod 600 local secret file,
+#    never shell exports or .env:
+#    ~/.config/pms/polymarket.local-secrets.yaml
 
 # 2. Create config.live.yaml
 #    mode: live
+#    secret_source: local_file
+#    local_secret_file: ~/.config/pms/polymarket.local-secrets.yaml
 #    live_trading_enabled: true
 #    risk: (copy from your validated paper soak config)
 
@@ -143,8 +141,6 @@ export PMS_POLYMARKET_SIGNATURE_TYPE="<your signature type>"
 #    /secure/pms/first-order.json — reviewed and approved by operator
 
 # 4. Start live mode (stub-gated — not implemented until paper soak + compliance gates pass)
-export PMS_MODE=live
-export PMS_LIVE_TRADING_ENABLED=true
 uv run pms-api --config config.live.yaml
 ```
 

--- a/config.live-soak.yaml
+++ b/config.live-soak.yaml
@@ -1,5 +1,6 @@
 # Tight PAPER soak configuration for the first real-data risk-readiness run.
-# Keep all credentials in environment variables or a secret manager.
+# Keep PAPER soak credentials out of config; LIVE Polymarket credentials must
+# come from a chmod 600 local secret file with secret_source=local_file.
 
 mode: paper
 live_trading_enabled: false

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -45,15 +45,9 @@ polymarket:
   host: https://clob.polymarket.com
   websocket_url: wss://ws-subscriptions-clob.polymarket.com/ws/
   chain_id: 137
-  # Keep live credentials out of config.yaml and load them from the process
-  # environment instead:
-  #
-  #   PMS_POLYMARKET__PRIVATE_KEY=...
-  #   PMS_POLYMARKET__API_KEY=...
-  #   PMS_POLYMARKET__API_SECRET=...
-  #   PMS_POLYMARKET__API_PASSPHRASE=...
-  #   PMS_POLYMARKET__SIGNATURE_TYPE=1
-  #   PMS_POLYMARKET__FUNDER_ADDRESS=...
+  # Keep live credentials out of config.yaml. Temporary local LIVE uses
+  # secret_source: local_file plus local_secret_file pointing at a chmod 600
+  # YAML file outside the repo. See docs/operations/live-polymarket-runbook.md.
   #
   # The first real-money order also needs a non-secret approval JSON file:
   #   PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH=/secure/pms/first-order.json

--- a/docs/operations/fly-deploy-runbook.md
+++ b/docs/operations/fly-deploy-runbook.md
@@ -16,18 +16,31 @@ same change.
 
 ## Secrets
 
-Inject secrets through Fly, never through config files or chat:
+Inject Fly deployment secrets through Fly, never through config files, shell
+exports, `.env` files, chat, issues, or PRs.
+
+For non-sensitive values such as `PMS_API_TOKEN`, `fly secrets set` is fine:
 
 ```bash
 fly secrets set \
   PMS_API_TOKEN='...' \
-  PMS_DISCORD__WEBHOOK_URL='https://discord.com/api/webhooks/...' \
-  PMS_POLYMARKET__PRIVATE_KEY='...' \
-  PMS_POLYMARKET__API_KEY='...' \
-  PMS_POLYMARKET__API_SECRET='...' \
-  PMS_POLYMARKET__API_PASSPHRASE='...' \
-  PMS_POLYMARKET__SIGNATURE_TYPE='...' \
-  PMS_POLYMARKET__FUNDER_ADDRESS='...'
+  PMS_DISCORD__WEBHOOK_URL='https://discord.com/api/webhooks/...'
+```
+
+Local LIVE currently uses the temporary local secret-file path documented in
+`docs/operations/live-polymarket-runbook.md`. If LIVE later moves to Fly, set
+the non-secret `PMS_SECRET_SOURCE=fly` marker in the Fly app environment and
+use stdin so Polymarket values do not land in shell history. Run this command,
+paste the `NAME=VALUE` lines, then press Ctrl-D:
+
+```text
+fly secrets import
+PMS_POLYMARKET__PRIVATE_KEY=<paste private key>
+PMS_POLYMARKET__API_KEY=<paste API key>
+PMS_POLYMARKET__API_SECRET=<paste API secret>
+PMS_POLYMARKET__API_PASSPHRASE=<paste API passphrase>
+PMS_POLYMARKET__SIGNATURE_TYPE=1
+PMS_POLYMARKET__FUNDER_ADDRESS=<paste wallet address>
 ```
 
 ## Deploy

--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -58,25 +58,62 @@ Install the live SDK in the runtime environment:
 uv sync --extra live
 ```
 
-Export credentials in the operator shell or secret manager that launches PMS:
+The temporary approved local path is a file-mounted secret outside the repo.
+It is weaker than a real secret manager, but avoids shell history, dotfiles,
+and `.env` files while we keep LIVE local. Do not export Polymarket
+credentials in an operator shell, dotfile, `.env`, compose override, or normal
+config file.
+
+Create a private local secret file and edit it with an editor. The file must
+be readable only by the operator account:
 
 ```bash
-export PMS_MODE=live
-export PMS_LIVE_TRADING_ENABLED=true
-export PMS_LIVE_ACCOUNT_RECONCILIATION_REQUIRED=true
-export PMS_CONTROLLER__TIME_IN_FORCE=IOC
-export PMS_POLYMARKET__PRIVATE_KEY=...
-export PMS_POLYMARKET__API_KEY=...
-export PMS_POLYMARKET__API_SECRET=...
-export PMS_POLYMARKET__API_PASSPHRASE=...
-export PMS_POLYMARKET__SIGNATURE_TYPE=1
-export PMS_POLYMARKET__FUNDER_ADDRESS=...
-export PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH=/secure/pms/first-order.json
+install -d -m 700 ~/.config/pms
+install -m 600 /dev/null ~/.config/pms/polymarket.local-secrets.yaml
+$EDITOR ~/.config/pms/polymarket.local-secrets.yaml
+```
+
+Use this YAML shape in the secret file:
+
+```yaml
+polymarket:
+  private_key: <paste private key>
+  api_key: <paste API key>
+  api_secret: <paste API secret>
+  api_passphrase: <paste API passphrase>
+  signature_type: 1
+  funder_address: <paste wallet address>
+```
+
+PMS refuses local LIVE startup if the file is missing, not a regular file, or
+is group/world readable. Fix permissions with:
+
+```bash
+chmod 600 ~/.config/pms/polymarket.local-secrets.yaml
 ```
 
 Required fields are validated before LIVE mode starts:
 `private_key`, `api_key`, `api_secret`, `api_passphrase`, `signature_type`,
 and `funder_address`.
+
+Configure LIVE mode with non-secret runtime config, not with credential
+exports. For example, `config.live.yaml` should include:
+
+```yaml
+mode: live
+secret_source: local_file
+local_secret_file: ~/.config/pms/polymarket.local-secrets.yaml
+live_trading_enabled: true
+live_account_reconciliation_required: true
+controller:
+  time_in_force: IOC
+polymarket:
+  first_live_order_approval_path: /secure/pms/first-order.json
+```
+
+Before the first live run, rotate any Polymarket credential that was ever
+pasted into a shell, issue, PR, chat, local `.env`, or dotfile during
+development. Treat those values as compromised.
 
 ## First Live Order
 

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import stat
 from pathlib import Path
 from typing import Any, Literal, Self
 
@@ -15,6 +16,9 @@ from pms.core.models import LiveTradingDisabledError, VenueCredentials
 
 class MissingPolymarketCredentialsError(LiveTradingDisabledError):
     """Raised when LIVE mode lacks required Polymarket credentials."""
+
+
+SecretSource = Literal["fly", "local_file"]
 
 
 class PolymarketSettings(BaseModel):
@@ -166,6 +170,8 @@ class PMSSettings(BaseSettings):
     )
 
     mode: RunMode = RunMode.BACKTEST
+    secret_source: SecretSource | None = None
+    local_secret_file: str | None = None
     live_trading_enabled: bool = False
     agent_strategy_runtime_enabled: bool = False
     auto_migrate_default_v2: bool = True
@@ -190,21 +196,19 @@ class PMSSettings(BaseSettings):
 
     @classmethod
     def load(cls, config_path: str | Path | None = "config.yaml") -> Self:
-        if config_path is None:
-            return cls()
+        config_data: dict[str, Any] = {}
 
-        path = Path(config_path)
-        if not path.exists():
-            return cls()
+        if config_path is not None:
+            path = Path(config_path)
+            if path.exists():
+                loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+                if loaded is not None:
+                    if not isinstance(loaded, dict):
+                        msg = f"Expected mapping in config file {path}"
+                        raise ValueError(msg)
+                    config_data = loaded
 
-        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
-        if loaded is None:
-            return cls()
-        if not isinstance(loaded, dict):
-            msg = f"Expected mapping in config file {path}"
-            raise ValueError(msg)
-
-        config_data: dict[str, Any] = loaded
+        config_data = _merge_local_secret_file(config_data)
         return cls(**config_data)
 
 
@@ -226,6 +230,23 @@ def validate_live_mode_ready(settings: PMSSettings) -> VenueCredentials:
         fields = ", ".join(missing)
         msg = f"Missing Polymarket credential fields: {fields}"
         raise MissingPolymarketCredentialsError(msg)
+    if settings.mode == RunMode.LIVE and settings.secret_source not in {"fly", "local_file"}:
+        msg = (
+            "LIVE mode requires Polymarket credentials to come from an approved "
+            "secret source. Set PMS_SECRET_SOURCE=local_file for temporary "
+            "local live trading, or PMS_SECRET_SOURCE=fly for Fly deployment."
+        )
+        raise LiveTradingDisabledError(msg)
+    if settings.mode == RunMode.LIVE and settings.secret_source == "local_file":
+        if settings.local_secret_file is None or settings.local_secret_file.strip() == "":
+            msg = "LIVE local_file secret source requires PMS_LOCAL_SECRET_FILE."
+            raise LiveTradingDisabledError(msg)
+        try:
+            _require_private_local_secret_file(
+                Path(settings.local_secret_file).expanduser()
+            )
+        except ValueError as exc:
+            raise LiveTradingDisabledError(str(exc)) from exc
     if settings.controller.time_in_force.upper() == "GTC":
         msg = (
             "LIVE GTC disabled until an open-order ledger reserves "
@@ -256,3 +277,89 @@ def _missing_polymarket_fields(credentials: VenueCredentials) -> list[str]:
     if credentials.signature_type is None:
         missing.append("signature_type")
     return missing
+
+
+def _merge_local_secret_file(config_data: dict[str, Any]) -> dict[str, Any]:
+    secret_source = _configured_string(
+        config_data,
+        field_name="secret_source",
+        env_name="PMS_SECRET_SOURCE",
+    )
+    if secret_source != "local_file":
+        return config_data
+
+    raw_path = _configured_string(
+        config_data,
+        field_name="local_secret_file",
+        env_name="PMS_LOCAL_SECRET_FILE",
+    )
+    if raw_path is None or raw_path.strip() == "":
+        return config_data
+
+    secret_path = Path(raw_path).expanduser()
+    local_secrets = _load_local_polymarket_secret_file(secret_path)
+    merged = dict(config_data)
+    existing_polymarket = merged.get("polymarket") or {}
+    if not isinstance(existing_polymarket, dict):
+        msg = "Expected polymarket config mapping before applying local secret file"
+        raise ValueError(msg)
+
+    merged["secret_source"] = "local_file"
+    merged["local_secret_file"] = str(secret_path)
+    merged["polymarket"] = {**existing_polymarket, **local_secrets}
+    return merged
+
+
+def _configured_string(
+    config_data: dict[str, Any],
+    *,
+    field_name: str,
+    env_name: str,
+) -> str | None:
+    raw_value = config_data.get(field_name)
+    if isinstance(raw_value, str):
+        return raw_value
+    env_value = os.environ.get(env_name)
+    if env_value is None:
+        return None
+    return env_value
+
+
+def _load_local_polymarket_secret_file(path: Path) -> dict[str, object]:
+    _require_private_local_secret_file(path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        msg = f"Expected mapping in local secret file {path}"
+        raise ValueError(msg)
+
+    raw_polymarket = loaded.get("polymarket")
+    if not isinstance(raw_polymarket, dict):
+        msg = f"Expected polymarket mapping in local secret file {path}"
+        raise ValueError(msg)
+
+    allowed_fields = {
+        "private_key",
+        "api_key",
+        "api_secret",
+        "api_passphrase",
+        "signature_type",
+        "funder_address",
+    }
+    return {
+        field_name: value
+        for field_name, value in raw_polymarket.items()
+        if field_name in allowed_fields
+    }
+
+
+def _require_private_local_secret_file(path: Path) -> None:
+    if not path.exists():
+        msg = f"Local secret file does not exist: {path}"
+        raise ValueError(msg)
+    if not path.is_file():
+        msg = f"Local secret path is not a file: {path}"
+        raise ValueError(msg)
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & 0o077:
+        msg = f"Local secret file {path} is too permissive; run `chmod 600 {path}`."
+        raise ValueError(msg)

--- a/tests/integration/test_market_selector_user_subscriptions.py
+++ b/tests/integration/test_market_selector_user_subscriptions.py
@@ -149,6 +149,7 @@ class _MatchingVenueReconciler:
 def _settings() -> PMSSettings:
     return PMSSettings(
         mode=RunMode.LIVE,
+        secret_source="fly",
         live_trading_enabled=True,
         auto_migrate_default_v2=False,
         controller=ControllerSettings(time_in_force="IOC"),

--- a/tests/integration/test_polymarket_live_execution.py
+++ b/tests/integration/test_polymarket_live_execution.py
@@ -151,6 +151,7 @@ async def test_live_polymarket_order_uses_runner_order_and_fill_persistence_path
 def _live_settings() -> PMSSettings:
     return PMSSettings(
         mode=RunMode.LIVE,
+        secret_source="fly",
         live_trading_enabled=True,
         auto_migrate_default_v2=False,
         controller=ControllerSettings(time_in_force="IOC"),

--- a/tests/unit/test_core_foundation.py
+++ b/tests/unit/test_core_foundation.py
@@ -187,6 +187,7 @@ def test_live_mode_validation_requires_all_polymarket_credentials() -> None:
 def test_live_mode_validation_returns_redacted_credentials() -> None:
     settings = PMSSettings(
         mode=RunMode.LIVE,
+        secret_source="fly",
         live_trading_enabled=True,
         controller=ControllerSettings(time_in_force="IOC"),
         polymarket=PolymarketSettings(
@@ -206,6 +207,73 @@ def test_live_mode_validation_returns_redacted_credentials() -> None:
     assert credentials.host == "https://clob.polymarket.com"
     assert credentials.private_key == "private-key"
     assert "private-key" not in repr(credentials)
+
+
+def test_live_mode_loads_local_secret_file_before_env_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret_path = tmp_path / "polymarket.local-secrets.yaml"
+    secret_path.write_text(
+        "\n".join(
+            [
+                "polymarket:",
+                "  private_key: file-private-key",
+                "  api_key: file-api-key",
+                "  api_secret: file-api-secret",
+                "  api_passphrase: file-passphrase",
+                "  signature_type: 1",
+                "  funder_address: '0xfile'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    secret_path.chmod(0o600)
+    config_path = tmp_path / "config.live.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "mode: live",
+                "secret_source: local_file",
+                f"local_secret_file: {secret_path}",
+                "live_trading_enabled: true",
+                "controller:",
+                "  time_in_force: IOC",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PMS_POLYMARKET__PRIVATE_KEY", "shell-private-key")
+
+    settings = PMSSettings.load(config_path)
+    credentials = validate_live_mode_ready(settings)
+
+    assert settings.secret_source == "local_file"
+    assert settings.local_secret_file == str(secret_path)
+    assert credentials.private_key == "file-private-key"
+    assert credentials.api_key == "file-api-key"
+    assert credentials.funder_address == "0xfile"
+
+
+def test_local_secret_file_must_not_be_group_or_world_readable(tmp_path: Path) -> None:
+    secret_path = tmp_path / "polymarket.local-secrets.yaml"
+    secret_path.write_text("polymarket: {}\n", encoding="utf-8")
+    secret_path.chmod(0o644)
+    config_path = tmp_path / "config.live.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "mode: live",
+                "secret_source: local_file",
+                f"local_secret_file: {secret_path}",
+                "live_trading_enabled: true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="chmod 600"):
+        PMSSettings.load(config_path)
 
 
 def test_core_enums_use_stable_wire_values() -> None:
@@ -251,9 +319,11 @@ def test_core_protocol_interfaces_are_declared() -> None:
 
 def test_config_defaults_and_env_loading(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PMS_MODE", raising=False)
+    monkeypatch.delenv("PMS_SECRET_SOURCE", raising=False)
     default_settings = PMSSettings()
 
     assert default_settings.mode is RunMode.BACKTEST
+    assert default_settings.secret_source is None
     assert default_settings.live_trading_enabled is False
     assert default_settings.risk.max_position_per_market == 100.0
     assert set(RiskSettings.model_fields) == {
@@ -267,9 +337,11 @@ def test_config_defaults_and_env_loading(monkeypatch: pytest.MonkeyPatch) -> Non
     }
 
     monkeypatch.setenv("PMS_MODE", "paper")
+    monkeypatch.setenv("PMS_SECRET_SOURCE", "fly")
     env_settings = PMSSettings()
 
     assert env_settings.mode is RunMode.PAPER
+    assert env_settings.secret_source == "fly"
 
 
 def test_database_dsn_honours_database_url_override(

--- a/tests/unit/test_docs_honesty_cp05.py
+++ b/tests/unit/test_docs_honesty_cp05.py
@@ -37,8 +37,10 @@ def test_live_runbook_first_order_example_includes_outcome_and_reconciliation_ga
     )
 
     assert '"outcome": "NO"' in runbook_text
-    assert "PMS_LIVE_ACCOUNT_RECONCILIATION_REQUIRED=true" in runbook_text
-    assert "PMS_CONTROLLER__TIME_IN_FORCE=IOC" in runbook_text
+    assert "live_account_reconciliation_required: true" in runbook_text
+    assert "time_in_force: IOC" in runbook_text
+    assert "secret_source: local_file" in runbook_text
+    assert "chmod 600" in runbook_text
 
 
 def test_live_and_kalshi_mentions_are_stubbed_not_capability_claims() -> None:

--- a/tests/unit/test_live_safety_followups.py
+++ b/tests/unit/test_live_safety_followups.py
@@ -176,6 +176,7 @@ def _portfolio() -> Portfolio:
 def _live_settings(**overrides: object) -> PMSSettings:
     values: dict[str, Any] = {
         "mode": RunMode.LIVE,
+        "secret_source": "fly",
         "live_trading_enabled": True,
         "auto_migrate_default_v2": False,
         "controller": ControllerSettings(time_in_force="IOC", min_volume=0.0),

--- a/tests/unit/test_live_trading_blockers.py
+++ b/tests/unit/test_live_trading_blockers.py
@@ -250,10 +250,11 @@ def test_posterior_branch_missing_all_inputs_does_not_emit_statistical_probabili
     assert "statistical" not in branch_probabilities
 
 
-def _live_settings(*, tif: str = "IOC") -> PMSSettings:
+def _live_settings(*, tif: str = "IOC", secret_source: str | None = "fly") -> PMSSettings:
     return PMSSettings(
         mode=RunMode.LIVE,
         live_trading_enabled=True,
+        secret_source=secret_source,
         auto_migrate_default_v2=False,
         controller=ControllerSettings(time_in_force=tif, min_volume=0.0),
         risk=RiskSettings(
@@ -306,6 +307,11 @@ def _decision(
 def test_live_mode_rejects_gtc_until_open_order_ledger_exists() -> None:
     with pytest.raises(LiveTradingDisabledError, match="LIVE GTC disabled"):
         validate_live_mode_ready(_live_settings(tif="GTC"))
+
+
+def test_live_mode_requires_approved_secret_source_marker() -> None:
+    with pytest.raises(LiveTradingDisabledError, match="PMS_SECRET_SOURCE=local_file"):
+        validate_live_mode_ready(_live_settings(secret_source=None))
 
 
 def test_trade_decision_rejects_action_side_mismatch() -> None:

--- a/tests/unit/test_runner_active_perception.py
+++ b/tests/unit/test_runner_active_perception.py
@@ -179,6 +179,7 @@ class MatchingVenueReconciler:
 def _settings(mode: RunMode) -> PMSSettings:
     return PMSSettings(
         mode=mode,
+        secret_source="fly" if mode == RunMode.LIVE else None,
         live_trading_enabled=mode == RunMode.LIVE,
         auto_migrate_default_v2=False,
         database=DatabaseSettings(
@@ -633,6 +634,7 @@ async def test_reselection_caps_subscription_asset_ids(
     runner = Runner(
         config=PMSSettings(
             mode=RunMode.LIVE,
+            secret_source="fly",
             live_trading_enabled=True,
             auto_migrate_default_v2=False,
             database=DatabaseSettings(
@@ -738,6 +740,7 @@ async def test_refresh_subscription_caps_asset_ids() -> None:
     runner = Runner(
         config=PMSSettings(
             mode=RunMode.LIVE,
+            secret_source="fly",
             live_trading_enabled=True,
             auto_migrate_default_v2=False,
             database=DatabaseSettings(

--- a/tests/unit/test_runner_cp01.py
+++ b/tests/unit/test_runner_cp01.py
@@ -161,6 +161,7 @@ class FakeRegistry:
 def _settings() -> PMSSettings:
     return PMSSettings(
         mode=RunMode.LIVE,
+        secret_source="fly",
         live_trading_enabled=True,
         auto_migrate_default_v2=False,
         database=DatabaseSettings(
@@ -182,6 +183,7 @@ def test_runner_builds_live_polymarket_adapter_with_sdk_client_and_file_gate(
 ) -> None:
     settings = PMSSettings(
         mode=RunMode.LIVE,
+        secret_source="fly",
         live_trading_enabled=True,
         auto_migrate_default_v2=False,
         polymarket=PolymarketSettings(

--- a/tests/unit/test_strategy_change_reselection.py
+++ b/tests/unit/test_strategy_change_reselection.py
@@ -263,6 +263,7 @@ def _signal() -> MarketSignal:
 def _settings(mode: RunMode) -> PMSSettings:
     return PMSSettings(
         mode=mode,
+        secret_source="fly" if mode == RunMode.LIVE else None,
         live_trading_enabled=mode == RunMode.LIVE,
         auto_migrate_default_v2=False,
         database=DatabaseSettings(
@@ -588,6 +589,7 @@ async def test_runner_constructs_single_strategy_registry_with_callback_for_boot
 
     settings = PMSSettings(
         mode=RunMode.LIVE,
+        secret_source="fly",
         live_trading_enabled=True,
         auto_migrate_default_v2=True,
         database=DatabaseSettings(

--- a/tests/unit/test_strategy_lifecycle_cp08.py
+++ b/tests/unit/test_strategy_lifecycle_cp08.py
@@ -227,6 +227,7 @@ class FakeControllerFactory:
 def _settings() -> PMSSettings:
     return PMSSettings(
         mode=RunMode.LIVE,
+        secret_source="fly",
         live_trading_enabled=True,
         auto_migrate_default_v2=False,
         database=DatabaseSettings(


### PR DESCRIPTION
## Summary
- Adds a temporary approved `local_file` secret source for local LIVE Polymarket trading.
- Loads the six Polymarket credential fields from a chmod 600 YAML file outside the repo before environment credentials can override them.
- Updates live runbooks/config docs away from shell exports and adds tests for the local secret-file guard.

## Why
Local LIVE trading is the current target, and Fly secrets are not desired yet. Raw shell exports are still unsafe for real-money Polymarket keys, so this PR uses a private local secret file as an explicit temporary risk-waived path.

## Validation
- `uv run pytest -q` -> 1107 passed, 163 skipped
- `uv run mypy src` -> success, no issues in 166 source files
