### PR TITLE
fix(storage): cooldown + persist toggles + history pruning to slash DB bloat

### DIFF
--- a/config.live-soak.yaml
+++ b/config.live-soak.yaml
@@ -18,11 +18,16 @@ risk:
 
 sensor:
   poll_interval_s: 5.0
+  max_reconnect_interval_s: 60.0
+  max_subscription_asset_ids: 100
+  persist_discovery_price_snapshots: false
+  persist_price_changes: false
 
 controller:
   min_volume: 0.0
   max_slippage_bps: 50
   time_in_force: IOC
+  decision_cooldown_s: 60.0
   max_book_age_ms: 1000.0
   allowed_book_clock_skew_ms: 250.0
   max_spread_bps: 100.0

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -48,6 +48,11 @@ controller:
   direct_quote_min_notional_usdc: 100.0
   dual_quote_max_price_delta_bps: 25.0
 
+database:
+  pool_min_size: 2
+  pool_max_size: 10
+  expired_decision_retention_s: 86400.0
+
 polymarket:
   host: https://clob.polymarket.com
   websocket_url: wss://ws-subscriptions-clob.polymarket.com/ws/

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -28,11 +28,18 @@ risk:
 
 sensor:
   poll_interval_s: 5.0
+  max_reconnect_interval_s: 60.0
+  max_subscription_asset_ids: 100
+  # Keep high-volume scan/delta history out of Postgres by default. Enable
+  # these only for a bounded research-capture window.
+  persist_discovery_price_snapshots: false
+  persist_price_changes: false
 
 controller:
   min_volume: 0.0
   max_slippage_bps: 50
   time_in_force: GTC
+  decision_cooldown_s: 60.0
   max_book_age_ms: 1000.0
   allowed_book_clock_skew_ms: 250.0
   max_spread_bps: 100.0

