### PR TITLE
fix: align live blocker secret source helper type

### DIFF
--- a/tests/unit/test_live_trading_blockers.py
+++ b/tests/unit/test_live_trading_blockers.py
@@ -22,6 +22,7 @@ from pms.config import (
     PMSSettings,
     PolymarketSettings,
     RiskSettings,
+    SecretSource,
     validate_live_mode_ready,
 )
 from pms.controller.calibrators.netcal import NetcalCalibrator
@@ -253,7 +254,7 @@ def test_posterior_branch_missing_all_inputs_does_not_emit_statistical_probabili
 def _live_settings(
     *,
     tif: str = "IOC",
-    secret_source: Literal["fly", "local_file"] | None = "fly",
+    secret_source: SecretSource | None = "fly",
 ) -> PMSSettings:
     return PMSSettings(
         mode=RunMode.LIVE,


### PR DESCRIPTION
## Summary
- Fixes the post-merge PR #65 strict mypy failure by typing the live-blocker test helper `secret_source` parameter as `SecretSource | None`.
- Keeps the test helper aligned with `PMSSettings.secret_source` (`Literal["fly", "local_file"] | None`) instead of broad `str | None`.

## Verification
- `uv run mypy tests/unit/test_live_trading_blockers.py --strict`
- `uv run pytest tests/unit/test_live_trading_blockers.py -q`
- `uv run mypy src/ tests/ --strict`
- `uv run ruff check tests/unit/test_live_trading_blockers.py`
- `git diff --check`

## Context
- Repairs task #52 / post-merge PR #65 red CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced type safety in live-mode configuration tests to improve test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->