### PR TITLE
feat(STO-10): operator workflow + first-order audit trail

### DIFF
--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -148,6 +148,128 @@ Keep the first-order notional at the minimum production risk cap. The approval
 file is not a credential, but it should still live outside the repo so stale
 approvals are not committed or reused accidentally.
 
+## Operator Workflow (STO-10)
+
+The first-order gate is fail-closed by code (see
+`src/pms/actuator/adapters/polymarket.py:584-660`), but the gate only does its
+job when the human side is named, reachable, and accountable. This section
+defines that human side.
+
+### Named operators
+
+- **Primary operator**: `TODO_DECISION` — fill in the named human responsible
+  for first-order approvals. Until this is filled in, the gate must remain
+  denied for every first-order signal.
+- **Backup operator**: `TODO_DECISION` — fill in the named human who covers
+  when the primary is unavailable.
+- **Reachability rule**: at least one named operator must be reachable for
+  every first-order event during normal market hours. First-order signals
+  outside named operator hours **stall the strategy by design** — there is no
+  on-call escalation path for first-order events until the user explicitly
+  funds one.
+
+Whoever is on Slack at the time is **not** the operator. An anonymous gate is
+no gate.
+
+### Approval-file location
+
+- **Canonical environment variable**:
+  `PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH`
+  (consumed at `src/pms/runner.py:2098-2104` →
+  `_first_live_order_gate`). An empty value resolves to
+  `DenyFirstLiveOrderGate` and **locks** the gate; do not set the env var to
+  empty as a "disable" — the gate is already disabled if the env var is
+  unset.
+- **Path**: `TODO_DECISION` — choose one of:
+  - encrypted directory on the runner host (e.g. `/secure/pms/first-order.json`
+    on a LUKS-backed mount or tmpfs);
+  - Fly secret mount if the runner is deployed on Fly (see `fly.toml`);
+  - operator's local machine over an SSH-tunnel-mounted dir.
+- **Permissions**: write the file with `umask 077`. The runner process UID
+  must be the only reader. The file must never be committed to the repo.
+- **Sidecar metadata**: alongside the approval JSON, the operator's tool
+  writes a `<approval-path>.meta.json` containing `{ "approver_id": "<id>",
+  "ts": "<ISO 8601>" }`. The audit writer reads this on the next event and
+  records the approver. Format remains stable across runs.
+
+### "First" order semantics
+
+"First" means **first since the actuator was instantiated** (see the in-
+memory state at `src/pms/actuator/adapters/polymarket.py:571-576`). A process
+restart resets the gate to denied — the next decision will re-prompt the
+operator. **This re-prompt on restart is intentional**, not a bug: any
+disruption that warrants a restart also warrants re-validating the operating
+environment before the next live submit.
+
+Concretely, an approval is consumed exactly once per actuator lifetime:
+
+1. Operator drops the approval JSON at the configured path.
+2. Adapter matches the next decision against the file and submits.
+3. Adapter calls `consume()`, which unlinks the file
+   (`polymarket.py:324-330`).
+4. `_approval_state.approved = True` flips the fast path open
+   (`polymarket.py:599-604`); subsequent orders skip the slow path.
+5. On any process restart, step 1 must repeat with a freshly-filed
+   approval.
+
+### Audit trail
+
+Every gate consultation appends one record to the JSONL at
+`live_emergency_audit_path` (default `.data/live-emergency-audit.jsonl`,
+configurable via `PMS_LIVE_EMERGENCY_AUDIT_PATH`).
+
+Three event types, written by `JsonlFirstOrderAuditWriter`
+(`src/pms/storage/first_order_audit.py`):
+
+| `event`              | When                                                  |
+|----------------------|-------------------------------------------------------|
+| `approval_matched`   | Gate returned True; submit is about to proceed.       |
+| `approval_denied`    | Gate returned False; `OperatorApprovalRequiredError`. |
+| `approval_consumed`  | Submit succeeded and `consume()` ran (file unlinked). |
+
+A record carries: `ts`, `event`, `approver_id` (from sidecar, may be `null`),
+`venue`, `market_id`, `token_id`, `side`, `outcome`, `max_notional_usdc`,
+`limit_price`, `max_slippage_bps`, `market_slug`, `question`. The audit
+writer is non-blocking — a write failure logs WARN and the order proceeds,
+mirroring `runner.py:1307-1308`.
+
+> **TODO_DECISION (audit sink)**: This runbook reuses `live_emergency_audit_path` as
+> the single consolidated authorization log. Filter records by the `event`
+> field (first-order) vs the `phase` field (emergency-halt) when reading.
+> Switch to a dedicated `first_order_audit_path` if you prefer separate
+> sinks; this is recorded as a deferred decision in STO-10.
+
+### Alerting and SLA
+
+- **Alert channel**: `TODO_DECISION` — choose one of: Slack webhook fed by a
+  log shipper that watches for `OperatorApprovalRequiredError`; PagerDuty;
+  email digest; or no alerting (operator polls runner status). Until this is
+  set, the operator must actively check `/status` before any first-order
+  signal is expected.
+- **Max acceptable elapsed time** from `OperatorApprovalRequiredError` to
+  `approval_consumed`: `TODO_DECISION` minutes. Exceeding this in cp-03
+  rehearsal is a signal to streamline the procedure before live.
+
+### End-to-end procedure (operator playbook)
+
+When `OperatorApprovalRequiredError` is observed (in logs or via alert):
+
+1. Pull the preview details from the error message (venue, market, token,
+   side, outcome, max_notional_usdc, limit_price, max_slippage_bps).
+2. Validate the preview against current strategy intent and risk caps.
+3. If approved, run the operator tool to write both the approval JSON
+   (matching every field) and the `<path>.meta.json` sidecar with your
+   `approver_id`.
+4. Wait for the next decision; the gate consults the file, matches, submits.
+5. Confirm `approval_consumed` lands in the audit JSONL.
+6. The fast path is now open for the rest of the actuator's lifetime; if
+   the runner restarts, repeat from step 1 on the next decision.
+
+If at any step you decide **not** to approve, do nothing. The next decision
+will trigger another `OperatorApprovalRequiredError`; the audit log will
+record `approval_denied`. The strategy stalls — that is the gate working as
+intended.
+
 ## Rollback
 
 1. Stop the runner: `curl -X POST http://127.0.0.1:8000/run/stop`.

--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -378,19 +378,29 @@ configurable via `PMS_LIVE_EMERGENCY_AUDIT_PATH`). The audit writer is
 the same `JsonlFirstOrderAuditWriter` wired in
 `src/pms/storage/first_order_audit.py`.
 
-Three event types:
+Four event types:
 
-| `event`              | When                                                  |
-|----------------------|-------------------------------------------------------|
-| `approval_matched`   | Gate returned True; submit is about to proceed.       |
-| `approval_denied`    | Gate returned False; `OperatorApprovalRequiredError`. |
-| `approval_consumed`  | Submit succeeded and `consume()` ran (file unlinked). |
+| `event`                    | When                                                  |
+|----------------------------|-------------------------------------------------------|
+| `approval_matched`         | Gate returned True; submit is about to proceed.       |
+| `approval_denied`          | Gate returned False; `OperatorApprovalRequiredError`. |
+| `approval_consumed`        | Submit succeeded and `consume()` ran cleanly (both approval JSON and sidecar unlinked). |
+| `approval_consume_failed`  | Submit succeeded but `consume()` raised; the approval artefacts may still be on disk. |
 
 A record carries: `ts`, `event`, `approver_id` (from sidecar, may be
 `null`), `venue`, `market_id`, `token_id`, `side`, `outcome`,
 `max_notional_usdc`, `limit_price`, `max_slippage_bps`, `market_slug`,
 `question`. The audit writer is non-blocking — a write failure logs
 WARN and the order proceeds, mirroring `runner.py:1307-1308`.
+
+`approval_consume_failed` is the operator's signal to clean up
+manually: the venue submit succeeded, but the approval JSON and/or
+its sidecar are still on disk, so a process restart could replay the
+approval against the next decision. Page on this event with the same
+priority as a runner halt: stop the runner if it has not stopped on
+its own, unlink any remaining files at the configured approval path,
+and confirm the audit JSONL has no further `approval_matched` records
+for the same `market_id` before resuming.
 
 The runbook reuses `live_emergency_audit_path` as the single
 consolidated authorization log; filter records by the `event` field

--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -175,73 +175,50 @@ Done outside this repo.
       private key is held in a hardware wallet or 1Password vault, not
       in plaintext on a laptop.
 
-### 1. Stage credentials in Fly secrets [setup]
+### 1. Stage credentials in the local secret file [setup]
 
-The production target is the Fly app `pms-paper-soak` (`fly.toml:1`).
-All secrets stay on Fly's encrypted secret store, never in the repo,
-never in shell history. From a shell with `flyctl` authenticated:
+LIVE mode currently runs locally on the operator's machine — see the
+"Credential Setup" section above for the canonical `secret_source:
+local_file` workflow that PMS validates at startup
+(`src/pms/config.py:233`+: `secret_source` must be `"fly"` or
+`"local_file"`; `local_file` requires `local_secret_file` to point
+at a 0o600 regular file outside the repo). Walk that section first,
+then return here to set up the operator-side artifacts.
 
-```bash
-fly secrets set \
-  PMS_POLYMARKET__PRIVATE_KEY='0x...' \
-  PMS_POLYMARKET__API_KEY='...' \
-  PMS_POLYMARKET__API_SECRET='...' \
-  PMS_POLYMARKET__API_PASSPHRASE='...' \
-  PMS_POLYMARKET__SIGNATURE_TYPE='1' \
-  PMS_POLYMARKET__FUNDER_ADDRESS='0x...' \
-  --app pms-paper-soak
-```
+In short: install the credentials YAML at
+`~/.config/pms/polymarket.local-secrets.yaml` with `chmod 600`, and
+point `local_secret_file` in `config.live.yaml` at it. Do not export
+`PMS_POLYMARKET__*` in shell history or `.env`. The `secret_source:
+fly` branch exists for a future Fly deployment but is not the current
+target.
 
-Confirm without revealing values:
+### 2. Set up the approval-file path [setup]
 
-```bash
-fly secrets list --app pms-paper-soak
-```
-
-For local development (NOT production): export the same variables in
-the shell that launches `uv run pms-api` (or use `direnv` with a
-`.envrc.local` that is gitignored). Never commit a `.env` containing
-these.
-
-> Required-fields validation runs at LIVE-mode startup
-> (`src/pms/config.py` →
-> `validate_live_mode_ready`). A missing field fails closed before any
-> venue call.
-
-### 2. Provision a Fly volume for the approval-file path [setup]
-
-The approval JSON must persist across deploys but live outside the
-container image. On Fly that means a mounted volume.
+The first-live-order approval JSON lives on the operator's machine
+alongside (but separate from) the credentials. The canonical config
+example in the "Credential Setup" section uses
+`/secure/pms/first-order.json`; make sure that path exists and is
+writable only by the operator UID before flipping the gate on.
 
 ```bash
-fly volumes create pms_data --region iad --size 1 --app pms-paper-soak
+sudo install -d -m 700 -o "$USER" /secure/pms
 ```
 
-Then add this block to `fly.toml` (anywhere after the `[env]` block):
+Set the path on `config.live.yaml`:
 
-```toml
-[[mounts]]
-  source = "pms_data"
-  destination = "/data"
-```
-
-Set the canonical path as a Fly secret (it is not strictly secret, but
-keeping it next to the credentials makes rotation simpler):
-
-```bash
-fly secrets set \
-  PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH=/data/pms/first-order.json \
-  --app pms-paper-soak
+```yaml
+polymarket:
+  first_live_order_approval_path: /secure/pms/first-order.json
 ```
 
 Empty value pitfall: `_first_live_order_gate`
 (`src/pms/runner.py:2098-2104`) treats an empty string as
 `DenyFirstLiveOrderGate` — the gate **locks shut**, it does not
-"disable." Do not set the env to empty as a workaround.
+"disable." Do not set the field to empty as a workaround.
 
-For local development the path is freeform. Recommended:
-`~/.local/share/pms/first-order.json`. Create the parent dir with
-`umask 077` so only your user account can read it.
+For dev work without `sudo`, a freeform path under your home is
+fine. Recommended: `~/.local/share/pms/first-order.json`. Create the
+parent dir with `umask 077` so only your user account can read it.
 
 ### 3. Name the primary and backup operators [fill-in]
 
@@ -267,8 +244,9 @@ anonymous gate is no gate.
 `OperatorApprovalRequiredError` and post to a Slack webhook. Lightweight,
 no extra paid service, sufficient at \$100 bankroll.
 
-Suggested log shipper rule (Fly Log Shipper, Vector, or
-`fly logs --app pms-paper-soak` piped through grep):
+Suggested log shipper rule (Vector, or `journalctl -fu pms-api | grep
+OperatorApprovalRequiredError` piped through `curl` while LIVE runs
+locally; switch to Fly Log Shipper if/when LIVE moves to Fly):
 
 - Match: log line contains `OperatorApprovalRequiredError`.
 - Action: POST to `SLACK_OPERATOR_WEBHOOK_URL` with the matched line.
@@ -293,25 +271,31 @@ ones.
 
 ### 6. Run the cp-03 rehearsal before going live [confirm]
 
-Before flipping `live_trading_enabled=true`, walk the procedure end to
-end against the paper-soak config with a fake client. Do this from a
-clean shell at the repo root:
+Before flipping `live_trading_enabled=true`, walk the procedure end
+to end. The `scripts/rehearse_first_order.py` driver does this in
+one command — drives the real `PolymarketActuator` slow path with a
+real `FileFirstLiveOrderGate` and a real `JsonlFirstOrderAuditWriter`
+backed by inline fakes for the venue client and quote provider. No
+network, no DB, no real money.
 
 ```bash