--- a/scripts/prune_market_history.py
+++ b/scripts/prune_market_history.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import timedelta
+import sys
+
+import asyncpg
+
+from pms.config import PMSSettings
+from pms.storage.maintenance import (
+    MarketHistoryPrunePolicy,
+    apply_market_history_prune_plan,
+    build_market_history_prune_plan,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prune high-volume market history tables. Dry-run by default; "
+            "pass --execute to apply the SQL."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="PMS YAML config path. Defaults to config.yaml.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually run the cleanup plan. Without this, only prints SQL.",
+    )
+    parser.add_argument(
+        "--keep-price-changes-days",
+        type=float,
+        default=7.0,
+        help="Retention window for price_changes. Defaults to 7 days.",
+    )
+    parser.add_argument(
+        "--no-truncate-market-price-snapshots",
+        action="store_true",
+        help="Keep market_price_snapshots instead of truncating it.",
+    )
+    parser.add_argument(
+        "--no-vacuum-full",
+        action="store_true",
+        help="Skip VACUUM FULL statements.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    settings = PMSSettings.load(args.config)
+    plan = build_market_history_prune_plan(
+        MarketHistoryPrunePolicy(
+            truncate_market_price_snapshots=(
+                not args.no_truncate_market_price_snapshots
+            ),
+            price_changes_retention=timedelta(
+                days=float(args.keep_price_changes_days)
+            ),
+            vacuum_full=not args.no_vacuum_full,
+        )
+    )
+
+    for statement in plan:
+        print(f"-- {statement.description}", file=sys.stdout)
+        print(statement.sql + ";", file=sys.stdout)
+        if statement.args:
+            print(f"-- args: {statement.args!r}", file=sys.stdout)
+
+    if not args.execute:
+        print("-- dry-run only; pass --execute to apply", file=sys.stdout)
+        return 0
+
+    pool = await asyncpg.create_pool(
+        settings.database.dsn,
+        min_size=settings.database.pool_min_size,
+        max_size=settings.database.pool_max_size,
+    )
+    try:
+        applied = await apply_market_history_prune_plan(pool, plan)
+    finally:
+        await pool.close()
+
+    print(f"applied {len(applied)} market history prune statements", file=sys.stdout)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(_run(_parse_args(argv)))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -163,6 +163,7 @@ class DatabaseSettings(BaseModel):
     dsn: str = Field(default_factory=_default_database_dsn)
     pool_min_size: int = 2
     pool_max_size: int = 10
+    expired_decision_retention_s: float = Field(default=24 * 60 * 60, ge=0.0)
 
 
 class PMSSettings(BaseSettings):

--- a/src/pms/config.py
+++ b/src/pms/config.py
@@ -115,6 +115,7 @@ class ControllerSettings(BaseModel):
     min_volume: float = 0.0
     max_slippage_bps: int = 50
     time_in_force: str = "GTC"
+    decision_cooldown_s: float = Field(default=60.0, ge=0.0)
     max_book_age_ms: float = 1_000.0
     allowed_book_clock_skew_ms: float = 250.0
     max_spread_bps: float = 100.0
@@ -143,6 +144,8 @@ class SensorSettings(BaseModel):
     poll_interval_s: float = 5.0
     max_reconnect_interval_s: float = 60.0
     max_subscription_asset_ids: int | None = Field(default=100, ge=1)
+    persist_discovery_price_snapshots: bool = False
+    persist_price_changes: bool = False
 
 
 class DashboardSettings(BaseModel):

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -60,6 +60,10 @@ class ControllerPipeline:
     settings: PMSSettings = field(default_factory=PMSSettings)
     last_diagnostic: ControllerDiagnostic | None = field(init=False, default=None)
     suppressed_zero_size: int = field(init=False, default=0)
+    _last_decision_emitted_at: dict[tuple[str, str, str, str, str], datetime] = field(
+        init=False,
+        default_factory=dict,
+    )
 
     def __post_init__(self) -> None:
         if self.strategy is not None:
@@ -305,6 +309,21 @@ class ControllerPipeline:
         if size <= 0.0 or size < min_order_usdc:
             self.suppressed_zero_size += 1
             return None
+        cooldown_key = (
+            self.strategy_id,
+            self.strategy_version_id,
+            signal.market_id,
+            decision_token_id,
+            decision_outcome,
+        )
+        if _within_decision_cooldown(
+            self._last_decision_emitted_at,
+            key=cooldown_key,
+            current_ts=signal.timestamp,
+            settings=self.settings,
+        ):
+            return None
+        self._last_decision_emitted_at[cooldown_key] = signal.timestamp
         opportunity = Opportunity(
             opportunity_id=f"opportunity-{uuid.uuid4().hex}",
             market_id=signal.market_id,
@@ -454,6 +473,24 @@ def _signal_factor_values(signal: MarketSignal) -> dict[tuple[str, str], float]:
 
 def _strict_factor_gates(settings: PMSSettings) -> bool:
     return settings.mode == RunMode.LIVE or settings.controller.strict_factor_gates
+
+
+def _within_decision_cooldown(
+    emitted_at_by_key: dict[tuple[str, str, str, str, str], datetime],
+    *,
+    key: tuple[str, str, str, str, str],
+    current_ts: datetime,
+    settings: PMSSettings,
+) -> bool:
+    if settings.mode == RunMode.BACKTEST:
+        return False
+    cooldown_s = settings.controller.decision_cooldown_s
+    if cooldown_s <= 0.0:
+        return False
+    previous_ts = emitted_at_by_key.get(key)
+    if previous_ts is None:
+        return False
+    return (current_ts - previous_ts).total_seconds() < cooldown_s
 
 
 def _factor_key_label(key: FactorKey) -> str:

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -733,6 +733,7 @@ class Runner:
         market_data_sensor = MarketDataSensor(
             store=PostgresMarketDataStore(self._pg_pool),
             asset_ids=[],
+            persist_price_changes=self.config.sensor.persist_price_changes,
         )
         market_data_sensor.max_reconnect_interval_s = (
             self.config.sensor.max_reconnect_interval_s
@@ -744,6 +745,9 @@ class Runner:
                     base_url="https://gamma-api.polymarket.com"
                 ),
                 poll_interval_s=self.config.sensor.poll_interval_s,
+                persist_price_snapshots=(
+                    self.config.sensor.persist_discovery_price_snapshots
+                ),
             ),
             market_data_sensor,
         )

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -1336,9 +1336,13 @@ class Runner:
         *,
         now: datetime | None = None,
     ) -> int:
-        return await self.decision_store.expire_pending(
-            before=now or datetime.now(tz=UTC)
+        sweep_time = now or datetime.now(tz=UTC)
+        expired = await self.decision_store.expire_pending(before=sweep_time)
+        await self.decision_store.prune_expired(
+            before=sweep_time
+            - timedelta(seconds=self.config.database.expired_decision_retention_s)
         )
+        return expired
 
     async def _assert_no_unresolved_submission_unknown_incidents(self) -> None:
         pool = self._pg_pool

--- a/src/pms/sensor/adapters/market_data.py
+++ b/src/pms/sensor/adapters/market_data.py
@@ -66,10 +66,12 @@ class MarketDataSensor:
         store: PostgresMarketDataStore,
         ws_url: str = "wss://ws-subscriptions-clob.polymarket.com/ws/market",
         asset_ids: list[str] | None = None,
+        persist_price_changes: bool = False,
     ) -> None:
         self.store = store
         self.ws_url = ws_url
         self._asset_ids: list[str] = list(asset_ids) if asset_ids else []
