### PR TITLE
fix(factors): keep factor service alive after compute errors

### DIFF
--- a/src/pms/factors/definitions/anchoring_lag_divergence.py
+++ b/src/pms/factors/definitions/anchoring_lag_divergence.py
@@ -48,7 +48,6 @@ class AnchoringLagDivergence(FactorDefinition):
     ) -> FactorValueRow | None:
         del outer_ring
 
-        yes_price = _require_open_probability(signal.yes_price, "yes_price")
         if (
             "llm_posterior" not in signal.external_signal
             or "news_timestamp" not in signal.external_signal
@@ -56,6 +55,7 @@ class AnchoringLagDivergence(FactorDefinition):
             or signal.external_signal["news_timestamp"] is None
         ):
             return None
+        yes_price = _require_open_probability(signal.yes_price, "yes_price")
         llm_posterior = _require_open_probability(
             signal.external_signal.get("llm_posterior"),
             "llm_posterior",

--- a/src/pms/factors/service.py
+++ b/src/pms/factors/service.py
@@ -77,10 +77,14 @@ class FactorService:
                     await self.compute_once(list(self._latest_signals.values()))
                 if self._stream_exhausted:
                     self._raise_stream_error(stream_task)
+                    logger.warning("factor signal stream exhausted; factor service exiting")
                     return
                 await asyncio.sleep(self.cadence_s)
         except asyncio.CancelledError:
             logger.info("factor service cancelled")
+            raise
+        except Exception:
+            logger.exception("factor service failed")
             raise
         finally:
             if not stream_task.done():
@@ -92,7 +96,16 @@ class FactorService:
         for signal in signals:
             await self._ensure_market_shell(signal)
             for factor_cls in self.factors:
-                row = factor_cls().compute(signal, self.store)
+                try:
+                    row = factor_cls().compute(signal, self.store)
+                except Exception:
+                    logger.exception(
+                        "factor compute failed factor_id=%s market_id=%s ts=%s",
+                        factor_cls.factor_id,
+                        signal.market_id,
+                        signal.timestamp.isoformat(),
+                    )
+                    continue
                 if row is None:
                     continue
                 dedupe_key = (row.factor_id, row.market_id, row.param)

--- a/src/pms/factors/service.py
+++ b/src/pms/factors/service.py
@@ -96,6 +96,10 @@ class FactorService:
         for signal in signals:
             await self._ensure_market_shell(signal)
             for factor_cls in self.factors:
+                if _requires_open_yes_price(factor_cls) and not _has_open_yes_price(
+                    signal
+                ):
+                    continue
                 try:
                     row = factor_cls().compute(signal, self.store)
                 except Exception:
@@ -201,3 +205,12 @@ def _is_constraint_violation(
 ) -> bool:
     actual_constraint = getattr(exc, "constraint_name", None)
     return actual_constraint == constraint_name or constraint_name in str(exc)
+
+
+def _requires_open_yes_price(factor_cls: type[FactorDefinition]) -> bool:
+    return "yes_price" in factor_cls.required_inputs
+
+
+def _has_open_yes_price(signal: MarketSignal) -> bool:
+    yes_price = signal.yes_price
+    return 0.0 < yes_price < 1.0 and yes_price == yes_price

--- a/tests/unit/test_anchoring_lag_factor.py
+++ b/tests/unit/test_anchoring_lag_factor.py
@@ -99,6 +99,13 @@ def test_anchoring_lag_factor_returns_none_when_llm_news_inputs_are_absent() -> 
     assert AnchoringLagDivergence().compute(signal, EMPTY_OUTER_RING) is None
 
 
+def test_anchoring_lag_factor_ignores_book_signal_without_llm_news_inputs() -> None:
+    signal = _signal(yes_price=0.0)
+    signal.external_signal.clear()
+
+    assert AnchoringLagDivergence().compute(signal, EMPTY_OUTER_RING) is None
+
+
 def test_anchoring_lag_factor_returns_none_for_null_llm_news_inputs() -> None:
     signal = _signal()
     signal.external_signal["llm_posterior"] = None

--- a/tests/unit/test_factor_service.py
+++ b/tests/unit/test_factor_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+import logging
 from typing import Any, cast
 
 import pytest
@@ -88,6 +89,19 @@ class MissingFactor(FactorDefinition):
         return None
 
 
+class ExplodingFactor(FactorDefinition):
+    factor_id = "exploding_factor"
+    required_inputs = ("yes_price",)
+
+    def compute(
+        self,
+        signal: MarketSignal,
+        outer_ring: object,
+    ) -> FactorValueRow | None:
+        del signal, outer_ring
+        raise ValueError("factor exploded")
+
+
 @pytest.mark.asyncio
 async def test_factor_service_compute_once_persists_non_none_rows(
     monkeypatch: pytest.MonkeyPatch,
@@ -121,6 +135,35 @@ async def test_factor_service_compute_once_persists_non_none_rows(
         )
     ]
     assert "factor-service-market" in store.markets
+
+
+@pytest.mark.asyncio
+async def test_factor_service_compute_once_continues_after_factor_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    persisted: list[FactorValueRow] = []
+
+    async def fake_persist(pool: object, row: FactorValueRow) -> None:
+        del pool
+        persisted.append(row)
+
+    monkeypatch.setattr("pms.factors.service.persist_factor_value", fake_persist)
+    service = FactorService(
+        pool=cast(Any, object()),
+        store=cast(Any, FakeStore()),
+        cadence_s=0.1,
+        factors=(ExplodingFactor, PersistedFactor),
+        signal_stream=SequenceSignalStream([]),
+    )
+
+    with caplog.at_level(logging.ERROR, logger="pms.factors.service"):
+        count = await service.compute_once([_signal(market_id="survives-factor-error")])
+
+    assert count == 1
+    assert [row.market_id for row in persisted] == ["survives-factor-error"]
+    assert "factor compute failed" in caplog.text
+    assert "exploding_factor" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_factor_service.py
+++ b/tests/unit/test_factor_service.py
@@ -15,13 +15,17 @@ from pms.factors.service import FactorService
 from pms.sensor.stream import SensorStream
 
 
-def _signal(*, market_id: str = "factor-service-market") -> MarketSignal:
+def _signal(
+    *,
+    market_id: str = "factor-service-market",
+    yes_price: float = 0.4,
+) -> MarketSignal:
     return MarketSignal(
         market_id=market_id,
         token_id="yes-token",
         venue="polymarket",
         title="Will FactorService persist factors?",
-        yes_price=0.4,
+        yes_price=yes_price,
         volume_24h=1000.0,
         resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
         orderbook={
@@ -87,6 +91,25 @@ class MissingFactor(FactorDefinition):
     ) -> FactorValueRow | None:
         del signal, outer_ring
         return None
+
+
+class OrderbookOnlyFactor(FactorDefinition):
+    factor_id = "orderbook_only_factor"
+    required_inputs = ("orderbook",)
+
+    def compute(
+        self,
+        signal: MarketSignal,
+        outer_ring: object,
+    ) -> FactorValueRow | None:
+        del outer_ring
+        return FactorValueRow(
+            factor_id=self.factor_id,
+            param="",
+            market_id=signal.market_id,
+            ts=signal.timestamp,
+            value=float(len(signal.orderbook.get("bids", []))),
+        )
 
 
 class ExplodingFactor(FactorDefinition):
@@ -164,6 +187,35 @@ async def test_factor_service_compute_once_continues_after_factor_error(
     assert [row.market_id for row in persisted] == ["survives-factor-error"]
     assert "factor compute failed" in caplog.text
     assert "exploding_factor" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_factor_service_skips_yes_price_factors_for_sentinel_book_signals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persisted: list[FactorValueRow] = []
+
+    async def fake_persist(pool: object, row: FactorValueRow) -> None:
+        del pool
+        persisted.append(row)
+
+    monkeypatch.setattr("pms.factors.service.persist_factor_value", fake_persist)
+    service = FactorService(
+        pool=cast(Any, object()),
+        store=cast(Any, FakeStore()),
+        cadence_s=0.1,
+        factors=(PersistedFactor, OrderbookOnlyFactor),
+        signal_stream=SequenceSignalStream([]),
+    )
+
+    count = await service.compute_once(
+        [_signal(market_id="sentinel-book-signal", yes_price=0.0)]
+    )
+
+    assert count == 1
+    assert [(row.factor_id, row.market_id) for row in persisted] == [
+        ("orderbook_only_factor", "sentinel-book-signal")
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Return `None` from `AnchoringLagDivergence` before price validation when LLM/news inputs are absent, so book-style market-data signals with `yes_price=0.0` do not crash factor computation.
- Log and skip per-factor compute exceptions in `FactorService.compute_once()` instead of letting one factor kill the service task.
- Add regressions for missing H2 inputs on book signals and FactorService survival after a factor exception.

## Root Cause
`MarketDataSensor` can emit book signals without a usable last-trade price, producing `yes_price=0.0`. `AnchoringLagDivergence` validated `yes_price` before checking whether its own LLM/news inputs existed, raising `ValueError`. Since `FactorService` did not isolate factor compute exceptions, that single exception ended the background task while the rest of the runner kept reporting healthy.

## Validation
- `uv run pytest -q tests/unit/test_anchoring_lag_factor.py tests/unit/test_factor_service.py`
- `uv run pytest -q`
- `uv run mypy src/ tests/ --strict`
- `git diff --check`
- Restarted `pms-soak`; verified fresh `factor_values` rows continued past the original failure window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in factor computation to continue processing remaining factors when individual computations fail, with detailed error logging.
  * Added signal stream exhaustion detection with appropriate warning notification.

* **Tests**
  * Added unit tests to verify robust error handling and edge case coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->