-# Terminal A — start the runner.
+uv run python scripts/rehearse_first_order.py --approver-id <your-handle>
+# ✓ PASS  events=['approval_denied', 'approval_matched', 'approval_consumed']
+#   audit log:    /tmp/pms-rehearsal-…/audit.jsonl
+```
+
+For a manual end-to-end against `config.live-soak.yaml` (PAPER mode,
+no submit), use the helper for the operator-side write:
+
+```bash
+# Terminal A — start the runner against the soak config.
 PMS_CONFIG_PATH=config.live-soak.yaml uv run pms-api
 
-# Terminal B — drop a matching approval JSON + sidecar.
-mkdir -p $(dirname $PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH)
-cat > $PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH <<'JSON'
-{ "approved": true, "max_notional_usdc": 5.0, "venue": "polymarket",
-  "market_id": "<from preview>", "token_id": "<from preview>",
-  "side": "BUY", "outcome": "YES",
-  "limit_price": 0.4, "max_slippage_bps": 50 }
-JSON
-cat > "${PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH}.meta.json" <<'JSON'
-{ "approver_id": "<your-handle>", "ts": "2026-05-07T00:00:00Z" }
-JSON
+# Terminal B — file the approval using the operator helper.
+uv run python scripts/approve_first_order.py \
+  --from-error '<paste the full OperatorApprovalRequiredError line>' \
+  --approver-id <your-handle> \
+  --path /secure/pms/first-order.json
 
 # Confirm the audit log records matched -> consumed.
 tail -n 5 .data/live-emergency-audit.jsonl
@@ -348,11 +332,16 @@ recorded.
 
 ### Approval-file location
 
-- **Production (Fly)**: `/data/pms/first-order.json` (provisioned in
-  step 2). Read only by the runner container's process UID.
+- **Local LIVE (current target)**: `/secure/pms/first-order.json`,
+  matching the canonical example in the "Credential Setup" section.
+  Read only by the operator UID; create the parent dir with
+  `install -d -m 700 -o "$USER" /secure/pms`.
 - **Local development**: a freeform path under the operator's home,
   for example `~/.local/share/pms/first-order.json`. Created with
   `umask 077`.
+- **Future Fly deployment**: a `[[mounts]]`-backed volume path such
+  as `/data/pms/first-order.json` so it persists across deploys. Not
+  the current target.
 - **Sidecar metadata**: alongside the approval JSON, the operator
   writes `<approval-path>.meta.json` containing
   `{ "approver_id": "<id>", "ts": "<ISO 8601>" }`. The audit writer
@@ -420,9 +409,12 @@ Slack alert from step 4):
 2. Validate the preview against current strategy intent and risk caps.
 3. If approved, write the approval JSON (matching every field) and
    the `<path>.meta.json` sidecar with your `approver_id` to the
-   configured path. On Fly: `fly ssh console --app pms-paper-soak`,
-   then write to `/data/pms/first-order.json` and the matching
-   sidecar.
+   configured path. The `scripts/approve_first_order.py` helper
+   handles both files in one command (see step 6 in the checklist
+   for usage); for local LIVE the path defaults to
+   `/secure/pms/first-order.json`. If LIVE later moves to Fly, the
+   same helper runs inside `fly ssh console` against the volume-
+   backed path.
 4. Wait for the next decision; the gate consults the file, matches,
    submits.
 5. Confirm `approval_consumed` lands in the audit JSONL.

--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -156,7 +156,7 @@ This is the human work that must happen before flipping
 file), or **[confirm]** (verify each launch).
 
 The first-order gate is fail-closed by code
-(`src/pms/actuator/adapters/polymarket.py:584-660`), but it only does its
+(`src/pms/actuator/adapters/polymarket.py:645-764`), but it only does its
 job when the human side is named, reachable, and accountable. Each item
 below makes one piece of the human side concrete.
 