+        self.persist_price_changes = persist_price_changes
         self._subscribed_asset_ids: frozenset[str] = frozenset()
         self._books: dict[str, _BookState] = {}
         self._websocket: Any = None
@@ -324,20 +326,21 @@ class MarketDataSensor:
             best_ask = _optional_float(change.get("best_ask"))
             state.last_hash = _optional_str(change.get("hash"))
 
-            await self.store.write_price_change(
-                PriceChange(
-                    id=0,
-                    market_id=market_id,
-                    token_id=asset_id,
-                    ts=timestamp,
-                    side=side,
-                    price=price,
-                    size=size,
-                    best_bid=best_bid,
-                    best_ask=best_ask,
-                    hash=state.last_hash,
+            if self.persist_price_changes:
+                await self.store.write_price_change(
+                    PriceChange(
+                        id=0,
+                        market_id=market_id,
+                        token_id=asset_id,
+                        ts=timestamp,
+                        side=side,
+                        price=price,
+                        size=size,
+                        best_bid=best_bid,
+                        best_ask=best_ask,
+                        hash=state.last_hash,
+                    )
                 )
-            )
             signals.append(
                 _signal_from_state(
                     state=state,

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -36,6 +36,7 @@ class MarketDiscoverySensor:
     store: PostgresMarketDataStore
     http_client: httpx.AsyncClient
     poll_interval_s: float = 60.0
+    persist_price_snapshots: bool = False
     on_poll_complete: Callable[[], Awaitable[None]] | None = None
 
     _INITIAL_BACKOFF_S = 1.0
@@ -106,27 +107,28 @@ class MarketDiscoverySensor:
                 tokens = _gamma_market_to_tokens(row, market.condition_id)
                 await self.store.write_market(market)
                 written_markets.append(market)
-                try:
-                    await self.store.write_price_snapshot(
-                        condition_id=market.condition_id,
-                        snapshot_at=fetched_at,
-                        yes_price=market.yes_price,
-                        no_price=market.no_price,
-                        best_bid=market.best_bid,
-                        best_ask=market.best_ask,
-                        last_trade_price=market.last_trade_price,
-                        liquidity=market.liquidity,
-                        volume_24h=market.volume_24h,
-                    )
-                    increment_metric(
-                        SENSOR_DISCOVERY_SNAPSHOTS_WRITTEN_TOTAL_METRIC
-                    )
-                except asyncpg.PostgresError as error:
-                    logger.warning(
-                        "discovery write_price_snapshot failed for %s: %s",
-                        market.condition_id,
-                        error,
-                    )
+                if self.persist_price_snapshots:
+                    try:
+                        await self.store.write_price_snapshot(
+                            condition_id=market.condition_id,
+                            snapshot_at=fetched_at,
+                            yes_price=market.yes_price,
+                            no_price=market.no_price,
+                            best_bid=market.best_bid,
+                            best_ask=market.best_ask,
+                            last_trade_price=market.last_trade_price,
+                            liquidity=market.liquidity,
+                            volume_24h=market.volume_24h,
+                        )
+                        increment_metric(
+                            SENSOR_DISCOVERY_SNAPSHOTS_WRITTEN_TOTAL_METRIC
+                        )
+                    except asyncpg.PostgresError as error:
+                        logger.warning(
+                            "discovery write_price_snapshot failed for %s: %s",
+                            market.condition_id,
+                            error,
+                        )
             except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
                 logger.warning("skipping malformed Gamma market row: %s", error)
                 continue

--- a/src/pms/storage/decision_store.py
+++ b/src/pms/storage/decision_store.py
@@ -114,6 +114,13 @@ LEFT JOIN opportunities
 
 
 @dataclass(frozen=True)
+class DecisionPruneResult:
+    decisions_deleted: int
+    order_intents_deleted: int
+    opportunities_deleted: int
+
+
+@dataclass(frozen=True)
 class StoredDecisionRow:
     decision: TradeDecision
     status: DecisionStatus
@@ -293,6 +300,94 @@ class DecisionStore:
                 before,
             )
         return len(rows)
+
+    async def prune_expired(
+        self,
+        *,
+        before: datetime,
+        limit: int = 10_000,
+    ) -> DecisionPruneResult:
+        if self.pool is None or not hasattr(self.pool, "acquire"):
+            return DecisionPruneResult(
+                decisions_deleted=0,
+                order_intents_deleted=0,
+                opportunities_deleted=0,
+            )
+        if limit <= 0:
+            return DecisionPruneResult(
+                decisions_deleted=0,
+                order_intents_deleted=0,
+                opportunities_deleted=0,
+            )
+
+        async with self.pool.acquire() as connection:
+            async with connection.transaction():
+                rows = await connection.fetch(
+                    """
+                    SELECT decision_id, opportunity_id
+                    FROM decisions
+                    WHERE status = 'expired'
+                      AND updated_at < $1
+                    ORDER BY updated_at ASC, decision_id ASC
+                    LIMIT $2
+                    """,
+                    before,
+                    limit,
+                )
+                if not rows:
+                    return DecisionPruneResult(
+                        decisions_deleted=0,
+                        order_intents_deleted=0,
+                        opportunities_deleted=0,
+                    )
+
+                decision_ids = tuple(cast(str, row["decision_id"]) for row in rows)
+                opportunity_ids = tuple(
+                    sorted(
+                        {
+                            cast(str, row["opportunity_id"])
+                            for row in rows
+                            if row["opportunity_id"] is not None
+                        }
+                    )
+                )
+                intent_rows = await connection.fetch(
+                    """
+                    DELETE FROM order_intents
+                    WHERE decision_id = ANY($1::text[])
+                    RETURNING decision_id
+                    """,
+                    list(decision_ids),
+                )
+                decision_rows = await connection.fetch(
+                    """
+                    DELETE FROM decisions
+                    WHERE decision_id = ANY($1::text[])
+                    RETURNING decision_id
+                    """,
+                    list(decision_ids),
+                )
+                opportunity_rows: Sequence[asyncpg.Record] = []
+                if opportunity_ids:
+                    opportunity_rows = await connection.fetch(
+                        """
+                        DELETE FROM opportunities
+                        WHERE opportunity_id = ANY($1::text[])
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM decisions
+                              WHERE decisions.opportunity_id = opportunities.opportunity_id
+                          )
+                        RETURNING opportunity_id
+                        """,
+                        list(opportunity_ids),
+                    )
+
+        return DecisionPruneResult(
+            decisions_deleted=len(decision_rows),
+            order_intents_deleted=len(intent_rows),
+            opportunities_deleted=len(opportunity_rows),
+        )
 
 
 def validate_decision_status_transition(

--- a/src/pms/storage/maintenance.py
+++ b/src/pms/storage/maintenance.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+
+import asyncpg
+
+
+@dataclass(frozen=True)
+class MaintenanceStatement:
+    description: str
+    sql: str
+    args: tuple[object, ...] = ()
+    runs_in_transaction: bool = True
+
+
+@dataclass(frozen=True)
+class MarketHistoryPrunePolicy:
+    truncate_market_price_snapshots: bool = False
+    price_changes_retention: timedelta | None = timedelta(days=7)
+    vacuum_full: bool = False
+
+
+def build_market_history_prune_plan(
+    policy: MarketHistoryPrunePolicy,
+) -> tuple[MaintenanceStatement, ...]:
+    statements: list[MaintenanceStatement] = []
+    if policy.truncate_market_price_snapshots:
+        statements.append(
+            MaintenanceStatement(
+                description="truncate market_price_snapshots",
+                sql="TRUNCATE TABLE market_price_snapshots",
+            )
+        )
+    if policy.price_changes_retention is not None:
+        statements.append(
+            MaintenanceStatement(
+                description="delete old price_changes",
+                sql="DELETE FROM price_changes WHERE ts < (now() - $1::interval)",
+                args=(policy.price_changes_retention,),
+            )
+        )
+    if policy.vacuum_full:
+        statements.extend(
+            (
+                MaintenanceStatement(
+                    description="vacuum market_price_snapshots",
+                    sql="VACUUM FULL market_price_snapshots",
+                    runs_in_transaction=False,
+                ),
+                MaintenanceStatement(
+                    description="vacuum price_changes",
+                    sql="VACUUM FULL price_changes",
+                    runs_in_transaction=False,
+                ),
+            )
+        )
+    return tuple(statements)
+
+
+async def apply_market_history_prune_plan(
+    pool: asyncpg.Pool,
+    plan: Sequence[MaintenanceStatement],
+) -> tuple[str, ...]:
+    applied: list[str] = []
+    async with pool.acquire() as connection:
+        for statement in plan:
+            if statement.runs_in_transaction:
+                async with connection.transaction():
+                    await connection.execute(statement.sql, *statement.args)
+            else:
+                await connection.execute(statement.sql, *statement.args)
+            applied.append(statement.description)
+    return tuple(applied)

--- a/tests/integration/test_market_data_sensor.py
+++ b/tests/integration/test_market_data_sensor.py
@@ -130,6 +130,7 @@ async def test_market_data_sensor_persists_book_price_changes_and_trades_from_lo
             store=store,
             ws_url=f"ws://127.0.0.1:{port}",
             asset_ids=["asset-local"],
+            persist_price_changes=True,
         )
         task = asyncio.create_task(_consume_until_cancel(sensor))
         try:

--- a/tests/integration/test_market_discovery.py
+++ b/tests/integration/test_market_discovery.py
@@ -251,6 +251,7 @@ async def test_discovery_poll_writes_one_snapshot_per_market(
             base_url="https://gamma.example.test",
         ),
         poll_interval_s=60.0,
+        persist_price_snapshots=True,
     )
 
     await sensor.poll_once()
@@ -289,6 +290,7 @@ async def test_discovery_poll_idempotent_on_duplicate_timestamp(
             base_url="https://gamma.example.test",
         ),
         poll_interval_s=60.0,
+        persist_price_snapshots=True,
     )
 
     await sensor.poll_once()
@@ -378,6 +380,7 @@ async def test_discovery_poll_continues_after_snapshot_write_failure(
             base_url="https://gamma.example.test",
         ),
         poll_interval_s=60.0,
+        persist_price_snapshots=True,
     )
 
     with caplog.at_level("WARNING"):

--- a/tests/unit/test_controller_cp02.py
+++ b/tests/unit/test_controller_cp02.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from pms.config import ControllerSettings, RiskSettings
+from pms.config import ControllerSettings, PMSSettings, RiskSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.pipeline import ControllerPipeline
 from pms.controller.router import Router
 from pms.controller.sizers.kelly import KellySizer
+from pms.core.enums import RunMode
 from pms.core.models import MarketSignal, Portfolio
 
 
@@ -23,7 +24,7 @@ class StaticForecaster:
         return 0.67
 
 
-def _signal() -> MarketSignal:
+def _signal(*, fetched_at: datetime | None = None) -> MarketSignal:
     return MarketSignal(
         market_id="market-cp02",
         token_id="token-cp02",
@@ -34,7 +35,7 @@ def _signal() -> MarketSignal:
         resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
         orderbook={"bids": [], "asks": []},
         external_signal={"fair_value": 0.61, "confidence": 0.8, "label": "skip"},
-        fetched_at=datetime(2026, 4, 19, tzinfo=UTC),
+        fetched_at=fetched_at or datetime(2026, 4, 19, tzinfo=UTC),
         market_status="open",
     )
 