@@ -212,7 +212,7 @@ polymarket:
 ```
 
 Empty value pitfall: `_first_live_order_gate`
-(`src/pms/runner.py:2098-2104`) treats an empty string as
+(`src/pms/runner.py:2110-2116`) treats an empty string as
 `DenyFirstLiveOrderGate` — the gate **locks shut**, it does not
 "disable." Do not set the field to empty as a workaround.
 
@@ -353,7 +353,7 @@ recorded.
 
 "First" means **first since the actuator was instantiated** (see the
 in-memory state at
-`src/pms/actuator/adapters/polymarket.py:571-576`). A process restart
+`src/pms/actuator/adapters/polymarket.py:632-637`). A process restart
 resets the gate to denied — the next decision will re-prompt the
 operator. **This re-prompt on restart is intentional**, not a bug: any
 disruption that warrants a restart also warrants re-validating the
@@ -364,9 +364,9 @@ Concretely, an approval is consumed exactly once per actuator lifetime:
 1. Operator drops the approval JSON at the configured path.
 2. Adapter matches the next decision against the file and submits.
 3. Adapter calls `consume()`, which unlinks the file
-   (`polymarket.py:324-330`).
+   (`polymarket.py:358-373`).
 4. `_approval_state.approved = True` flips the fast path open
-   (`polymarket.py:599-604`); subsequent orders skip the slow path.
+   (`polymarket.py:660-665`); subsequent orders skip the slow path.
 5. On any process restart, step 1 must repeat with a freshly-filed
    approval.
 
@@ -391,7 +391,7 @@ A record carries: `ts`, `event`, `approver_id` (from sidecar, may be
 `null`), `venue`, `market_id`, `token_id`, `side`, `outcome`,
 `max_notional_usdc`, `limit_price`, `max_slippage_bps`, `market_slug`,
 `question`. The audit writer is non-blocking — a write failure logs
-WARN and the order proceeds, mirroring `runner.py:1307-1308`.
+WARN and the order proceeds, mirroring `runner.py:1319-1320`.
 
 `approval_consume_failed` is the operator's signal to clean up
 manually: the venue submit succeeded, but the approval JSON and/or

--- a/docs/operations/live-polymarket-runbook.md
+++ b/docs/operations/live-polymarket-runbook.md
@@ -148,58 +148,227 @@ Keep the first-order notional at the minimum production risk cap. The approval
 file is not a credential, but it should still live outside the repo so stale
 approvals are not committed or reused accidentally.
 
-## Operator Workflow (STO-10)
+## Pre-launch Operator Checklist (STO-10)
 
-The first-order gate is fail-closed by code (see
-`src/pms/actuator/adapters/polymarket.py:584-660`), but the gate only does its
-job when the human side is named, reachable, and accountable. This section
-defines that human side.
+This is the human work that must happen before flipping
+`live_trading_enabled=true`. Walk top to bottom. Items are tagged
+**[setup]** (one-time), **[fill-in]** (replace `__FILL_IN__` in this
+file), or **[confirm]** (verify each launch).
+
+The first-order gate is fail-closed by code
+(`src/pms/actuator/adapters/polymarket.py:584-660`), but it only does its
+job when the human side is named, reachable, and accountable. Each item
+below makes one piece of the human side concrete.
+
+### 0. Prerequisites — Polymarket account [setup]
+
+Done outside this repo.
+
+- [ ] Polymarket account in good standing. The funder wallet
+      (`PMS_POLYMARKET__FUNDER_ADDRESS`) holds USDC.e on Polygon
+      (chain id 137). Minimum balance: at least the live-soak
+      `max_total_exposure` (\$50) plus a buffer for slippage and gas.
+- [ ] CLOB API credentials issued from the Polymarket dashboard:
+      `private_key`, `api_key`, `api_secret`, `api_passphrase`,
+      `signature_type` (use `1` for Polymarket-managed signing).
+- [ ] Two-factor enabled on the Polymarket account; the funder wallet
+      private key is held in a hardware wallet or 1Password vault, not
+      in plaintext on a laptop.
+
+### 1. Stage credentials in Fly secrets [setup]
+
+The production target is the Fly app `pms-paper-soak` (`fly.toml:1`).
+All secrets stay on Fly's encrypted secret store, never in the repo,
+never in shell history. From a shell with `flyctl` authenticated:
+
+```bash
+fly secrets set \
+  PMS_POLYMARKET__PRIVATE_KEY='0x...' \
+  PMS_POLYMARKET__API_KEY='...' \
+  PMS_POLYMARKET__API_SECRET='...' \
+  PMS_POLYMARKET__API_PASSPHRASE='...' \
+  PMS_POLYMARKET__SIGNATURE_TYPE='1' \
+  PMS_POLYMARKET__FUNDER_ADDRESS='0x...' \
+  --app pms-paper-soak
+```
+
+Confirm without revealing values:
+
+```bash
+fly secrets list --app pms-paper-soak
+```
+
+For local development (NOT production): export the same variables in
+the shell that launches `uv run pms-api` (or use `direnv` with a
+`.envrc.local` that is gitignored). Never commit a `.env` containing
+these.
+
+> Required-fields validation runs at LIVE-mode startup
+> (`src/pms/config.py` →
+> `validate_live_mode_ready`). A missing field fails closed before any
+> venue call.
+
+### 2. Provision a Fly volume for the approval-file path [setup]
+
+The approval JSON must persist across deploys but live outside the
+container image. On Fly that means a mounted volume.
+
+```bash
+fly volumes create pms_data --region iad --size 1 --app pms-paper-soak
+```
+
+Then add this block to `fly.toml` (anywhere after the `[env]` block):
+
+```toml
+[[mounts]]
+  source = "pms_data"
+  destination = "/data"
+```
+
+Set the canonical path as a Fly secret (it is not strictly secret, but
+keeping it next to the credentials makes rotation simpler):
+
+```bash
+fly secrets set \
+  PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH=/data/pms/first-order.json \
+  --app pms-paper-soak
+```
+
+Empty value pitfall: `_first_live_order_gate`
+(`src/pms/runner.py:2098-2104`) treats an empty string as
+`DenyFirstLiveOrderGate` — the gate **locks shut**, it does not
+"disable." Do not set the env to empty as a workaround.
+
+For local development the path is freeform. Recommended:
+`~/.local/share/pms/first-order.json`. Create the parent dir with
+`umask 077` so only your user account can read it.
+
+### 3. Name the primary and backup operators [fill-in]
+
+Edit the lines below. The gate has no concept of "operator" — naming
+is enforced socially, by this runbook, and audited via the sidecar
+metadata file.
+
+- **Primary operator**: `__FILL_IN__` — handle (e.g. GitHub username),
+  contact (Slack DM, phone), and time-zone window of availability.
+- **Backup operator**: `__FILL_IN__` — same fields. Covers when the
+  primary is unreachable.
+- **Reachability rule**: at least one named operator must be reachable
+  for every first-order event during the configured operator window.
+  First-order signals outside that window stall the strategy by design;
+  there is no on-call escalation path until you explicitly fund one.
+
+Whoever happens to be on Slack at the time is **not** the operator. An
+anonymous gate is no gate.
+
+### 4. Configure operator alerting [setup, recommended default]
+
+**Recommended default**: tail the runner log for the literal string
+`OperatorApprovalRequiredError` and post to a Slack webhook. Lightweight,
+no extra paid service, sufficient at \$100 bankroll.
+
+Suggested log shipper rule (Fly Log Shipper, Vector, or
+`fly logs --app pms-paper-soak` piped through grep):
+
+- Match: log line contains `OperatorApprovalRequiredError`.
+- Action: POST to `SLACK_OPERATOR_WEBHOOK_URL` with the matched line.
+- Throttle: 1 message per 60 s (the gate is one-shot per actuator
+  lifetime so floods are unlikely, but the log line repeats per
+  decision until the file is filed).
+
+If you skip this step, the operator must actively poll
+`/status`. That is acceptable only for the first cp-03 rehearsal.
+
+### 5. Confirm the SLA threshold [confirm, recommended default]
+
+**Recommended default**: 15 minutes from
+`OperatorApprovalRequiredError` raise to `approval_consumed` event in
+the audit JSONL. Below 15 minutes is normal; above 15 minutes triggers
+a follow-up to streamline the procedure (or, if it happens twice in a
+row, revert to PAPER until the bottleneck is fixed).
+
+This is your risk tolerance call. Tighten to 5 minutes if you trade
+short-lived markets; loosen to 60 minutes if you only trade long-dated
+ones.
+
+### 6. Run the cp-03 rehearsal before going live [confirm]
+
+Before flipping `live_trading_enabled=true`, walk the procedure end to
+end against the paper-soak config with a fake client. Do this from a
+clean shell at the repo root:
+
+```bash
+# Terminal A — start the runner.
+PMS_CONFIG_PATH=config.live-soak.yaml uv run pms-api
+
+# Terminal B — drop a matching approval JSON + sidecar.
+mkdir -p $(dirname $PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH)
+cat > $PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH <<'JSON'
+{ "approved": true, "max_notional_usdc": 5.0, "venue": "polymarket",
+  "market_id": "<from preview>", "token_id": "<from preview>",
+  "side": "BUY", "outcome": "YES",
+  "limit_price": 0.4, "max_slippage_bps": 50 }
+JSON
+cat > "${PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH}.meta.json" <<'JSON'
+{ "approver_id": "<your-handle>", "ts": "2026-05-07T00:00:00Z" }
+JSON
+
+# Confirm the audit log records matched -> consumed.
+tail -n 5 .data/live-emergency-audit.jsonl
+```
+
+The rehearsal is acceptance-complete when:
+
+- The audit JSONL shows exactly `approval_matched` followed by
+  `approval_consumed` for the rehearsal decision (no spurious events).
+- The approval file is unlinked after consume.
+- Both primary and backup have run the rehearsal at least once.
+- Elapsed time from raise to consume is below the chosen SLA from
+  step 5.
+
+Append a short sign-off entry to this runbook ("Rehearsal log
+YYYY-MM-DD: primary X, backup Y, elapsed N minutes") on completion.
+
+### 7. Final go/no-go
+
+Only flip `PMS_LIVE_TRADING_ENABLED=true` when steps 0-6 are all
+checked. The first live decision will hit the slow path; the gate will
+deny; the operator follows the playbook in the **Reference** section
+below.
+
+---
+
+## Reference
 
 ### Named operators
 
-- **Primary operator**: `TODO_DECISION` — fill in the named human responsible
-  for first-order approvals. Until this is filled in, the gate must remain
-  denied for every first-order signal.
-- **Backup operator**: `TODO_DECISION` — fill in the named human who covers
-  when the primary is unavailable.
-- **Reachability rule**: at least one named operator must be reachable for
-  every first-order event during normal market hours. First-order signals
-  outside named operator hours **stall the strategy by design** — there is no
-  on-call escalation path for first-order events until the user explicitly
-  funds one.
-
-Whoever is on Slack at the time is **not** the operator. An anonymous gate is
-no gate.
+Replace the `__FILL_IN__` markers in step 3 above. The reachability
+rule and "anonymous gate is no gate" framing apply once names are
+recorded.
 
 ### Approval-file location
 
-- **Canonical environment variable**:
-  `PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH`
-  (consumed at `src/pms/runner.py:2098-2104` →
-  `_first_live_order_gate`). An empty value resolves to
-  `DenyFirstLiveOrderGate` and **locks** the gate; do not set the env var to
-  empty as a "disable" — the gate is already disabled if the env var is
-  unset.
-- **Path**: `TODO_DECISION` — choose one of:
-  - encrypted directory on the runner host (e.g. `/secure/pms/first-order.json`
-    on a LUKS-backed mount or tmpfs);
-  - Fly secret mount if the runner is deployed on Fly (see `fly.toml`);
-  - operator's local machine over an SSH-tunnel-mounted dir.
-- **Permissions**: write the file with `umask 077`. The runner process UID
-  must be the only reader. The file must never be committed to the repo.
-- **Sidecar metadata**: alongside the approval JSON, the operator's tool
-  writes a `<approval-path>.meta.json` containing `{ "approver_id": "<id>",
-  "ts": "<ISO 8601>" }`. The audit writer reads this on the next event and
-  records the approver. Format remains stable across runs.
+- **Production (Fly)**: `/data/pms/first-order.json` (provisioned in
+  step 2). Read only by the runner container's process UID.
+- **Local development**: a freeform path under the operator's home,
+  for example `~/.local/share/pms/first-order.json`. Created with
+  `umask 077`.
+- **Sidecar metadata**: alongside the approval JSON, the operator
+  writes `<approval-path>.meta.json` containing
+  `{ "approver_id": "<id>", "ts": "<ISO 8601>" }`. The audit writer
+  reads this and records the approver in the JSONL.
+- **Never** commit either file to the repo. Both are gitignored under
+  `.data/` and operator-specific paths.
 
 ### "First" order semantics
 
-"First" means **first since the actuator was instantiated** (see the in-
-memory state at `src/pms/actuator/adapters/polymarket.py:571-576`). A process
-restart resets the gate to denied — the next decision will re-prompt the
+"First" means **first since the actuator was instantiated** (see the
+in-memory state at
+`src/pms/actuator/adapters/polymarket.py:571-576`). A process restart
+resets the gate to denied — the next decision will re-prompt the
 operator. **This re-prompt on restart is intentional**, not a bug: any
-disruption that warrants a restart also warrants re-validating the operating
-environment before the next live submit.
+disruption that warrants a restart also warrants re-validating the
+operating environment before the next live submit.
 
 Concretely, an approval is consumed exactly once per actuator lifetime:
 
@@ -216,10 +385,11 @@ Concretely, an approval is consumed exactly once per actuator lifetime:
 
 Every gate consultation appends one record to the JSONL at
 `live_emergency_audit_path` (default `.data/live-emergency-audit.jsonl`,
-configurable via `PMS_LIVE_EMERGENCY_AUDIT_PATH`).
+configurable via `PMS_LIVE_EMERGENCY_AUDIT_PATH`). The audit writer is
+the same `JsonlFirstOrderAuditWriter` wired in
+`src/pms/storage/first_order_audit.py`.
 
-Three event types, written by `JsonlFirstOrderAuditWriter`
-(`src/pms/storage/first_order_audit.py`):
+Three event types:
 
 | `event`              | When                                                  |
 |----------------------|-------------------------------------------------------|
@@ -227,48 +397,42 @@ Three event types, written by `JsonlFirstOrderAuditWriter`
 | `approval_denied`    | Gate returned False; `OperatorApprovalRequiredError`. |
 | `approval_consumed`  | Submit succeeded and `consume()` ran (file unlinked). |
 
-A record carries: `ts`, `event`, `approver_id` (from sidecar, may be `null`),
-`venue`, `market_id`, `token_id`, `side`, `outcome`, `max_notional_usdc`,
-`limit_price`, `max_slippage_bps`, `market_slug`, `question`. The audit
-writer is non-blocking — a write failure logs WARN and the order proceeds,
-mirroring `runner.py:1307-1308`.
+A record carries: `ts`, `event`, `approver_id` (from sidecar, may be
+`null`), `venue`, `market_id`, `token_id`, `side`, `outcome`,
+`max_notional_usdc`, `limit_price`, `max_slippage_bps`, `market_slug`,
+`question`. The audit writer is non-blocking — a write failure logs
+WARN and the order proceeds, mirroring `runner.py:1307-1308`.
 
-> **TODO_DECISION (audit sink)**: This runbook reuses `live_emergency_audit_path` as
-> the single consolidated authorization log. Filter records by the `event`
-> field (first-order) vs the `phase` field (emergency-halt) when reading.
-> Switch to a dedicated `first_order_audit_path` if you prefer separate
-> sinks; this is recorded as a deferred decision in STO-10.
-
-### Alerting and SLA
-
-- **Alert channel**: `TODO_DECISION` — choose one of: Slack webhook fed by a
-  log shipper that watches for `OperatorApprovalRequiredError`; PagerDuty;
-  email digest; or no alerting (operator polls runner status). Until this is
-  set, the operator must actively check `/status` before any first-order
-  signal is expected.
-- **Max acceptable elapsed time** from `OperatorApprovalRequiredError` to
-  `approval_consumed`: `TODO_DECISION` minutes. Exceeding this in cp-03
-  rehearsal is a signal to streamline the procedure before live.
+The runbook reuses `live_emergency_audit_path` as the single
+consolidated authorization log; filter records by the `event` field
+(first-order) vs the `phase` field (emergency-halt) when reading.
+Switching to a dedicated path is a deferred decision; revisit if
+authorization-event volume grows enough to make filtering noisy.
 
 ### End-to-end procedure (operator playbook)
 
-When `OperatorApprovalRequiredError` is observed (in logs or via alert):
+When `OperatorApprovalRequiredError` is observed (in logs or via the
+Slack alert from step 4):
 
-1. Pull the preview details from the error message (venue, market, token,
-   side, outcome, max_notional_usdc, limit_price, max_slippage_bps).
+1. Pull the preview details from the error message (venue, market,
+   token, side, outcome, max_notional_usdc, limit_price,
+   max_slippage_bps).
 2. Validate the preview against current strategy intent and risk caps.
-3. If approved, run the operator tool to write both the approval JSON
-   (matching every field) and the `<path>.meta.json` sidecar with your
-   `approver_id`.
-4. Wait for the next decision; the gate consults the file, matches, submits.
+3. If approved, write the approval JSON (matching every field) and
+   the `<path>.meta.json` sidecar with your `approver_id` to the
+   configured path. On Fly: `fly ssh console --app pms-paper-soak`,
+   then write to `/data/pms/first-order.json` and the matching
+   sidecar.
+4. Wait for the next decision; the gate consults the file, matches,
+   submits.
 5. Confirm `approval_consumed` lands in the audit JSONL.
-6. The fast path is now open for the rest of the actuator's lifetime; if
-   the runner restarts, repeat from step 1 on the next decision.
+6. The fast path is now open for the rest of the actuator's lifetime;
+   if the runner restarts, repeat from step 1 on the next decision.
 
-If at any step you decide **not** to approve, do nothing. The next decision
-will trigger another `OperatorApprovalRequiredError`; the audit log will
-record `approval_denied`. The strategy stalls — that is the gate working as
-intended.
+If at any step you decide **not** to approve, do nothing. The next
+decision will trigger another `OperatorApprovalRequiredError`; the
+audit log will record `approval_denied`. The strategy stalls — that
+is the gate working as intended.
 
 ## Rollback
 

--- a/scripts/approve_first_order.py
+++ b/scripts/approve_first_order.py
@@ -143,11 +143,19 @@ def write_approval(
         "ts": ts.isoformat(),
     }
 
-    _write_secret_file(path, json.dumps(payload, sort_keys=True))
+    # Write order matters: the gate matches on the approval JSON, then
+    # `read_approver_id` reads the sidecar. If the approval JSON
+    # appeared first, a running actuator could match between the two
+    # writes and emit `approval_matched` with `approver_id: null`.
+    # Writing the sidecar first guarantees identity is on disk before
+    # the approval is observable to the gate. If the sidecar write
+    # raises, the approval JSON is never written — the gate stays
+    # denied and the operator's tool exits non-zero.
     _write_secret_file(
         sidecar_path,
         json.dumps(sidecar_payload, sort_keys=True),
     )
+    _write_secret_file(path, json.dumps(payload, sort_keys=True))
 
     return path, sidecar_path
 

--- a/scripts/approve_first_order.py
+++ b/scripts/approve_first_order.py
@@ -1,0 +1,243 @@
+"""Operator helper for the first-live-order approval gate (STO-10).
+
+Given an `OperatorApprovalRequiredError` message (or the equivalent
+preview fields) and an `approver_id`, write:
+
+  1. The approval JSON at the configured path. Fields match exactly
+     what `_approval_payload_matches`
+     (`src/pms/actuator/adapters/polymarket.py`) checks, so the gate
+     matches on the next decision without operator typo risk.
+  2. The sidecar `<path>.meta.json` so
+     `FileFirstLiveOrderGate.read_approver_id` populates the
+     `approver_id` field on every audit-log event for this
+     authorization.
+
+Both files are written with mode 0o600 — the runner UID is the only
+reader. By default the helper refuses to overwrite an existing approval
+file (would clobber a still-pending authorization); pass `--force` to
+override.
+
+Operator usage:
+
+    uv run python scripts/approve_first_order.py \\
+        --from-error 'First Polymarket live order requires operator \\
+            approval: venue=polymarket market=... token=... side=BUY \\
+            outcome=YES max_notional_usdc=5.0 limit_price=0.4 \\
+            max_slippage_bps=50' \\
+        --approver-id alice@example \\
+        --path /data/pms/first-order.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalPreview:
+    venue: str
+    market_id: str
+    token_id: str | None
+    side: str
+    outcome: str
+    max_notional_usdc: float
+    limit_price: float
+    max_slippage_bps: int
+
+
+# Map error-message keys (e.g. `market=`) to ApprovalPreview field names.
+# The actuator's f-string format uses the short keys for readability;
+# the JSON the gate matches uses the long names. Centralise the mapping.
+_KEY_ALIASES: dict[str, str] = {
+    "venue": "venue",
+    "market": "market_id",
+    "token": "token_id",
+    "side": "side",
+    "outcome": "outcome",
+    "max_notional_usdc": "max_notional_usdc",
+    "limit_price": "limit_price",
+    "max_slippage_bps": "max_slippage_bps",
+}
+
+_TOKEN_RE = re.compile(r"(\w+)=(\S+)")
+
+
+def parse_preview_from_error(message: str) -> ApprovalPreview:
+    """Parse an `OperatorApprovalRequiredError` message into an
+    `ApprovalPreview`. Raises ValueError if any required field is
+    missing — better than silently producing a partial JSON that would
+    fail the gate match without a clear cause."""
+    raw: dict[str, str] = {}
+    for match in _TOKEN_RE.finditer(message):
+        key = match.group(1)
+        value = match.group(2)
+        if key in _KEY_ALIASES:
+            raw[_KEY_ALIASES[key]] = value
+
+    required_fields = (
+        "venue",
+        "market_id",
+        "token_id",
+        "side",
+        "outcome",
+        "max_notional_usdc",
+        "limit_price",
+        "max_slippage_bps",
+    )
+    missing = [field for field in required_fields if field not in raw]
+    if missing:
+        raise ValueError(
+            f"missing required preview fields in error message: {missing!r}"
+        )
+
+    token_id: str | None = raw["token_id"]
+    if token_id == "None":
+        token_id = None
+
+    return ApprovalPreview(
+        venue=raw["venue"],
+        market_id=raw["market_id"],
+        token_id=token_id,
+        side=raw["side"],
+        outcome=raw["outcome"],
+        max_notional_usdc=float(raw["max_notional_usdc"]),
+        limit_price=float(raw["limit_price"]),
+        max_slippage_bps=int(raw["max_slippage_bps"]),
+    )
+
+
+def write_approval(
+    preview: ApprovalPreview,
+    *,
+    path: Path,
+    approver_id: str,
+    ts: datetime,
+    force: bool = False,
+) -> tuple[Path, Path]:
+    """Write the approval JSON and the sidecar `<path>.meta.json`.
+
+    Returns the (approval_path, sidecar_path) pair. Both files have
+    mode 0o600. Refuses to overwrite an existing approval file unless
+    `force=True` — guards against clobbering a pending authorization.
+    """
+    sidecar_path = Path(str(path) + ".meta.json")
+
+    if path.exists() and not force:
+        raise FileExistsError(
+            f"approval file already exists at {path}; pass force=True to overwrite"
+        )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict[str, Any] = {"approved": True, **asdict(preview)}
+    sidecar_payload: dict[str, Any] = {
+        "approver_id": approver_id,
+        "ts": ts.isoformat(),
+    }
+
+    _write_secret_file(path, json.dumps(payload, sort_keys=True))
+    _write_secret_file(
+        sidecar_path,
+        json.dumps(sidecar_payload, sort_keys=True),
+    )
+
+    return path, sidecar_path
+
+
+def _write_secret_file(path: Path, content: str) -> None:
+    """Write `content` to `path` with mode 0o600.
+
+    Uses `os.open` with the explicit mode rather than relying on the
+    process umask, then sets mode again post-write defensively in case
+    a wide umask masked the create mode."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            file.write(content)
+            file.write("\n")
+    except BaseException:
+        # If fdopen never claimed the descriptor we'd leak it; the
+        # context manager above closes on success. Belt-and-braces:
+        # ignore failure here — the original exception is what matters.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        raise
+    os.chmod(path, 0o600)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Write a first-live-order approval JSON + sidecar.",
+    )
+    parser.add_argument(
+        "--from-error",
+        required=True,
+        help="The OperatorApprovalRequiredError message to parse.",
+    )
+    parser.add_argument(
+        "--approver-id",
+        required=True,
+        help="Identity of the human authorizing this order.",
+    )
+    parser.add_argument(
+        "--path",
+        default=os.environ.get("PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH"),
+        help=(
+            "Approval file path. Defaults to "
+            "$PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing approval file. Default: refuse.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.path:
+        parser.error(
+            "no approval path provided; pass --path or set "
+            "PMS_POLYMARKET__FIRST_LIVE_ORDER_APPROVAL_PATH"
+        )
+
+    try:
+        preview = parse_preview_from_error(args.from_error)
+    except ValueError as exc:
+        # parser.error() is typed NoReturn (calls sys.exit), so no
+        # follow-up return statement is needed and mypy strict (with
+        # warn_unreachable) flags any dead code after.
+        parser.error(f"could not parse error message: {exc}")
+
+    ts = datetime.now(tz=UTC)
+    approval_path, sidecar_path = write_approval(
+        preview,
+        path=Path(args.path),
+        approver_id=args.approver_id,
+        ts=ts,
+        force=args.force,
+    )
+
+    print(f"✓ Wrote approval JSON: {approval_path}")
+    print(f"✓ Wrote sidecar:       {sidecar_path}")
+    print(f"✓ Approver ID:         {args.approver_id}")
+    print(f"✓ Timestamp:           {ts.isoformat()}")
+    print(
+        "The first-order gate will match on the next decision and submit; "
+        "consume() will then unlink both files."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rehearse_first_order.py
+++ b/scripts/rehearse_first_order.py
@@ -1,0 +1,331 @@
+"""STO-10 cp-03: end-to-end first-live-order rehearsal driver.
+
+Drives the real `PolymarketActuator` slow path with a real
+`FileFirstLiveOrderGate` and a real `JsonlFirstOrderAuditWriter`,
+backed by inline fakes for the venue client and quote provider. No
+network, no DB, no real money.
+
+The script exists so an operator can run a single-command smoke test
+on the deployed Fly machine before the first live launch:
+
+    uv run python scripts/rehearse_first_order.py --approver-id alice
+
+PASS proves four things together: (1) the volume is mounted at a path
+the runner UID can write; (2) the audit JSONL pipeline writes records;
+(3) the gate matches an approval JSON the operator helper produces;
+(4) the consume() lifecycle unlinks both files. FAIL prints which step
+broke and where the audit log is for inspection.
+
+Tests in `tests/unit/test_rehearse_first_order_script.py` exercise the
+same path through the asyncio entry point so CI catches regressions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pms.actuator.adapters.polymarket import (
+    FileFirstLiveOrderGate,
+    LivePreSubmitQuote,
+    OperatorApprovalRequiredError,
+    PolymarketActuator,
+    PolymarketOrderRequest,
+    PolymarketOrderResult,
+)
+from pms.config import ControllerSettings, PMSSettings, PolymarketSettings
+from pms.core.enums import OrderStatus, Side, TimeInForce
+from pms.core.models import Portfolio, TradeDecision
+from pms.storage.first_order_audit import JsonlFirstOrderAuditWriter
+from scripts.approve_first_order import ApprovalPreview, write_approval
+
+
+_EXPECTED_EVENT_SEQUENCE: tuple[str, ...] = (
+    "approval_denied",
+    "approval_matched",
+    "approval_consumed",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RehearsalResult:
+    passed: bool
+    events: list[str]
+    audit_path: Path
+    approval_path: Path
+    failure_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RehearsalClient:
+    """Stand-in for `PolymarketSDKClient` that returns a fixed
+    matched-fill result. Local-only — never reaches the venue."""
+
+    async def submit_order(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: object,
+    ) -> PolymarketOrderResult:
+        del credentials
+        filled_quantity = (
+            order.notional_usdc / order.price if order.price > 0 else 0.0
+        )
+        return PolymarketOrderResult(
+            order_id="rehearsal-order-1",
+            status=OrderStatus.MATCHED.value,
+            raw_status="matched",
+            filled_notional_usdc=order.notional_usdc,
+            remaining_notional_usdc=0.0,
+            fill_price=order.price,
+            filled_quantity=filled_quantity,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _RehearsalQuoteProvider:
+    async def quote(
+        self,
+        order: PolymarketOrderRequest,
+        credentials: object,
+    ) -> LivePreSubmitQuote:
+        del credentials
+        return LivePreSubmitQuote(
+            market_status="open",
+            book_age_ms=25.0,
+            executable_notional_usdc=order.notional_usdc,
+            best_executable_price=order.price,
+            spread_bps=10.0,
+            quote_hash="rehearsal-quote",
+            book_ts=datetime.now(tz=UTC),
+        )
+
+
+def _rehearsal_settings() -> PMSSettings:
+    return PMSSettings(
+        live_trading_enabled=True,
+        controller=ControllerSettings(time_in_force="IOC"),
+        polymarket=PolymarketSettings(
+            private_key="rehearsal-private-key",
+            api_key="rehearsal-api-key",
+            api_secret="rehearsal-api-secret",
+            api_passphrase="rehearsal-passphrase",
+            signature_type=1,
+            funder_address="0xrehearsal",
+        ),
+    )
+
+
+def _rehearsal_decision() -> TradeDecision:
+    return TradeDecision(
+        decision_id="rehearsal-decision",
+        market_id="m-rehearsal",
+        token_id="t-rehearsal-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        notional_usdc=5.0,
+        order_type="limit",
+        max_slippage_bps=50,
+        stop_conditions=["rehearsal"],
+        prob_estimate=0.6,
+        expected_edge=0.2,
+        time_in_force=TimeInForce.IOC,
+        opportunity_id="op-rehearsal",
+        strategy_id="rehearsal",
+        strategy_version_id="rehearsal-v1",
+        action=Side.BUY.value,
+        limit_price=0.4,
+        outcome="YES",
+    )
+
+
+def _rehearsal_portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1000.0,
+        free_usdc=1000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+        max_drawdown_pct=None,
+    )
+
+
+def _read_audit_events(audit_path: Path) -> list[str]:
+    if not audit_path.exists():
+        return []
+    events: list[str] = []
+    for line in audit_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        event = record.get("event")
+        if isinstance(event, str):
+            events.append(event)
+    return events
+
+
+async def run_rehearsal(
+    *,
+    workdir: Path,
+    approver_id: str = "rehearsal-operator",
+) -> RehearsalResult:
+    """Execute the cp-03 procedure end to end and return a result.
+
+    The function never raises for expected operational outcomes —
+    every failure mode lands in `RehearsalResult.failure_reason` so a
+    caller can branch on `passed`."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    approval_path = workdir / "first-order.json"
+    audit_path = workdir / "audit.jsonl"
+
+    actuator = PolymarketActuator(
+        settings=_rehearsal_settings(),
+        client=_RehearsalClient(),
+        operator_gate=FileFirstLiveOrderGate(approval_path),
+        quote_provider=_RehearsalQuoteProvider(),
+        audit_writer=JsonlFirstOrderAuditWriter(audit_path),
+    )
+
+    decision = _rehearsal_decision()
+    portfolio = _rehearsal_portfolio()
+
+    # Step 1: gate denies (no approval file yet) — emits approval_denied.
+    try:
+        await actuator.execute(decision, portfolio)
+    except OperatorApprovalRequiredError:
+        pass
+    else:
+        return RehearsalResult(
+            passed=False,
+            events=_read_audit_events(audit_path),
+            audit_path=audit_path,
+            approval_path=approval_path,
+            failure_reason=(
+                "first execute() succeeded with no approval file present; "
+                "the gate must deny when the file is missing"
+            ),
+        )
+
+    # Step 2: operator files the approval (use the same helper the
+    # runbook step 6 procedure uses).
+    write_approval(
+        ApprovalPreview(
+            venue=decision.venue,
+            market_id=decision.market_id,
+            token_id=decision.token_id,
+            side=decision.side,
+            outcome=decision.outcome,
+            max_notional_usdc=decision.notional_usdc,
+            limit_price=decision.limit_price,
+            max_slippage_bps=decision.max_slippage_bps,
+        ),
+        path=approval_path,
+        approver_id=approver_id,
+        ts=datetime.now(tz=UTC),
+    )
+
+    # Step 3: gate matches, submit succeeds, consume runs.
+    try:
+        order_state = await actuator.execute(decision, portfolio)
+    except Exception as exc:  # noqa: BLE001
+        return RehearsalResult(
+            passed=False,
+            events=_read_audit_events(audit_path),
+            audit_path=audit_path,
+            approval_path=approval_path,
+            failure_reason=f"second execute() raised after approval was filed: {exc!r}",
+        )
+
+    if order_state.status != OrderStatus.MATCHED.value:
+        return RehearsalResult(
+            passed=False,
+            events=_read_audit_events(audit_path),
+            audit_path=audit_path,
+            approval_path=approval_path,
+            failure_reason=(
+                f"order status was {order_state.status!r}, expected "
+                f"{OrderStatus.MATCHED.value!r}"
+            ),
+        )
+
+    # Step 4: validate the audit JSONL.
+    events = _read_audit_events(audit_path)
+    if tuple(events) != _EXPECTED_EVENT_SEQUENCE:
+        return RehearsalResult(
+            passed=False,
+            events=events,
+            audit_path=audit_path,
+            approval_path=approval_path,
+            failure_reason=(
+                f"audit events were {events!r}, expected "
+                f"{list(_EXPECTED_EVENT_SEQUENCE)!r}"
+            ),
+        )
+
+    return RehearsalResult(
+        passed=True,
+        events=events,
+        audit_path=audit_path,
+        approval_path=approval_path,
+        failure_reason=None,
+    )
+
+
+def report_result(result: RehearsalResult) -> int:
+    """Print the rehearsal outcome and return the exit code. Pure
+    sync, no asyncio: testable without harness concerns."""
+    if result.passed:
+        print(f"✓ PASS  events={result.events}")
+        print(f"  audit log:    {result.audit_path}")
+        print(f"  approval:     {result.approval_path} (unlinked after consume)")
+        return 0
+
+    print(f"✗ FAIL  reason: {result.failure_reason}")
+    print(f"  events seen:  {result.events}")
+    print(f"  audit log:    {result.audit_path}")
+    print(f"  approval:     {result.approval_path}")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "STO-10 cp-03 first-live-order rehearsal: drives the actuator "
+            "slow path end to end with fakes and verifies the audit log."
+        ),
+    )
+    parser.add_argument(
+        "--workdir",
+        default=None,
+        help=(
+            "Where to write the approval JSON, sidecar, and audit JSONL. "
+            "Defaults to a fresh temp directory."
+        ),
+    )
+    parser.add_argument(
+        "--approver-id",
+        default="rehearsal-operator",
+        help="Identity recorded in the audit log's approver_id field.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.workdir is None:
+        workdir = Path(tempfile.mkdtemp(prefix="pms-rehearsal-"))
+    else:
+        workdir = Path(args.workdir)
+
+    result = asyncio.run(
+        run_rehearsal(workdir=workdir, approver_id=args.approver_id)
+    )
+    return report_result(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -301,6 +301,40 @@ class DenyFirstLiveOrderGate:
         del preview
 
 
+class FirstOrderAuditWriter(Protocol):
+    """Persistence sink for first-live-order operator events.
+
+    Implementations record one event per call. Failures must NOT raise into
+    the trading hot path — the actuator wraps each call in try/except to
+    keep audit-write degradation independent of order submission. See
+    `runner.py:1307-1308` for the same pattern on emergency-audit writes.
+    """
+
+    async def record_event(
+        self,
+        *,
+        event: str,
+        preview: LiveOrderPreview,
+        approver_id: str | None = None,
+    ) -> None: ...
+
+
+@dataclass(frozen=True)
+class _NoopFirstOrderAuditWriter:
+    """Default no-op audit writer used when no first-order audit sink is
+    configured. Keeps offline tests, paper mode, and dev runs from
+    requiring a writable audit path on disk."""
+
+    async def record_event(
+        self,
+        *,
+        event: str,
+        preview: LiveOrderPreview,
+        approver_id: str | None = None,
+    ) -> None:
+        del event, preview, approver_id
+
+
 @dataclass
 class FirstLiveOrderApprovalState:
     approved: bool = False
@@ -568,6 +602,9 @@ class PolymarketActuator:
     client: PolymarketClient = field(default_factory=MissingPolymarketClient)
     operator_gate: FirstLiveOrderGate = field(default_factory=DenyFirstLiveOrderGate)
     quote_provider: LiveQuoteProvider = field(default_factory=MissingLiveQuoteProvider)
+    audit_writer: FirstOrderAuditWriter = field(
+        default_factory=_NoopFirstOrderAuditWriter,
+    )
     _approval_state: FirstLiveOrderApprovalState = field(
         default_factory=FirstLiveOrderApprovalState,
         init=False,
@@ -627,6 +664,7 @@ class PolymarketActuator:
             preview = await self._live_order_preview(decision)
             approved = await self.operator_gate.approve_first_order(preview)
             if not approved:
+                await self._emit_audit(event="approval_denied", preview=preview)
                 msg = (
                     "First Polymarket live order requires operator approval: "
                     f"venue={preview.venue} market={preview.market_id} "
@@ -637,6 +675,8 @@ class PolymarketActuator:
                     f"max_slippage_bps={preview.max_slippage_bps}"
                 )
                 raise OperatorApprovalRequiredError(msg)
+
+            await self._emit_audit(event="approval_matched", preview=preview)
 
             # Submit while still holding the lock. If this raises, the
             # `async with` releases the lock and `_approval_state.approved`
@@ -656,8 +696,22 @@ class PolymarketActuator:
                 await self.operator_gate.consume(preview)
             except Exception as exc:  # noqa: BLE001
                 logger.warning("first-order gate consume failed: %s", exc)
+            await self._emit_audit(event="approval_consumed", preview=preview)
 
         return order_state
+
+    async def _emit_audit(self, *, event: str, preview: LiveOrderPreview) -> None:
+        # Audit emission is fire-and-forget from the trading hot path: a
+        # writer outage must never block or roll back an order. Mirrors the
+        # precedent at runner.py:1307-1308 for emergency-audit append.
+        try:
+            await self.audit_writer.record_event(event=event, preview=preview)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "first-order audit write failed: event=%s err=%s",
+                event,
+                exc,
+            )
 
     def _first_order_approved(self) -> bool:
         return self._approval_state.approved

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -358,11 +358,35 @@ class FileFirstLiveOrderGate:
     async def consume(self, preview: LiveOrderPreview) -> None:
         # Atomically consume the approval artefact so it cannot be replayed
         # by a future restart or a concurrent `approve_first_order` call.
+        # Both the approval JSON and its sidecar metadata file share a
+        # single authorization lifetime; unlink both so a stale sidecar
+        # cannot misattribute a future authorization to the previous
+        # approver.
         del preview
         try:
             self.path.unlink()
         except FileNotFoundError:
             pass
+        try:
+            self._sidecar_path().unlink()
+        except FileNotFoundError:
+            pass
+
+    def read_approver_id(self) -> str | None:
+        sidecar = self._sidecar_path()
+        if not sidecar.exists():
+            return None
+        try:
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        approver_id = payload.get("approver_id")
+        return approver_id if isinstance(approver_id, str) else None
+
+    def _sidecar_path(self) -> Path:
+        return Path(str(self.path) + ".meta.json")
 
 
 @dataclass(frozen=True)
@@ -663,8 +687,18 @@ class PolymarketActuator:
 
             preview = await self._live_order_preview(decision)
             approved = await self.operator_gate.approve_first_order(preview)
+            # Capture approver_id from the operator gate once, before
+            # consume() can unlink any sidecar. Threading the same
+            # value through matched/denied/consumed events guarantees
+            # the audit log answers "who authorized this" consistently
+            # across all three records for one authorization act.
+            approver_id = self._read_approver_id()
             if not approved:
-                await self._emit_audit(event="approval_denied", preview=preview)
+                await self._emit_audit(
+                    event="approval_denied",
+                    preview=preview,
+                    approver_id=approver_id,
+                )
                 msg = (
                     "First Polymarket live order requires operator approval: "
                     f"venue={preview.venue} market={preview.market_id} "
@@ -676,7 +710,11 @@ class PolymarketActuator:
                 )
                 raise OperatorApprovalRequiredError(msg)
 
-            await self._emit_audit(event="approval_matched", preview=preview)
+            await self._emit_audit(
+                event="approval_matched",
+                preview=preview,
+                approver_id=approver_id,
+            )
 
             # Submit while still holding the lock. If this raises, the
             # `async with` releases the lock and `_approval_state.approved`
@@ -696,22 +734,55 @@ class PolymarketActuator:
                 await self.operator_gate.consume(preview)
             except Exception as exc:  # noqa: BLE001
                 logger.warning("first-order gate consume failed: %s", exc)
-            await self._emit_audit(event="approval_consumed", preview=preview)
+            await self._emit_audit(
+                event="approval_consumed",
+                preview=preview,
+                approver_id=approver_id,
+            )
 
         return order_state
 
-    async def _emit_audit(self, *, event: str, preview: LiveOrderPreview) -> None:
+    async def _emit_audit(
+        self,
+        *,
+        event: str,
+        preview: LiveOrderPreview,
+        approver_id: str | None,
+    ) -> None:
         # Audit emission is fire-and-forget from the trading hot path: a
         # writer outage must never block or roll back an order. Mirrors the
         # precedent at runner.py:1307-1308 for emergency-audit append.
         try:
-            await self.audit_writer.record_event(event=event, preview=preview)
+            await self.audit_writer.record_event(
+                event=event,
+                preview=preview,
+                approver_id=approver_id,
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "first-order audit write failed: event=%s err=%s",
                 event,
                 exc,
             )
+
+    def _read_approver_id(self) -> str | None:
+        # Duck-typed: only FileFirstLiveOrderGate exposes
+        # `read_approver_id` today. Other gates (Recording, Deny,
+        # Blocking, *CountingFile) fall through to None — they have
+        # no sidecar concept. Same getattr pattern used at
+        # _submit_with_quote_guard to keep optional gate features off
+        # the FirstLiveOrderGate Protocol surface.
+        reader = getattr(self.operator_gate, "read_approver_id", None)
+        if not callable(reader):
+            return None
+        try:
+            result = reader()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "first-order operator gate read_approver_id failed: %s", exc
+            )
+            return None
+        return result if isinstance(result, str) else None
 
     def _first_order_approved(self) -> bool:
         return self._approval_state.approved

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -307,7 +307,7 @@ class FirstOrderAuditWriter(Protocol):
     Implementations record one event per call. Failures must NOT raise into
     the trading hot path — the actuator wraps each call in try/except to
     keep audit-write degradation independent of order submission. See
-    `runner.py:1307-1308` for the same pattern on emergency-audit writes.
+    `runner.py:1319-1320` for the same pattern on emergency-audit writes.
     """
 
     async def record_event(
@@ -772,7 +772,7 @@ class PolymarketActuator:
     ) -> None:
         # Audit emission is fire-and-forget from the trading hot path: a
         # writer outage must never block or roll back an order. Mirrors the
-        # precedent at runner.py:1307-1308 for emergency-audit append.
+        # precedent at runner.py:1319-1320 for emergency-audit append.
         try:
             await self.audit_writer.record_event(
                 event=event,

--- a/src/pms/actuator/adapters/polymarket.py
+++ b/src/pms/actuator/adapters/polymarket.py
@@ -729,16 +729,37 @@ class PolymarketActuator:
             # First venue submission succeeded: lock in first-order
             # completion and consume the operator-side approval artefact
             # so it cannot be replayed by a future restart.
+            #
+            # `_approval_state.approved=True` MUST stay set even if
+            # consume() fails — flipping it back would cause the next
+            # in-process decision to re-prompt the gate and double-submit
+            # against the still-present approval file. The cleanup-
+            # failure handling below is forensic, not transactional.
             self._approval_state.approved = True
             try:
                 await self.operator_gate.consume(preview)
             except Exception as exc:  # noqa: BLE001
-                logger.warning("first-order gate consume failed: %s", exc)
-            await self._emit_audit(
-                event="approval_consumed",
-                preview=preview,
-                approver_id=approver_id,
-            )
+                # Record the truth: cleanup failed, the artefact may
+                # still be on disk, a future restart could replay it.
+                # ERROR-level so an external alerter can page the
+                # operator for manual cleanup.
+                logger.error(
+                    "first-order gate consume failed: %s. Approval "
+                    "artefact may remain on disk and could replay on "
+                    "restart; manual cleanup required.",
+                    exc,
+                )
+                await self._emit_audit(
+                    event="approval_consume_failed",
+                    preview=preview,
+                    approver_id=approver_id,
+                )
+            else:
+                await self._emit_audit(
+                    event="approval_consumed",
+                    preview=preview,
+                    approver_id=approver_id,
+                )
 
         return order_state
 

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -84,6 +84,7 @@ from pms.storage.decision_store import DecisionStore
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
 from pms.storage.fill_store import FillStore
+from pms.storage.first_order_audit import JsonlFirstOrderAuditWriter
 from pms.storage.live_emergency_audit import LiveEmergencyAuditWriter
 from pms.storage.market_data_store import PostgresMarketDataStore
 from pms.storage.market_subscription_store import PostgresMarketSubscriptionStore
@@ -936,11 +937,22 @@ class Runner:
                 ),
                 settings=self.config,
             )
+        # STO-10 cp-02: reuse `live_emergency_audit_path` as the single
+        # consolidated authorization-event log. First-order audit records
+        # have a distinct schema (event/preview fields) from emergency
+        # records (phase/decision/error), so a reader filters by the
+        # `event` vs `phase` field to extract first-order events.
+        # TODO_DECISION (user): switch to a dedicated `first_order_audit_path`
+        # if you prefer separate sinks; this is the recommended default
+        # from the STO-10 spec.
         return PolymarketActuator(
             self.config,
             client=PolymarketSDKClient(),
             operator_gate=_first_live_order_gate(self.config),
             quote_provider=quote_provider,
+            audit_writer=JsonlFirstOrderAuditWriter(
+                Path(self.config.live_emergency_audit_path)
+            ),
         )
 
     def _remember_paper_orderbook(self, signal: MarketSignal) -> None:

--- a/src/pms/storage/first_order_audit.py
+++ b/src/pms/storage/first_order_audit.py
@@ -16,7 +16,7 @@ class JsonlFirstOrderAuditWriter:
     """Append-only JSONL sink for first-live-order operator events.
 
     Records the gate's match-keys (the same fields
-    `_approval_payload_matches` checks at polymarket.py:976-998) plus
+    `_approval_payload_matches` checks at polymarket.py:1122-1144) plus
     timestamp, event name, and an optional approver_id supplied by the
     operator's tooling. One record per event, one event per `record_event`
     call. Parent directory is created on demand to mirror

--- a/src/pms/storage/first_order_audit.py
+++ b/src/pms/storage/first_order_audit.py
@@ -65,6 +65,12 @@ def _audit_record(
 
 def _append_jsonl(path: Path, record: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Single `write()` so the underlying `O_APPEND` write(2) is atomic
+    # with respect to other concurrent writers on the same path
+    # (e.g. `LiveEmergencyAuditWriter` sharing
+    # `live_emergency_audit_path`). Two separate writes for the JSON
+    # body and the trailing newline could be flushed as two non-atomic
+    # write(2) calls and interleave with another writer's record.
+    line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
     with path.open("a", encoding="utf-8") as file:
-        file.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
-        file.write("\n")
+        file.write(line)

--- a/src/pms/storage/first_order_audit.py
+++ b/src/pms/storage/first_order_audit.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pms.actuator.adapters.polymarket import LiveOrderPreview
+
+
+@dataclass(frozen=True, slots=True)
+class JsonlFirstOrderAuditWriter:
+    """Append-only JSONL sink for first-live-order operator events.
+
+    Records the gate's match-keys (the same fields
+    `_approval_payload_matches` checks at polymarket.py:976-998) plus
+    timestamp, event name, and an optional approver_id supplied by the
+    operator's tooling. One record per event, one event per `record_event`
+    call. Parent directory is created on demand to mirror
+    `LiveEmergencyAuditWriter` behaviour at live_emergency_audit.py:75.
+    """
+
+    path: Path
+
+    async def record_event(
+        self,
+        *,
+        event: str,
+        preview: LiveOrderPreview,
+        approver_id: str | None = None,
+    ) -> None:
+        record = _audit_record(
+            event=event,
+            preview=preview,
+            approver_id=approver_id,
+        )
+        await asyncio.to_thread(_append_jsonl, self.path, record)
+
+
+def _audit_record(
+    *,
+    event: str,
+    preview: LiveOrderPreview,
+    approver_id: str | None,
+) -> dict[str, Any]:
+    return {
+        "ts": datetime.now(tz=UTC).isoformat(),
+        "event": event,
+        "approver_id": approver_id,
+        "venue": preview.venue,
+        "market_id": preview.market_id,
+        "token_id": preview.token_id,
+        "side": preview.side,
+        "outcome": preview.outcome,
+        "max_notional_usdc": preview.max_notional_usdc,
+        "limit_price": preview.limit_price,
+        "max_slippage_bps": preview.max_slippage_bps,
+        "market_slug": preview.market_slug,
+        "question": preview.question,
+    }
+
+
+def _append_jsonl(path: Path, record: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
+        file.write("\n")

--- a/src/pms/storage/live_emergency_audit.py
+++ b/src/pms/storage/live_emergency_audit.py
@@ -73,6 +73,12 @@ def _audit_record(
 
 def _append_jsonl(path: Path, record: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Single `write()` so the underlying `O_APPEND` write(2) is atomic
+    # with respect to other concurrent writers on the same path
+    # (e.g. `JsonlFirstOrderAuditWriter` sharing the same audit log).
+    # Splitting the JSON body and the trailing newline into two
+    # `file.write` calls risks two non-atomic write(2) flushes, which
+    # can interleave with another writer's record under contention.
+    line = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
     with path.open("a", encoding="utf-8") as file:
-        file.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
-        file.write("\n")
+        file.write(line)

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -2646,3 +2646,114 @@ async def test_polymarket_partial_fill_accepts_sub_cent_rounding_drift(
         _live_settings().polymarket.credentials(),
     )
     assert result.filled_notional_usdc == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# STO-10 cp-02: first-order audit emission
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RecordingFirstOrderAuditWriter:
+    events: list[tuple[str, LiveOrderPreview, str | None]] = field(default_factory=list)
+    raise_on_event: str | None = None
+
+    async def record_event(
+        self,
+        *,
+        event: str,
+        preview: LiveOrderPreview,
+        approver_id: str | None = None,
+    ) -> None:
+        self.events.append((event, preview, approver_id))
+        if self.raise_on_event == event:
+            raise RuntimeError(f"audit write failed: {event}")
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_emits_audit_on_gate_match_and_consume() -> None:
+    """STO-10 cp-02: happy path emits approval_matched then approval_consumed
+    with the same preview, so a forensic walker can reconstruct what was
+    authorized and confirm the consume completed."""
+    writer = RecordingFirstOrderAuditWriter()
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=RecordingPolymarketClient(),
+        operator_gate=RecordingOperatorGate(approved=True),
+        quote_provider=AllowQuoteProvider(),
+        audit_writer=writer,
+    )
+
+    state = await actuator.execute(_decision(), _portfolio())
+
+    assert state.status == OrderStatus.MATCHED.value
+    assert [event for event, _, _ in writer.events] == [
+        "approval_matched",
+        "approval_consumed",
+    ]
+    matched_preview = writer.events[0][1]
+    consumed_preview = writer.events[1][1]
+    assert matched_preview == consumed_preview
+    assert matched_preview.market_id == "m-cp06"
+    assert matched_preview.token_id == "t-yes"
+    assert matched_preview.side == Side.BUY.value
+    assert matched_preview.max_notional_usdc == 10.0
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_emits_audit_on_gate_denial() -> None:
+    """STO-10 cp-02: denial path emits approval_denied with the preview
+    that was rejected, so the audit log records every gate consultation
+    even when the gate refuses."""
+    writer = RecordingFirstOrderAuditWriter()
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=RecordingPolymarketClient(),
+        operator_gate=RecordingOperatorGate(approved=False),
+        quote_provider=AllowQuoteProvider(),
+        audit_writer=writer,
+    )
+
+    with pytest.raises(OperatorApprovalRequiredError):
+        await actuator.execute(_decision(), _portfolio())
+
+    assert [event for event, _, _ in writer.events] == ["approval_denied"]
+    assert writer.events[0][1].market_id == "m-cp06"
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_audit_writer_failure_does_not_break_submit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """STO-10 cp-02: an audit-writer failure must NOT block the submit
+    or leave the gate in an inconsistent state. Audit failure logs WARN
+    and the order proceeds. Mirrors precedent at runner.py:1307-1308 where
+    LiveEmergencyAuditWriter failures degrade gracefully rather than
+    interrupting the trading hot path."""
+    writer = RecordingFirstOrderAuditWriter(raise_on_event="approval_matched")
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=RecordingPolymarketClient(),
+        operator_gate=RecordingOperatorGate(approved=True),
+        quote_provider=AllowQuoteProvider(),
+        audit_writer=writer,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pms.actuator.adapters.polymarket"):
+        state = await actuator.execute(_decision(), _portfolio())
+
+    assert state.status == OrderStatus.MATCHED.value
+    # approval_matched emit raised; approval_consumed must still fire so the
+    # audit log records the eventual consume even when the matched-event
+    # write failed transiently.
+    assert [event for event, _, _ in writer.events] == [
+        "approval_matched",
+        "approval_consumed",
+    ]
+    assert any(
+        "first-order audit" in record.message and "approval_matched" in record.message
+        for record in caplog.records
+    ), (
+        "expected WARN log mentioning approval_matched failure, got: "
+        f"{[r.message for r in caplog.records]}"
+    )

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -2757,3 +2757,167 @@ async def test_polymarket_actuator_audit_writer_failure_does_not_break_submit(
         "expected WARN log mentioning approval_matched failure, got: "
         f"{[r.message for r in caplog.records]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# STO-10 follow-up: sidecar approver_id reader on FileFirstLiveOrderGate
+# ---------------------------------------------------------------------------
+
+
+def _approval_payload(*, market_id: str = "m-cp06") -> dict[str, object]:
+    return {
+        "approved": True,
+        "max_notional_usdc": 10.0,
+        "venue": "polymarket",
+        "market_id": market_id,
+        "token_id": "t-yes",
+        "side": Side.BUY.value,
+        "outcome": "YES",
+        "limit_price": 0.4,
+        "max_slippage_bps": 50,
+    }
+
+
+def _sidecar_path(approval_path: Path) -> Path:
+    return Path(str(approval_path) + ".meta.json")
+
+
+def test_file_first_live_order_gate_reads_approver_id_from_sidecar(
+    tmp_path: Path,
+) -> None:
+    """STO-10 sidecar: approver_id from <path>.meta.json is captured so
+    the audit log records who authorized the order."""
+    approval_path = tmp_path / "approval.json"
+    _sidecar_path(approval_path).write_text(
+        json.dumps({"approver_id": "operator-alice", "ts": "2026-05-07T00:00:00Z"}),
+        encoding="utf-8",
+    )
+
+    gate = FileFirstLiveOrderGate(approval_path)
+
+    assert gate.read_approver_id() == "operator-alice"
+
+
+def test_file_first_live_order_gate_returns_none_when_sidecar_missing(
+    tmp_path: Path,
+) -> None:
+    """No sidecar → approver_id is None (degraded but unblocked: the
+    runbook's gate's job is to authorize the trade, not to enforce
+    metadata hygiene)."""
+    gate = FileFirstLiveOrderGate(tmp_path / "approval.json")
+
+    assert gate.read_approver_id() is None
+
+
+def test_file_first_live_order_gate_returns_none_when_sidecar_malformed(
+    tmp_path: Path,
+) -> None:
+    """Malformed sidecar (invalid JSON, wrong shape, non-string
+    approver_id) must degrade to None without raising."""
+    approval_path = tmp_path / "approval.json"
+
+    _sidecar_path(approval_path).write_text("not-json", encoding="utf-8")
+    assert FileFirstLiveOrderGate(approval_path).read_approver_id() is None
+
+    _sidecar_path(approval_path).write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert FileFirstLiveOrderGate(approval_path).read_approver_id() is None
+
+    _sidecar_path(approval_path).write_text(
+        json.dumps({"approver_id": 42}), encoding="utf-8"
+    )
+    assert FileFirstLiveOrderGate(approval_path).read_approver_id() is None
+
+
+@pytest.mark.asyncio
+async def test_file_first_live_order_gate_consume_unlinks_sidecar(
+    tmp_path: Path,
+) -> None:
+    """STO-10 sidecar: consume() must unlink the sidecar alongside the
+    approval JSON so a stale `<path>.meta.json` cannot linger and
+    misattribute a future authorization to the previous approver."""
+    approval_path = tmp_path / "approval.json"
+    sidecar = _sidecar_path(approval_path)
+    approval_path.write_text(json.dumps(_approval_payload()), encoding="utf-8")
+    sidecar.write_text(json.dumps({"approver_id": "operator-alice"}), encoding="utf-8")
+
+    gate = FileFirstLiveOrderGate(approval_path)
+    preview = LiveOrderPreview(
+        max_notional_usdc=10.0,
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side=Side.BUY.value,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+
+    await gate.consume(preview)
+
+    assert approval_path.exists() is False
+    assert sidecar.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_audit_includes_approver_id_from_sidecar(
+    tmp_path: Path,
+) -> None:
+    """STO-10 follow-up: end-to-end the approver_id flows from the
+    operator's sidecar file into every audit record (matched and
+    consumed). This closes the loop on 'who authorized this order' for
+    forensic walkers."""
+    approval_path = tmp_path / "approval.json"
+    approval_path.write_text(json.dumps(_approval_payload()), encoding="utf-8")
+    _sidecar_path(approval_path).write_text(
+        json.dumps({"approver_id": "operator-alice"}), encoding="utf-8"
+    )
+
+    writer = RecordingFirstOrderAuditWriter()
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=RecordingPolymarketClient(),
+        operator_gate=FileFirstLiveOrderGate(approval_path),
+        quote_provider=AllowQuoteProvider(),
+        audit_writer=writer,
+    )
+
+    state = await actuator.execute(_decision(), _portfolio())
+
+    assert state.status == OrderStatus.MATCHED.value
+    # Both matched and consumed events must carry the approver_id;
+    # capturing once before consume() unlinks the sidecar guarantees
+    # consumed sees the same approver as matched.
+    assert [
+        (event, approver_id) for event, _, approver_id in writer.events
+    ] == [
+        ("approval_matched", "operator-alice"),
+        ("approval_consumed", "operator-alice"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_polymarket_actuator_audit_approver_id_is_none_when_sidecar_absent(
+    tmp_path: Path,
+) -> None:
+    """Regression: actuator must still emit cleanly when no sidecar
+    exists (the unattributed-but-authorized fallback path)."""
+    approval_path = tmp_path / "approval.json"
+    approval_path.write_text(json.dumps(_approval_payload()), encoding="utf-8")
+
+    writer = RecordingFirstOrderAuditWriter()
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=RecordingPolymarketClient(),
+        operator_gate=FileFirstLiveOrderGate(approval_path),
+        quote_provider=AllowQuoteProvider(),
+        audit_writer=writer,
+    )
+
+    state = await actuator.execute(_decision(), _portfolio())
+
+    assert state.status == OrderStatus.MATCHED.value
+    assert [
+        (event, approver_id) for event, _, approver_id in writer.events
+    ] == [
+        ("approval_matched", None),
+        ("approval_consumed", None),
+    ]

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -2895,6 +2895,69 @@ async def test_polymarket_actuator_audit_includes_approver_id_from_sidecar(
 
 
 @pytest.mark.asyncio
+async def test_polymarket_actuator_emits_consume_failed_when_consume_raises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """STO-10 review-loop f1: when `consume()` raises after a successful
+    submit, the audit log must NOT claim the approval was cleanly
+    consumed — the artifact may still be on disk and could replay on
+    restart. Emit a distinct `approval_consume_failed` event instead so
+    forensic walkers can separate "successfully consumed" from "consumed
+    but cleanup failed", and log at ERROR rather than WARN.
+
+    The fast path (`_approval_state.approved=True`) MUST stay set after
+    submit succeeds — flipping it back would cause the *next* in-process
+    decision to re-prompt the gate and double-submit on the same
+    approval file. The cleanup-failure handling is forensic, not
+    transactional."""
+
+    @dataclass
+    class _ConsumeRaisesGate:
+        consume_error: Exception
+        previews: list[LiveOrderPreview] = field(default_factory=list)
+
+        async def approve_first_order(self, preview: LiveOrderPreview) -> bool:
+            self.previews.append(preview)
+            return True
+
+        async def consume(self, preview: LiveOrderPreview) -> None:
+            del preview
+            raise self.consume_error
+
+    writer = RecordingFirstOrderAuditWriter()
+    gate = _ConsumeRaisesGate(consume_error=OSError("disk full"))
+    actuator = PolymarketActuator(
+        _live_settings(),
+        client=RecordingPolymarketClient(),
+        operator_gate=gate,
+        quote_provider=AllowQuoteProvider(),
+        audit_writer=writer,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="pms.actuator.adapters.polymarket"):
+        state = await actuator.execute(_decision(), _portfolio())
+
+    # Submit succeeded; the in-process fast path must stay open so the
+    # next decision doesn't re-trigger the gate.
+    assert state.status == OrderStatus.MATCHED.value
+    assert actuator._first_order_approved() is True
+
+    # Audit log records the failure honestly, not a clean consume.
+    events = [event for event, _, _ in writer.events]
+    assert events == ["approval_matched", "approval_consume_failed"]
+    assert "approval_consumed" not in events
+
+    # ERROR-level log fires on consume failure (not the previous WARN).
+    assert any(
+        record.levelname == "ERROR" and "consume" in record.message.lower()
+        for record in caplog.records
+    ), (
+        "expected ERROR log on consume failure, got: "
+        f"{[(r.levelname, r.message) for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_polymarket_actuator_audit_approver_id_is_none_when_sidecar_absent(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -2727,7 +2727,7 @@ async def test_polymarket_actuator_audit_writer_failure_does_not_break_submit(
 ) -> None:
     """STO-10 cp-02: an audit-writer failure must NOT block the submit
     or leave the gate in an inconsistent state. Audit failure logs WARN
-    and the order proceeds. Mirrors precedent at runner.py:1307-1308 where
+    and the order proceeds. Mirrors precedent at runner.py:1319-1320 where
     LiveEmergencyAuditWriter failures degrade gracefully rather than
     interrupting the trading hot path."""
     writer = RecordingFirstOrderAuditWriter(raise_on_event="approval_matched")

--- a/tests/unit/test_approve_first_order_script.py
+++ b/tests/unit/test_approve_first_order_script.py
@@ -4,7 +4,7 @@ The script's job is to take an `OperatorApprovalRequiredError` message
 (or explicit fields) and write the approval JSON + sidecar metadata file
 correctly so the gate matches on the next decision. Mismatches between
 what the operator types and what `_approval_payload_matches` expects
-(`src/pms/actuator/adapters/polymarket.py:976-998`) would silently fail
+(`src/pms/actuator/adapters/polymarket.py:1122-1144`) would silently fail
 the gate; centralising the write in one tested helper prevents that.
 """
 

--- a/tests/unit/test_approve_first_order_script.py
+++ b/tests/unit/test_approve_first_order_script.py
@@ -1,0 +1,260 @@
+"""Unit tests for the operator helper at scripts/approve_first_order.py.
+
+The script's job is to take an `OperatorApprovalRequiredError` message
+(or explicit fields) and write the approval JSON + sidecar metadata file
+correctly so the gate matches on the next decision. Mismatches between
+what the operator types and what `_approval_payload_matches` expects
+(`src/pms/actuator/adapters/polymarket.py:976-998`) would silently fail
+the gate; centralising the write in one tested helper prevents that.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.approve_first_order import (
+    ApprovalPreview,
+    main,
+    parse_preview_from_error,
+    write_approval,
+)
+
+
+_GOLDEN_ERROR_MESSAGE = (
+    "First Polymarket live order requires operator approval: "
+    "venue=polymarket market=m-0x123 token=t-yes-0x456 side=BUY "
+    "outcome=YES max_notional_usdc=5.0 limit_price=0.4 "
+    "max_slippage_bps=50"
+)
+
+
+def test_parse_preview_extracts_all_fields() -> None:
+    """Golden path: the helper must round-trip every field that
+    `_approval_payload_matches` checks. A missing field would cause the
+    gate to silently reject."""
+    preview = parse_preview_from_error(_GOLDEN_ERROR_MESSAGE)
+
+    assert preview.venue == "polymarket"
+    assert preview.market_id == "m-0x123"
+    assert preview.token_id == "t-yes-0x456"
+    assert preview.side == "BUY"
+    assert preview.outcome == "YES"
+    assert preview.max_notional_usdc == 5.0
+    assert preview.limit_price == 0.4
+    assert preview.max_slippage_bps == 50
+
+
+def test_parse_preview_handles_none_token() -> None:
+    """LiveOrderPreview.token_id is `str | None`. When None, the
+    f-string emits `token=None` — the helper must round-trip that as
+    Python None so the JSON contains `"token_id": null` (which the
+    gate's exact-equality check handles correctly)."""
+    message = _GOLDEN_ERROR_MESSAGE.replace("token=t-yes-0x456", "token=None")
+
+    preview = parse_preview_from_error(message)
+
+    assert preview.token_id is None
+
+
+def test_parse_preview_rejects_malformed_input() -> None:
+    """Malformed input must raise rather than silently produce a
+    partial preview (which would cause a confusing gate mismatch)."""
+    with pytest.raises(ValueError, match="venue"):
+        parse_preview_from_error("not an error message at all")
+
+    with pytest.raises(ValueError, match="max_notional_usdc"):
+        parse_preview_from_error(
+            "First Polymarket live order requires operator approval: "
+            "venue=polymarket market=m side=BUY outcome=YES "
+            "limit_price=0.4 max_slippage_bps=50"
+        )
+
+
+def test_write_approval_creates_both_files(tmp_path: Path) -> None:
+    """Helper must write the approval JSON and the
+    `<path>.meta.json` sidecar in lockstep, so the gate's match and
+    the audit's approver_id capture succeed together."""
+    preview = ApprovalPreview(
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side="BUY",
+        outcome="YES",
+        max_notional_usdc=10.0,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+    approval_path = tmp_path / "first-order.json"
+    ts = datetime(2026, 5, 7, 12, 0, tzinfo=UTC)
+
+    written_approval, written_sidecar = write_approval(
+        preview,
+        path=approval_path,
+        approver_id="operator-alice",
+        ts=ts,
+    )
+
+    assert written_approval == approval_path
+    assert written_sidecar == Path(str(approval_path) + ".meta.json")
+
+    payload = json.loads(approval_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "approved": True,
+        "venue": "polymarket",
+        "market_id": "m-cp06",
+        "token_id": "t-yes",
+        "side": "BUY",
+        "outcome": "YES",
+        "max_notional_usdc": 10.0,
+        "limit_price": 0.4,
+        "max_slippage_bps": 50,
+    }
+
+    sidecar_payload = json.loads(written_sidecar.read_text(encoding="utf-8"))
+    assert sidecar_payload == {
+        "approver_id": "operator-alice",
+        "ts": "2026-05-07T12:00:00+00:00",
+    }
+
+
+def test_write_approval_creates_parent_directory(tmp_path: Path) -> None:
+    """The configured approval path may include directories that don't
+    yet exist (e.g. /data/pms/first-order.json on a fresh Fly volume).
+    Mirrors LiveEmergencyAuditWriter parent-dir creation behaviour."""
+    preview = ApprovalPreview(
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side="BUY",
+        outcome="YES",
+        max_notional_usdc=10.0,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+
+    write_approval(
+        preview,
+        path=tmp_path / "fresh" / "subdir" / "first-order.json",
+        approver_id="op-a",
+        ts=datetime.now(tz=UTC),
+    )
+
+    assert (tmp_path / "fresh" / "subdir" / "first-order.json").exists()
+
+
+def test_write_approval_files_have_owner_only_permissions(tmp_path: Path) -> None:
+    """STO-10 security: the runbook requires umask 077 on the approval
+    file so only the runner UID can read. Helper enforces this."""
+    preview = ApprovalPreview(
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side="BUY",
+        outcome="YES",
+        max_notional_usdc=10.0,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+
+    approval_path = tmp_path / "first-order.json"
+    written_approval, written_sidecar = write_approval(
+        preview,
+        path=approval_path,
+        approver_id="op-a",
+        ts=datetime.now(tz=UTC),
+    )
+
+    approval_mode = stat.S_IMODE(written_approval.stat().st_mode)
+    sidecar_mode = stat.S_IMODE(written_sidecar.stat().st_mode)
+    assert approval_mode == 0o600, f"approval mode is 0o{approval_mode:o}, want 0o600"
+    assert sidecar_mode == 0o600, f"sidecar mode is 0o{sidecar_mode:o}, want 0o600"
+
+
+def test_write_approval_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    """Safety: if an approval file already exists, the helper must
+    refuse to overwrite without --force. Otherwise an operator could
+    accidentally clobber a still-pending authorization."""
+    preview = ApprovalPreview(
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side="BUY",
+        outcome="YES",
+        max_notional_usdc=10.0,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+    approval_path = tmp_path / "first-order.json"
+    approval_path.write_text("pre-existing", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        write_approval(
+            preview,
+            path=approval_path,
+            approver_id="op-a",
+            ts=datetime.now(tz=UTC),
+        )
+
+    # Pre-existing content must be untouched.
+    assert approval_path.read_text(encoding="utf-8") == "pre-existing"
+
+
+def test_write_approval_force_overwrites(tmp_path: Path) -> None:
+    preview = ApprovalPreview(
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side="BUY",
+        outcome="YES",
+        max_notional_usdc=10.0,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+    approval_path = tmp_path / "first-order.json"
+    approval_path.write_text("pre-existing", encoding="utf-8")
+
+    write_approval(
+        preview,
+        path=approval_path,
+        approver_id="op-a",
+        ts=datetime.now(tz=UTC),
+        force=True,
+    )
+
+    payload = json.loads(approval_path.read_text(encoding="utf-8"))
+    assert payload["approved"] is True
+
+
+def test_main_end_to_end(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """End-to-end: pass an error message and an approver-id; assert
+    both files appear with the right shape. The operator's actual
+    invocation path."""
+    approval_path = tmp_path / "first-order.json"
+
+    exit_code = main(
+        [
+            "--from-error",
+            _GOLDEN_ERROR_MESSAGE,
+            "--approver-id",
+            "operator-alice",
+            "--path",
+            str(approval_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert approval_path.exists()
+    assert (Path(str(approval_path) + ".meta.json")).exists()
+
+    stdout = capsys.readouterr().out
+    assert str(approval_path) in stdout
+    assert "operator-alice" in stdout
+
+    payload = json.loads(approval_path.read_text(encoding="utf-8"))
+    assert payload["market_id"] == "m-0x123"
+    assert payload["token_id"] == "t-yes-0x456"

--- a/tests/unit/test_approve_first_order_script.py
+++ b/tests/unit/test_approve_first_order_script.py
@@ -10,6 +10,7 @@ the gate; centralising the write in one tested helper prevents that.
 
 from __future__ import annotations
 
+import importlib
 import json
 import stat
 from datetime import UTC, datetime
@@ -228,6 +229,96 @@ def test_write_approval_force_overwrites(tmp_path: Path) -> None:
 
     payload = json.loads(approval_path.read_text(encoding="utf-8"))
     assert payload["approved"] is True
+
+
+def test_write_approval_writes_sidecar_before_approval_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """STO-10 review-loop f2: the actuator's gate matches on the
+    approval JSON; if the JSON appears before the sidecar, a running
+    actuator can match and submit while `read_approver_id` returns
+    None — the audit log would record a real authorization with
+    `approver_id: null`. Writing the sidecar first closes that race."""
+    write_order: list[str] = []
+    real_write = importlib.import_module("scripts.approve_first_order")._write_secret_file
+
+    def _tracking_write(target_path: Path, content: str) -> None:
+        write_order.append(target_path.name)
+        real_write(target_path, content)
+
+    monkeypatch.setattr(
+        "scripts.approve_first_order._write_secret_file", _tracking_write
+    )
+
+    preview = ApprovalPreview(
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side="BUY",
+        outcome="YES",
+        max_notional_usdc=10.0,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+    approval_path = tmp_path / "first-order.json"
+
+    write_approval(
+        preview,
+        path=approval_path,
+        approver_id="op-a",
+        ts=datetime.now(tz=UTC),
+    )
+
+    assert write_order == [
+        "first-order.json.meta.json",
+        "first-order.json",
+    ], (
+        "sidecar must be written before the approval JSON so the gate "
+        f"never sees the approval before the operator identity is on disk; "
+        f"actual order: {write_order}"
+    )
+
+
+def test_write_approval_does_not_publish_approval_when_sidecar_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If sidecar writing raises, the approval JSON must NOT exist on
+    disk afterwards — otherwise an actuator could match a half-armed
+    authorization with no operator identity recorded."""
+    real_write = importlib.import_module("scripts.approve_first_order")._write_secret_file
+
+    def _failing_sidecar_write(target_path: Path, content: str) -> None:
+        if target_path.name.endswith(".meta.json"):
+            raise OSError("simulated sidecar write failure")
+        real_write(target_path, content)
+
+    monkeypatch.setattr(
+        "scripts.approve_first_order._write_secret_file", _failing_sidecar_write
+    )
+
+    preview = ApprovalPreview(
+        venue="polymarket",
+        market_id="m-cp06",
+        token_id="t-yes",
+        side="BUY",
+        outcome="YES",
+        max_notional_usdc=10.0,
+        limit_price=0.4,
+        max_slippage_bps=50,
+    )
+    approval_path = tmp_path / "first-order.json"
+
+    with pytest.raises(OSError, match="simulated sidecar write failure"):
+        write_approval(
+            preview,
+            path=approval_path,
+            approver_id="op-a",
+            ts=datetime.now(tz=UTC),
+        )
+
+    assert not approval_path.exists(), (
+        "approval JSON must not exist when sidecar write failed first"
+    )
 
 
 def test_main_end_to_end(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_first_order_audit.py
+++ b/tests/unit/test_first_order_audit.py
@@ -50,7 +50,7 @@ async def test_jsonl_first_order_audit_writer_appends_one_record_per_event(
     assert record_consumed["event"] == "approval_consumed"
 
     # Match-keys (the same fields _approval_payload_matches checks
-    # at polymarket.py around 976-998).
+    # at polymarket.py:1122-1144).
     assert record_matched["venue"] == "polymarket"
     assert record_matched["market_id"] == "m-x"
     assert record_matched["token_id"] == "t-yes"

--- a/tests/unit/test_first_order_audit.py
+++ b/tests/unit/test_first_order_audit.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pms.actuator.adapters.polymarket import LiveOrderPreview
+from pms.core.enums import Side
+from pms.storage.first_order_audit import JsonlFirstOrderAuditWriter
+
+
+def _preview() -> LiveOrderPreview:
+    return LiveOrderPreview(
+        max_notional_usdc=10.0,
+        venue="polymarket",
+        market_id="m-x",
+        token_id="t-yes",
+        side=Side.BUY.value,
+        limit_price=0.4,
+        max_slippage_bps=50,
+        outcome="YES",
+    )
+
+
+@pytest.mark.asyncio
+async def test_jsonl_first_order_audit_writer_appends_one_record_per_event(
+    tmp_path: Path,
+) -> None:
+    """STO-10 cp-02: each call to record_event appends exactly one
+    JSONL line, in call order, with the preview's match-keys captured
+    so a forensic walker can compare an event back to the gate."""
+    audit_path = tmp_path / "audit.jsonl"
+    writer = JsonlFirstOrderAuditWriter(audit_path)
+
+    await writer.record_event(
+        event="approval_matched", preview=_preview(), approver_id="op-a"
+    )
+    await writer.record_event(
+        event="approval_consumed", preview=_preview(), approver_id="op-a"
+    )
+
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+
+    record_matched = json.loads(lines[0])
+    record_consumed = json.loads(lines[1])
+
+    assert record_matched["event"] == "approval_matched"
+    assert record_consumed["event"] == "approval_consumed"
+
+    # Match-keys (the same fields _approval_payload_matches checks
+    # at polymarket.py around 976-998).
+    assert record_matched["venue"] == "polymarket"
+    assert record_matched["market_id"] == "m-x"
+    assert record_matched["token_id"] == "t-yes"
+    assert record_matched["side"] == "BUY"
+    assert record_matched["outcome"] == "YES"
+    assert record_matched["max_notional_usdc"] == 10.0
+    assert record_matched["limit_price"] == 0.4
+    assert record_matched["max_slippage_bps"] == 50
+    assert record_matched["approver_id"] == "op-a"
+    assert "ts" in record_matched and record_matched["ts"].endswith("+00:00")
+
+
+@pytest.mark.asyncio
+async def test_jsonl_first_order_audit_writer_creates_parent_directory(
+    tmp_path: Path,
+) -> None:
+    """STO-10 cp-02: the writer must create missing parent dirs (matching
+    LiveEmergencyAuditWriter behaviour at live_emergency_audit.py:75)."""
+    audit_path = tmp_path / "deep" / "nested" / "audit.jsonl"
+    writer = JsonlFirstOrderAuditWriter(audit_path)
+
+    await writer.record_event(event="approval_matched", preview=_preview())
+
+    assert audit_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_jsonl_first_order_audit_writer_handles_missing_approver_id(
+    tmp_path: Path,
+) -> None:
+    """approver_id is optional — if not supplied, the JSONL record must
+    include the field as null so downstream readers can rely on schema
+    stability."""
+    audit_path = tmp_path / "audit.jsonl"
+    writer = JsonlFirstOrderAuditWriter(audit_path)
+
+    await writer.record_event(event="approval_denied", preview=_preview())
+
+    record = json.loads(audit_path.read_text(encoding="utf-8").splitlines()[0])
+    assert record["approver_id"] is None

--- a/tests/unit/test_live_trading_blockers.py
+++ b/tests/unit/test_live_trading_blockers.py
@@ -250,7 +250,11 @@ def test_posterior_branch_missing_all_inputs_does_not_emit_statistical_probabili
     assert "statistical" not in branch_probabilities
 
 
-def _live_settings(*, tif: str = "IOC", secret_source: str | None = "fly") -> PMSSettings:
+def _live_settings(
+    *,
+    tif: str = "IOC",
+    secret_source: Literal["fly", "local_file"] | None = "fly",
+) -> PMSSettings:
     return PMSSettings(
         mode=RunMode.LIVE,
         live_trading_enabled=True,

--- a/tests/unit/test_rehearse_first_order_script.py
+++ b/tests/unit/test_rehearse_first_order_script.py
@@ -1,0 +1,140 @@
+"""Tests for the cp-03 first-live-order rehearsal driver at
+scripts/rehearse_first_order.py.
+
+The rehearsal exercises the real `PolymarketActuator` slow path with a
+real `FileFirstLiveOrderGate` + real `JsonlFirstOrderAuditWriter`, so
+it doubles as a deployment smoke test: a successful run on the Fly
+machine proves the volume is mounted, the env var resolves to a
+writable path, and the audit pipeline emits the expected sequence.
+
+Test split:
+
+* Async tests exercise `run_rehearsal()` end to end through the real
+  actuator. These are the load-bearing assertions.
+* Sync tests exercise `report_result()` — the pure print-and-exit-code
+  helper that `main()` delegates to. Splitting `main()` this way lets
+  us test the operator-facing behaviour without invoking
+  `asyncio.run()` from a sync test (which tangles with pytest's
+  session loop and the project's `filterwarnings = ["error"]`).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.rehearse_first_order import RehearsalResult, report_result, run_rehearsal
+
+
+@pytest.mark.asyncio
+async def test_run_rehearsal_passes_with_correct_audit_sequence(
+    tmp_path: Path,
+) -> None:
+    """The full happy path: gate denies once, operator files approval,
+    gate matches, submit succeeds, consume runs, audit log records
+    `approval_denied → approval_matched → approval_consumed`."""
+    result = await run_rehearsal(workdir=tmp_path, approver_id="rehearsal-op")
+
+    assert result.passed, f"rehearsal failed: {result.failure_reason}"
+    assert result.events == [
+        "approval_denied",
+        "approval_matched",
+        "approval_consumed",
+    ]
+    assert result.failure_reason is None
+
+
+@pytest.mark.asyncio
+async def test_run_rehearsal_writes_audit_jsonl_with_approver(
+    tmp_path: Path,
+) -> None:
+    """STO-10 cp-02 + sidecar end-to-end: the audit JSONL the rehearsal
+    leaves on disk must record `approver_id` for the matched and
+    consumed events (denied has no approver yet — the file isn't filed
+    until step 2)."""
+    result = await run_rehearsal(workdir=tmp_path, approver_id="rehearsal-op")
+
+    assert result.passed
+    lines = result.audit_path.read_text(encoding="utf-8").splitlines()
+    records = [json.loads(line) for line in lines]
+
+    by_event = {record["event"]: record for record in records}
+    assert by_event["approval_denied"]["approver_id"] is None
+    assert by_event["approval_matched"]["approver_id"] == "rehearsal-op"
+    assert by_event["approval_consumed"]["approver_id"] == "rehearsal-op"
+
+
+@pytest.mark.asyncio
+async def test_run_rehearsal_unlinks_both_approval_files_on_consume(
+    tmp_path: Path,
+) -> None:
+    """After consume the approval JSON and the sidecar must both be
+    gone — verifies the cp-02 sidecar-cleanup change end to end."""
+    result = await run_rehearsal(workdir=tmp_path, approver_id="rehearsal-op")
+
+    assert result.passed
+    assert not result.approval_path.exists()
+    assert not (Path(str(result.approval_path) + ".meta.json")).exists()
+
+
+def test_report_result_returns_zero_and_prints_pass_on_success(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """report_result is the operator-facing summary — PASS path prints
+    the audit log location so the operator can `cat` it."""
+    audit_path = tmp_path / "audit.jsonl"
+    approval_path = tmp_path / "first-order.json"
+    result = RehearsalResult(
+        passed=True,
+        events=["approval_denied", "approval_matched", "approval_consumed"],
+        audit_path=audit_path,
+        approval_path=approval_path,
+        failure_reason=None,
+    )
+
+    exit_code = report_result(result)
+
+    stdout = capsys.readouterr().out
+    assert exit_code == 0
+    assert "PASS" in stdout
+    assert str(audit_path) in stdout
+
+
+def test_report_result_returns_one_and_surfaces_reason_on_failure(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """FAIL path returns nonzero and surfaces the failure reason so an
+    operator (or a deploy-time gate) can act on it."""
+    result = RehearsalResult(
+        passed=False,
+        events=["approval_denied"],
+        audit_path=tmp_path / "audit.jsonl",
+        approval_path=tmp_path / "first-order.json",
+        failure_reason="audit events were ['approval_denied'], expected …",
+    )
+
+    exit_code = report_result(result)
+
+    stdout = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL" in stdout
+    assert "audit events were" in stdout
+
+
+def test_rehearsal_result_dataclass_is_frozen() -> None:
+    """STO-10: result-bearing value objects are frozen dataclasses
+    (project convention; see CLAUDE.md). Prevents accidental post-hoc
+    mutation of an audit-bearing record."""
+    result = RehearsalResult(
+        passed=True,
+        events=["approval_matched"],
+        audit_path=Path("/tmp/audit.jsonl"),
+        approval_path=Path("/tmp/approval.json"),
+        failure_reason=None,
+    )
+
+    with pytest.raises(Exception):
+        # frozen dataclass blocks attribute assignment
+        result.passed = False  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Closes the operational gap on the existing fail-closed first-live-order gate ([STO-10](https://multica.ai/i/fcb7d9dd-5630-4077-823f-1250622a53d6)). The code gate at `src/pms/actuator/adapters/polymarket.py:584-660` was already in place; this PR adds the human-side workflow (named operators, secret-managed approval-file location, audit trail, "first" semantics) and a JSONL audit log for every gate consultation.
- New audit emission for `approval_matched`, `approval_denied`, `approval_consumed` events from the actuator's slow path. Records land in `live_emergency_audit_path` JSONL alongside the emergency-halt records (single consolidated authorization log; readers filter by the `event` vs `phase` field).
- New `FileFirstLiveOrderGate.read_approver_id()` parses a `<approval-path>.meta.json` sidecar so the audit captures who authorized each order. `consume()` now unlinks the sidecar alongside the approval JSON to keep authorization-artifact lifetime symmetric.
- Runbook gets a "Pre-launch Operator Checklist (STO-10)" with concrete `fly secrets set` commands, `fly volumes create` for the approval-file path, and a copy-paste cp-03 rehearsal script. Two `__FILL_IN__` markers remain for the genuinely human-only fields (primary + backup operator names).

## Test plan

- [x] `uv run pytest -q` — 1116 passed, 163 skipped (no regression vs. baseline)
- [x] `uv run pytest tests/unit/test_actuator_cp06.py tests/unit/test_first_order_audit.py -q` — 79 passed (including 9 new STO-10 tests covering matched/denied/consumed emit, writer-failure-degrades-gracefully, sidecar present/absent/malformed, consume unlinks both files, end-to-end approver_id flow)
- [x] `uv run mypy src/ tests/ --strict` — clean, 397 source files (+2)
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Operator runs the cp-03 rehearsal end to end before the first live launch (per runbook step 6)

## Spec deviation note

The spec used `approval_filed` for the gate-matched event, conflating an operator-side action ("file written") with an actuator-side observation ("gate matched"). Renamed to `approval_matched` for honesty. Rationale captured in the cp-02 commit body. A separate operator-tooling event for "filed" can be added later if `scripts/approve_first_order.py` (next follow-up) wants to record file-write time in the audit log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator approval workflow for the first live order with persisted audit events (denied, matched, consumed)
  * CLI helper to create/approve first-order files and an end-to-end rehearsal script to validate the approval flow

* **Documentation**
  * Comprehensive pre-launch operator checklist and playbook detailing setup, approval steps, alerting, SLA guidance, and expected audit outcomes

* **Tests**
  * Added unit and integration tests covering approval parsing, file/sidecar behavior, audit writing, and rehearsal scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->