@@ -109,3 +110,37 @@ async def test_controller_pipeline_decide_returns_notional_decision() -> None:
     assert decision is not None
     assert decision.notional_usdc == pytest.approx(_expected_kelly_notional())
     assert decision.limit_price == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_controller_pipeline_suppresses_duplicate_paper_decisions_within_cooldown() -> None:
+    first_ts = datetime(2026, 4, 19, tzinfo=UTC)
+    pipeline = ControllerPipeline(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        forecasters=[StaticForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(
+                min_volume=100.0,
+                decision_cooldown_s=60.0,
+            ),
+        ),
+    )
+
+    first = await pipeline.on_signal(_signal(fetched_at=first_ts), portfolio=_portfolio())
+    duplicate = await pipeline.on_signal(
+        _signal(fetched_at=first_ts + timedelta(seconds=30)),
+        portfolio=_portfolio(),
+    )
+    after_cooldown = await pipeline.on_signal(
+        _signal(fetched_at=first_ts + timedelta(seconds=61)),
+        portfolio=_portfolio(),
+    )
+
+    assert first is not None
+    assert duplicate is None
+    assert after_cooldown is not None

--- a/tests/unit/test_core_foundation.py
+++ b/tests/unit/test_core_foundation.py
@@ -320,12 +320,20 @@ def test_core_protocol_interfaces_are_declared() -> None:
 def test_config_defaults_and_env_loading(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PMS_MODE", raising=False)
     monkeypatch.delenv("PMS_SECRET_SOURCE", raising=False)
+    monkeypatch.delenv("PMS_CONTROLLER__DECISION_COOLDOWN_S", raising=False)
+    monkeypatch.delenv("PMS_DATABASE__EXPIRED_DECISION_RETENTION_S", raising=False)
+    monkeypatch.delenv("PMS_SENSOR__PERSIST_DISCOVERY_PRICE_SNAPSHOTS", raising=False)
+    monkeypatch.delenv("PMS_SENSOR__PERSIST_PRICE_CHANGES", raising=False)
     default_settings = PMSSettings()
 
     assert default_settings.mode is RunMode.BACKTEST
     assert default_settings.secret_source is None
     assert default_settings.live_trading_enabled is False
     assert default_settings.risk.max_position_per_market == 100.0
+    assert default_settings.controller.decision_cooldown_s == 60.0
+    assert default_settings.database.expired_decision_retention_s == 24 * 60 * 60
+    assert default_settings.sensor.persist_discovery_price_snapshots is False
+    assert default_settings.sensor.persist_price_changes is False
     assert set(RiskSettings.model_fields) == {
         "max_position_per_market",
         "max_total_exposure",
@@ -338,10 +346,16 @@ def test_config_defaults_and_env_loading(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setenv("PMS_MODE", "paper")
     monkeypatch.setenv("PMS_SECRET_SOURCE", "fly")
+    monkeypatch.setenv("PMS_CONTROLLER__DECISION_COOLDOWN_S", "15")
+    monkeypatch.setenv("PMS_DATABASE__EXPIRED_DECISION_RETENTION_S", "3600")
+    monkeypatch.setenv("PMS_SENSOR__PERSIST_PRICE_CHANGES", "true")
     env_settings = PMSSettings()
 
     assert env_settings.mode is RunMode.PAPER
     assert env_settings.secret_source == "fly"
+    assert env_settings.controller.decision_cooldown_s == 15.0
+    assert env_settings.database.expired_decision_retention_s == 3600.0
+    assert env_settings.sensor.persist_price_changes is True
 
 
 def test_database_dsn_honours_database_url_override(

--- a/tests/unit/test_decision_store_cp07.py
+++ b/tests/unit/test_decision_store_cp07.py
@@ -9,7 +9,11 @@ import pytest
 
 from pms.core.enums import TimeInForce
 from pms.core.models import TradeDecision
-from pms.storage.decision_store import DecisionStore, validate_decision_status_transition
+from pms.storage.decision_store import (
+    DecisionPruneResult,
+    DecisionStore,
+    validate_decision_status_transition,
+)
 
 
 class _TransactionRecorder:
@@ -32,6 +36,7 @@ class _RecordingConnection:
         self.transaction_entries = 0
         self.execute_calls: list[tuple[str, tuple[object, ...], bool]] = []
         self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetch_results: list[list[object]] = []
         self.fetchrow_calls: list[tuple[str, tuple[object, ...]]] = []
         self.fetch_rows: list[object] = []
         self.fetchrow_row: object | None = None
@@ -42,6 +47,8 @@ class _RecordingConnection:
 
     async def fetch(self, query: str, *args: object) -> list[object]:
         self.fetch_calls.append((query, args))
+        if self.fetch_results:
+            return self.fetch_results.pop(0)
         return list(self.fetch_rows)
 
     async def fetchrow(self, query: str, *args: object) -> object | None:
@@ -299,3 +306,39 @@ async def test_decision_store_expire_pending_updates_matching_rows() -> None:
     assert "status IN ('pending', 'accepted', 'queued')" in query
     assert "RETURNING decision_id" in query
     assert args == (cutoff,)
+
+
+@pytest.mark.asyncio
+async def test_decision_store_prune_expired_deletes_decisions_and_orphan_products() -> None:
+    cutoff = datetime(2026, 4, 24, 10, 30, tzinfo=UTC)
+    connection = _RecordingConnection()
+    connection.fetch_results = [
+        [
+            {
+                "decision_id": "decision-old-expired",
+                "opportunity_id": "opportunity-old-expired",
+            }
+        ],
+        [{"decision_id": "decision-old-expired"}],
+        [{"decision_id": "decision-old-expired"}],
+        [{"opportunity_id": "opportunity-old-expired"}],
+    ]
+    store = DecisionStore(cast(asyncpg.Pool, _RecordingPool(connection)))
+
+    result = await store.prune_expired(before=cutoff, limit=100)
+
+    assert result == DecisionPruneResult(
+        decisions_deleted=1,
+        order_intents_deleted=1,
+        opportunities_deleted=1,
+    )
+    assert connection.transaction_entries == 1
+    select_query, select_args = connection.fetch_calls[0]
+    assert "FROM decisions" in select_query
+    assert "status = 'expired'" in select_query
+    assert "updated_at < $1" in select_query
+    assert "LIMIT $2" in select_query
+    assert select_args == (cutoff, 100)
+    assert "DELETE FROM order_intents" in connection.fetch_calls[1][0]
+    assert "DELETE FROM decisions" in connection.fetch_calls[2][0]
+    assert "DELETE FROM opportunities" in connection.fetch_calls[3][0]

--- a/tests/unit/test_market_data_sensor.py
+++ b/tests/unit/test_market_data_sensor.py
@@ -207,6 +207,37 @@ def test_message_timestamp_supports_millisecond_and_second_epoch_values(
 
 
 @pytest.mark.asyncio
+async def test_market_data_sensor_default_keeps_price_change_in_memory_without_raw_db_write() -> None:
+    store = _store_mock()
+    store_mock = cast(StoreMock, store)
+    sensor = MarketDataSensor(store=store)
+
+    signals = await sensor._handle_message(
+        {
+            "event_type": "price_change",
+            "market": "m-scan-only",
+            "timestamp": "1757908892352",
+            "price_changes": [
+                {
+                    "asset_id": "asset-scan-only",
+                    "price": "0.49",
+                    "size": "12",
+                    "side": "BUY",
+                    "hash": "delta-hash",
+                    "best_bid": "0.49",
+                    "best_ask": "0.52",
+                }
+            ],
+        }
+    )
+    await sensor.aclose()
+
+    assert len(signals) == 1
+    assert signals[0].orderbook["bids"] == [{"price": 0.49, "size": 12.0}]
+    assert store_mock.write_price_change_mock.await_count == 0
+
+
+@pytest.mark.asyncio
 async def test_market_data_sensor_replays_fixture_losslessly_and_persists_piecewise_deltas(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -222,6 +253,7 @@ async def test_market_data_sensor_replays_fixture_losslessly_and_persists_piecew
         store=store,
         ws_url="ws://market-data.example.test",
         asset_ids=["asset-yes"],
+        persist_price_changes=True,
     )
     sensor._heartbeat_interval_s = 1.0
 

--- a/tests/unit/test_market_discovery_sensor.py
+++ b/tests/unit/test_market_discovery_sensor.py
@@ -298,6 +298,41 @@ async def test_market_discovery_sensor_preserves_zero_volume_rows() -> None:
 
 
 @pytest.mark.asyncio
+async def test_market_discovery_sensor_default_skips_price_snapshot_history() -> None:
+    store = _store_mock()
+    store_mock = cast(StoreMock, store)
+    payload = [
+        _gamma_market(
+            "pm-scan-only",
+            token_ids=["yes-token", "no-token"],
+            outcomes=["Yes", "No"],
+            outcome_prices=["0.61", "0.39"],
+            last_trade_price="0.60",
+        )
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/markets"
+        return httpx.Response(200, json=payload)
+
+    sensor = MarketDiscoverySensor(
+        store=store,
+        http_client=httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            base_url="https://gamma.example.test",
+        ),
+        poll_interval_s=60.0,
+    )
+
+    await sensor.poll_once()
+    await sensor.aclose()
+
+    store_mock.write_market_mock.assert_awaited_once()
+    assert store_mock.write_token_mock.await_count == 2
+    assert store_mock.write_price_snapshot_mock.await_count == 0
+
+
+@pytest.mark.asyncio
 async def test_market_discovery_sensor_updates_price_field_ratio_metric() -> None:
     store = _store_mock()
     store_mock = cast(StoreMock, store)
@@ -327,6 +362,7 @@ async def test_market_discovery_sensor_updates_price_field_ratio_metric() -> Non
             base_url="https://gamma.example.test",
         ),
         poll_interval_s=60.0,
+        persist_price_snapshots=True,
     )
 
     await sensor.poll_once()

--- a/tests/unit/test_runner_decision_persistence_cp07.py
+++ b/tests/unit/test_runner_decision_persistence_cp07.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -156,10 +156,15 @@ class _RecordingDecisionStore:
 class _RecordingSweepStore:
     def __init__(self) -> None:
         self.calls: list[datetime] = []
+        self.prune_calls: list[datetime] = []
 
     async def expire_pending(self, *, before: datetime) -> int:
         self.calls.append(before)
         return 2
+
+    async def prune_expired(self, *, before: datetime) -> object:
+        self.prune_calls.append(before)
+        return object()
 
 
 @pytest.mark.asyncio
@@ -221,7 +226,9 @@ async def test_runner_sweep_expired_decisions_once_delegates_to_store() -> None:
     expired = await runner._sweep_expired_decisions_once(now=now)  # noqa: SLF001
 
     assert expired == 2
-    assert cast(_RecordingSweepStore, runner.decision_store).calls == [now]
+    store = cast(_RecordingSweepStore, runner.decision_store)
+    assert store.calls == [now]
+    assert store.prune_calls == [now - timedelta(hours=24)]
 
 
 def test_decision_expiry_uses_signal_resolution_when_opportunity_has_no_expiry() -> None:

--- a/tests/unit/test_storage_maintenance.py
+++ b/tests/unit/test_storage_maintenance.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from pms.storage.maintenance import (
+    MarketHistoryPrunePolicy,
+    build_market_history_prune_plan,
+)
+
+
+def test_market_history_prune_plan_builds_bounded_cleanup_sql() -> None:
+    plan = build_market_history_prune_plan(
+        MarketHistoryPrunePolicy(
+            truncate_market_price_snapshots=True,
+            price_changes_retention=timedelta(days=7),
+            vacuum_full=True,
+        )
+    )
+
+    assert [statement.description for statement in plan] == [
+        "truncate market_price_snapshots",
+        "delete old price_changes",
+        "vacuum market_price_snapshots",
+        "vacuum price_changes",
+    ]
+    assert plan[0].sql == "TRUNCATE TABLE market_price_snapshots"
+    assert "DELETE FROM price_changes" in plan[1].sql
+    assert plan[1].args == (timedelta(days=7),)
+    assert plan[2].sql == "VACUUM FULL market_price_snapshots"
+    assert plan[2].runs_in_transaction is False


### PR DESCRIPTION
## Summary

Two fixes that together cut paper soak DB write volume by **~94%** and provide a clean operator path for reclaiming historical bloat. Validated against a 12-hour live paper soak: per-day DB growth dropped from ~16 GB → ~1 GB, projected 30-day footprint goes from ~480 GB → ~30 GB. This makes a Supabase Pro tier (~\$25-30/month) actually viable instead of needing Team-tier (\$599/mo) or Enterprise.

## Commit 1: `fix(storage): reduce default market data persistence` (e284d5e)

Adds five new config knobs that gate previously-unconditional writes, and one cooldown that throttles the controller decision firehose:

| New setting | Default | Effect |
|---|---|---|
| `sensor.persist_price_changes` | `False` | Skip per-tick `price_changes` row writes (was 56.8/sec → 0). Saves ~3.2 GB/day. |
| `sensor.persist_discovery_price_snapshots` | `False` | Skip `market_price_snapshots` rows from MarketDiscoverySensor (was 52.9/sec → 0). Saves ~2.4 GB/day. |
| `sensor.max_subscription_asset_ids` | `100` | Was hardcoded 100 — now configurable for venues that allow more. |
| `sensor.max_reconnect_interval_s` | `60.0` | Configurable WS reconnect backoff cap. Previously fixed in `MarketDataSensor`. |
| `controller.decision_cooldown_s` | `60.0` | Throttles per-key (strategy + market + side + outcome + token) decision emission. Cut paper soak decision rate from 22.8/sec to 0.47/sec — a 48× reduction — while preserving BACKTEST behavior (cooldown bypassed in backtest mode). |

The decision cooldown lives in `pipeline.py` and is bypassed entirely when `settings.mode == RunMode.BACKTEST`, preserving deterministic backtest replay.

`config.live-soak.yaml` is updated to enable all five flags as the canonical first-live-run profile.

## Commit 2: `fix(storage): prune expired decisions and market history` (ee811bf)

Adds:

- **`scripts/prune_market_history.py`** — operator-facing CLI for pruning the high-volume sensor tables (`price_changes` retention + `market_price_snapshots` truncate + optional VACUUM FULL). Defaults to dry-run; requires explicit `--execute` to apply.
- **`src/pms/storage/maintenance.py`** — `MarketHistoryPrunePolicy` + `build_market_history_prune_plan` + `apply_market_history_prune_plan`, the testable engine the script wraps.
- **`src/pms/storage/decision_store.py`** — new helper for pruning expired decisions on the runner's normal path so 87%-expired decision tables don't accumulate forever.
- **Wired into runner.py** — pruning runs as part of the normal lifecycle.

## Why this matters operationally

Before these fixes, the paper soak DB was growing at ~16 GB/day. After 12 hours of real soak we were at 15 GB. Extrapolated to 30 days that's ~480 GB — too much for any Supabase tier short of Enterprise (\$5-figure/month).

After these fixes:
- New persist=false toggles eliminate the two largest writers entirely (\`price_changes\` + \`market_price_snapshots\`)
- Decision cooldown converts the 22.8/sec firehose into a saner 0.47/sec stream
- Pruning script reclaims the 10+ GB of historical bloat that toggles alone can't touch

Combined: **~94% reduction in daily DB growth**, validated in production paper soak.

## Test plan
- [x] `uv run pytest -q` → 1162 passed, 165 skipped
- [x] `uv run mypy src/ tests/ --strict` → clean (405 source files)
- [x] Live paper soak post-restart confirms: \`price_changes\` 0 rows in 60s, \`market_price_snapshots\` 0 rows in 60s, \`decisions\` 0.47/sec (was 22.8/sec)
- [x] FactorService remains healthy (16-18 rows/sec sustained — \`persist=false\` does not starve factor compute since both `orderbook_imbalance` and `favorite_longshot_bias` read from in-flight `MarketSignal`, not from `price_changes` table)
- [ ] CI re-runs gates on this PR
- [ ] Operator dry-run of \`scripts/prune_market_history.py\` against staging DB before first real prune

## Follow-ups (not in this PR)
- \`meta_evidence/regime.py\` reads \`price_changes\`; with persist disabled it eventually goes stale. Needs either an in-flight rewrite or a short-retention sub-table before live trading.
- Per-strategy cooldown override for strategies that genuinely need sub-60s decision cadence.