### PR TITLE
[codex] add realtime quality signals

### DIFF
--- a/alembic/versions/0001_baseline.py
+++ b/alembic/versions/0001_baseline.py
@@ -25,6 +25,7 @@ _CREATED_TABLES: Final[tuple[str, ...]] = (
     "order_intents",
     "orders",
     "decisions",
+    "quote_eval_records",
     "eval_records",
     "feedback",
     "strategy_factors",

--- a/alembic/versions/0017_quote_eval_records.py
+++ b/alembic/versions/0017_quote_eval_records.py
@@ -1,0 +1,56 @@
+"""Add quote-based evaluation records."""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy.engine import Connection
+
+
+revision = "0017_quote_eval_records"
+down_revision = "0016_market_relations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    connection: Connection = op.get_bind()
+    connection.exec_driver_sql(
+        """
+        CREATE TABLE IF NOT EXISTS quote_eval_records (
+            fill_id TEXT NOT NULL,
+            decision_id TEXT NOT NULL,
+            market_id TEXT NOT NULL,
+            token_id TEXT,
+            strategy_id TEXT NOT NULL,
+            strategy_version_id TEXT NOT NULL,
+            prob_estimate DOUBLE PRECISION NOT NULL,
+            quote_price DOUBLE PRECISION NOT NULL,
+            quote_source TEXT NOT NULL,
+            quote_lag_seconds INTEGER NOT NULL,
+            quote_score DOUBLE PRECISION NOT NULL,
+            mtm_pnl DOUBLE PRECISION NOT NULL,
+            book_ts TIMESTAMPTZ NOT NULL,
+            recorded_at TIMESTAMPTZ NOT NULL,
+            citations JSONB NOT NULL DEFAULT '[]'::jsonb,
+            category TEXT,
+            model_id TEXT,
+            PRIMARY KEY (fill_id, quote_lag_seconds),
+            CONSTRAINT quote_eval_records_strategy_identity_check
+                CHECK (strategy_id != '' AND strategy_version_id != '')
+        )
+        """
+    )
+    connection.exec_driver_sql(
+        """
+        CREATE INDEX IF NOT EXISTS idx_quote_eval_records_strategy_identity_recorded_at
+            ON quote_eval_records(strategy_id, strategy_version_id, recorded_at DESC)
+        """
+    )
+
+
+def downgrade() -> None:
+    connection: Connection = op.get_bind()
+    connection.exec_driver_sql(
+        "DROP INDEX IF EXISTS idx_quote_eval_records_strategy_identity_recorded_at"
+    )
+    connection.exec_driver_sql("DROP TABLE IF EXISTS quote_eval_records")

--- a/schema.sql
+++ b/schema.sql
@@ -282,6 +282,27 @@ ALTER TABLE eval_records
     ADD COLUMN IF NOT EXISTS edge_at_decision DOUBLE PRECISION NOT NULL DEFAULT 0.0,
     ADD COLUMN IF NOT EXISTS spread_bps_at_decision INTEGER;
 
+CREATE TABLE IF NOT EXISTS quote_eval_records (
+    fill_id TEXT NOT NULL,
+    decision_id TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    token_id TEXT,
+    strategy_id TEXT NOT NULL,
+    strategy_version_id TEXT NOT NULL,
+    prob_estimate DOUBLE PRECISION NOT NULL,
+    quote_price DOUBLE PRECISION NOT NULL,
+    quote_source TEXT NOT NULL,
+    quote_lag_seconds INTEGER NOT NULL,
+    quote_score DOUBLE PRECISION NOT NULL,
+    mtm_pnl DOUBLE PRECISION NOT NULL,
+    book_ts TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    citations JSONB NOT NULL DEFAULT '[]'::jsonb,
+    category TEXT,
+    model_id TEXT,
+    PRIMARY KEY (fill_id, quote_lag_seconds)
+);
+
 CREATE TABLE IF NOT EXISTS strategy_performance_peaks (
     strategy_id TEXT NOT NULL,
     strategy_version_id TEXT NOT NULL,
@@ -600,6 +621,10 @@ ALTER TABLE eval_records
     ALTER COLUMN strategy_id SET NOT NULL,
     ALTER COLUMN strategy_version_id SET NOT NULL;
 
+ALTER TABLE quote_eval_records
+    ALTER COLUMN strategy_id SET NOT NULL,
+    ALTER COLUMN strategy_version_id SET NOT NULL;
+
 ALTER TABLE orders
     ALTER COLUMN strategy_id SET NOT NULL,
     ALTER COLUMN strategy_version_id SET NOT NULL;
@@ -641,6 +666,20 @@ BEGIN
     ) THEN
         ALTER TABLE eval_records
             ADD CONSTRAINT eval_records_strategy_identity_check
+            CHECK (strategy_id != '' AND strategy_version_id != '');
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'quote_eval_records_strategy_identity_check'
+    ) THEN
+        ALTER TABLE quote_eval_records
+            ADD CONSTRAINT quote_eval_records_strategy_identity_check
             CHECK (strategy_id != '' AND strategy_version_id != '');
     END IF;
 END
@@ -780,6 +819,9 @@ CREATE INDEX IF NOT EXISTS idx_eval_records_strategy_identity
 
 CREATE INDEX IF NOT EXISTS idx_eval_records_strategy_identity_recorded_at
     ON eval_records(strategy_id, strategy_version_id, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_quote_eval_records_strategy_identity_recorded_at
+    ON quote_eval_records(strategy_id, strategy_version_id, recorded_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_orders_strategy_identity
     ON orders(strategy_id, strategy_version_id);

--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -73,8 +73,16 @@ from pms.alerting.discord import DiscordWebhookClient
 from pms.alerting.scheduler import EODScheduler
 from pms.alerting.subscriber import run_alerting_subscription
 from pms.core.enums import RunMode
-from pms.core.models import EvalRecord, LiveTradingDisabledError, MarketSignal, TradeDecision
+from pms.core.models import (
+    EvalRecord,
+    LiveTradingDisabledError,
+    MarketSignal,
+    Position,
+    QuoteEvalRecord,
+    TradeDecision,
+)
 from pms.evaluation.metrics import MetricsCollector, MetricsSnapshot
+from pms.evaluation.quote_metrics import QuoteMetricsCollector, QuoteMetricsSnapshot
 from pms.metrics import metrics_snapshot
 from pms.runner import Runner
 from pms.storage.schema_check import ensure_schema_current
@@ -198,6 +206,9 @@ def create_app(
     async def status(request: Request) -> dict[str, Any]:
         records = await active_runner.eval_store.all()
         metrics_snapshot = MetricsCollector(records).global_ops_snapshot()
+        quote_records = await _quote_eval_records(active_runner)
+        quote_snapshot = QuoteMetricsCollector(quote_records).global_ops_snapshot()
+        mark_to_market = await _mark_to_market_payload(active_runner)
         return {
             "mode": active_runner.state.mode.value,
             "runner_started_at": _jsonable(active_runner.state.runner_started_at),
@@ -219,6 +230,12 @@ def create_app(
                 "eval_records_total": len(records),
                 "brier_overall": metrics_snapshot.brier_overall,
             },
+            "quality": _quality_payload(
+                records=records,
+                metrics_snapshot=metrics_snapshot,
+                mark_to_market=mark_to_market,
+                quote_snapshot=quote_snapshot,
+            ),
         }
 
     @app.get("/health")
@@ -466,9 +483,16 @@ def create_app(
             await active_runner.eval_store.all(),
             key=lambda record: (record.recorded_at, record.decision_id),
         )
+        quote_records = sorted(
+            await _quote_eval_records(active_runner),
+            key=lambda record: (record.recorded_at, record.fill_id),
+        )
+        mark_to_market = await _mark_to_market_payload(active_runner)
         first_trade_time_seconds = await _first_trade_time_seconds(active_runner.pg_pool)
         return _metrics_payload(
             records,
+            quote_records=quote_records,
+            mark_to_market=mark_to_market,
             first_trade_time_seconds=first_trade_time_seconds,
         )
 
@@ -720,13 +744,78 @@ def _latest(items: Sequence[T], limit: int) -> list[T]:
     return list(items[-bounded_limit:])
 
 
+async def _quote_eval_records(runner: Runner) -> list[QuoteEvalRecord]:
+    store = getattr(runner, "quote_eval_store", None)
+    all_records = getattr(store, "all", None)
+    if not callable(all_records):
+        return []
+    try:
+        return list(await all_records())
+    except Exception:  # noqa: BLE001
+        logger.exception("quote evaluation metrics unavailable")
+        return []
+
+
+async def _mark_to_market_payload(runner: Runner) -> dict[str, float | int]:
+    read_positions = getattr(runner.fill_store, "read_positions", None)
+    if not callable(read_positions):
+        return _mark_to_market_from_positions([])
+    try:
+        positions = list(await read_positions())
+    except Exception:  # noqa: BLE001
+        logger.exception("mark-to-market metrics unavailable")
+        return _mark_to_market_from_positions([])
+    return _mark_to_market_from_positions(positions)
+
+
+def _mark_to_market_from_positions(
+    positions: Sequence[Position],
+) -> dict[str, float | int]:
+    return {
+        "open_positions": len(positions),
+        "locked_usdc": float(sum(Decimal(str(item.locked_usdc)) for item in positions)),
+        "unrealized_pnl": float(
+            sum(Decimal(str(item.unrealized_pnl)) for item in positions)
+        ),
+    }
+
+
+def _quality_payload(
+    *,
+    records: Sequence[EvalRecord],
+    metrics_snapshot: MetricsSnapshot,
+    mark_to_market: dict[str, float | int],
+    quote_snapshot: QuoteMetricsSnapshot,
+) -> dict[str, Any]:
+    return {
+        "final_brier": {
+            "record_count": len(records),
+            "brier_overall": metrics_snapshot.brier_overall,
+        },
+        "mark_to_market": mark_to_market,
+        "quote_calibration": _quote_calibration_payload(quote_snapshot),
+    }
+
+
+def _quote_calibration_payload(snapshot: QuoteMetricsSnapshot) -> dict[str, Any]:
+    return {
+        "record_count": snapshot.record_count,
+        "quote_score_overall": snapshot.quote_score_overall,
+        "mtm_pnl": snapshot.mtm_pnl,
+    }
+
+
 def _metrics_payload(
     records: list[EvalRecord],
     *,
+    quote_records: list[QuoteEvalRecord] | None = None,
+    mark_to_market: dict[str, float | int] | None = None,
     first_trade_time_seconds: float | None = None,
 ) -> dict[str, Any]:
     collector = MetricsCollector(records)
     ops_view = _metrics_aggregate_payload(records, collector.global_ops_snapshot())
+    quote_records = [] if quote_records is None else quote_records
+    quote_snapshot = QuoteMetricsCollector(quote_records).global_ops_snapshot()
     strategy_snapshots = collector.snapshot_by_strategy()
     grouped_records: dict[tuple[str, str], list[EvalRecord]] = defaultdict(list)
     for record in records:
@@ -755,6 +844,18 @@ def _metrics_payload(
     payload.update(metrics_snapshot())
     payload["per_strategy"] = per_strategy
     payload["ops_view"] = ops_view
+    payload["mark_to_market"] = (
+        _mark_to_market_from_positions([])
+        if mark_to_market is None
+        else mark_to_market
+    )
+    payload["quote_calibration"] = _quote_calibration_payload(quote_snapshot)
+    payload["quality"] = _quality_payload(
+        records=records,
+        metrics_snapshot=collector.global_ops_snapshot(),
+        mark_to_market=payload["mark_to_market"],
+        quote_snapshot=quote_snapshot,
+    )
     return payload
 
 

--- a/src/pms/core/models.py
+++ b/src/pms/core/models.py
@@ -331,6 +331,27 @@ class EvalRecord:
 
 
 @dataclass(frozen=True)
+class QuoteEvalRecord:
+    fill_id: str
+    decision_id: str
+    market_id: str
+    token_id: str | None
+    strategy_id: str
+    strategy_version_id: str
+    prob_estimate: float
+    quote_price: float
+    quote_source: str
+    quote_lag_seconds: int
+    quote_score: float
+    mtm_pnl: float
+    book_ts: datetime
+    recorded_at: datetime
+    citations: list[str]
+    category: str | None = None
+    model_id: str | None = None
+
+
+@dataclass(frozen=True)
 class Feedback:
     feedback_id: str
     target: str

--- a/src/pms/evaluation/quote_metrics.py
+++ b/src/pms/evaluation/quote_metrics.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+
+from pms.core.models import QuoteEvalRecord
+
+
+StrategyVersionKey = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class QuoteMetricsSnapshot:
+    quote_score_overall: float | None
+    quote_score_by_category: dict[str, float]
+    quote_score_samples: dict[str, int]
+    record_count: int
+    mtm_pnl: float
+
+
+@dataclass(frozen=True, init=False)
+class QuoteMetricsCollector:
+    records: tuple[QuoteEvalRecord, ...]
+
+    def __init__(self, records: Iterable[QuoteEvalRecord]) -> None:
+        object.__setattr__(self, "records", tuple(records))
+
+    def global_ops_snapshot(self) -> QuoteMetricsSnapshot:
+        return _build_quote_metrics_snapshot(self.records)
+
+    def snapshot_by_strategy(self) -> Mapping[StrategyVersionKey, QuoteMetricsSnapshot]:
+        grouped_records: dict[StrategyVersionKey, list[QuoteEvalRecord]] = defaultdict(list)
+        for record in self.records:
+            grouped_records[(record.strategy_id, record.strategy_version_id)].append(record)
+        return {
+            key: _build_quote_metrics_snapshot(records)
+            for key, records in grouped_records.items()
+        }
+
+
+def _build_quote_metrics_snapshot(
+    records: tuple[QuoteEvalRecord, ...] | list[QuoteEvalRecord],
+) -> QuoteMetricsSnapshot:
+    if not records:
+        return QuoteMetricsSnapshot(
+            quote_score_overall=None,
+            quote_score_by_category={},
+            quote_score_samples={},
+            record_count=0,
+            mtm_pnl=0.0,
+        )
+
+    scores_by_category: dict[str, list[Decimal]] = defaultdict(list)
+    for record in records:
+        category = record.category or record.model_id or "unknown"
+        scores_by_category[category].append(Decimal(str(record.quote_score)))
+
+    total_quote_score = sum(Decimal(str(record.quote_score)) for record in records)
+    total_mtm_pnl = sum(Decimal(str(record.mtm_pnl)) for record in records)
+    return QuoteMetricsSnapshot(
+        quote_score_overall=float(total_quote_score / Decimal(len(records))),
+        quote_score_by_category={
+            category: float(sum(scores) / Decimal(len(scores)))
+            for category, scores in scores_by_category.items()
+        },
+        quote_score_samples={
+            category: len(scores) for category, scores in scores_by_category.items()
+        },
+        record_count=len(records),
+        mtm_pnl=float(total_mtm_pnl),
+    )

--- a/src/pms/evaluation/quote_reader.py
+++ b/src/pms/evaluation/quote_reader.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from pms.core.models import BookLevel, BookSnapshot, BookSummary
+
+
+class TokenBookStore(Protocol):
+    async def read_latest_snapshot(
+        self,
+        market_id: str,
+        token_id: str,
+    ) -> BookSnapshot | None: ...
+
+    async def read_levels_for_snapshot(self, snapshot_id: int) -> list[BookLevel]: ...
+
+
+@dataclass(frozen=True)
+class TokenBookQuoteReader:
+    store: TokenBookStore
+
+    async def latest_book_summary(
+        self,
+        market_id: str,
+        token_id: str | None,
+    ) -> BookSummary | None:
+        if token_id is None:
+            return None
+        snapshot = await self.store.read_latest_snapshot(market_id, token_id)
+        if snapshot is None:
+            return None
+        levels = await self.store.read_levels_for_snapshot(snapshot.id)
+        bids = [(level.price, level.size) for level in levels if level.side == "BUY"]
+        asks = [(level.price, level.size) for level in levels if level.side == "SELL"]
+        if not bids or not asks:
+            return None
+
+        best_bid = max(price for price, _ in bids)
+        best_ask = min(price for price, _ in asks)
+        midpoint = (best_bid + best_ask) / 2.0
+        if midpoint <= 0.0:
+            return None
+        top_bid_depth = sum(price * size for price, size in bids if price == best_bid)
+        top_ask_depth = sum(price * size for price, size in asks if price == best_ask)
+        return BookSummary(
+            best_bid=best_bid,
+            best_ask=best_ask,
+            spread_bps=((best_ask - best_bid) / midpoint) * 10_000.0,
+            depth_usdc=top_bid_depth + top_ask_depth,
+            timestamp=snapshot.ts,
+        )

--- a/src/pms/evaluation/quote_scoring.py
+++ b/src/pms/evaluation/quote_scoring.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from pms.core.enums import Side
+from pms.core.models import BookSummary, FillRecord, QuoteEvalRecord, TradeDecision
+
+
+@dataclass(frozen=True)
+class QuoteScorer:
+    quote_source: str = "postgres_snapshot"
+
+    def score(
+        self,
+        fill: FillRecord,
+        decision: TradeDecision,
+        quote: BookSummary,
+        *,
+        quote_lag_seconds: int,
+        recorded_at: datetime | None = None,
+    ) -> QuoteEvalRecord:
+        if (
+            fill.strategy_id != decision.strategy_id
+            or fill.strategy_version_id != decision.strategy_version_id
+        ):
+            msg = "FillRecord and TradeDecision strategy identity must match for quote scoring"
+            raise ValueError(msg)
+        if quote.best_bid <= 0.0 or quote.best_ask <= 0.0:
+            msg = "quote bid/ask must be positive"
+            raise ValueError(msg)
+
+        quote_price = (quote.best_bid + quote.best_ask) / 2.0
+        return QuoteEvalRecord(
+            fill_id=fill.fill_id or fill.trade_id,
+            decision_id=decision.decision_id,
+            market_id=fill.market_id,
+            token_id=fill.token_id,
+            strategy_id=fill.strategy_id,
+            strategy_version_id=fill.strategy_version_id,
+            prob_estimate=decision.prob_estimate,
+            quote_price=quote_price,
+            quote_source=self.quote_source,
+            quote_lag_seconds=quote_lag_seconds,
+            quote_score=(decision.prob_estimate - quote_price) ** 2,
+            mtm_pnl=_mtm_pnl(fill, decision, quote),
+            book_ts=quote.timestamp,
+            recorded_at=recorded_at or datetime.now(tz=UTC),
+            citations=[fill.trade_id],
+            category="unknown" if decision.model_id is None else decision.model_id,
+            model_id=decision.model_id,
+        )
+
+
+def _mtm_pnl(fill: FillRecord, decision: TradeDecision, quote: BookSummary) -> float:
+    action = decision.action if decision.action is not None else decision.side
+    if action == Side.SELL.value:
+        return (fill.fill_price - quote.best_ask) * fill.fill_quantity
+    return (quote.best_bid - fill.fill_price) * fill.fill_quantity

--- a/src/pms/evaluation/spool.py
+++ b/src/pms/evaluation/spool.py
@@ -5,12 +5,16 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, field
+from typing import Protocol
 
+from pms.core.models import BookSummary
 from pms.core.models import FillRecord, TradeDecision
 from pms.evaluation.adapters.scoring import Scorer
 from pms.evaluation.feedback import EvaluatorFeedback
 from pms.evaluation.metrics import StrategyMetricsSnapshot, StrategyVersionKey
+from pms.evaluation.quote_scoring import QuoteScorer
 from pms.storage.eval_store import EvalStore
+from pms.storage.quote_eval_store import QuoteEvalStore
 from pms.strategies.projections import EvalSpec
 
 
@@ -27,12 +31,24 @@ StrategyMetricsProvider = Callable[
 ]
 
 
+class QuoteReader(Protocol):
+    async def latest_book_summary(
+        self,
+        market_id: str,
+        token_id: str | None,
+    ) -> BookSummary | None: ...
+
+
 @dataclass
 class EvalSpool:
     store: EvalStore
     scorer: Scorer
     feedback_generator: EvaluatorFeedback | None = None
     metrics_provider: StrategyMetricsProvider | None = None
+    quote_store: QuoteEvalStore | None = None
+    quote_reader: QuoteReader | None = None
+    quote_scorer: QuoteScorer = field(default_factory=QuoteScorer)
+    quote_lag_seconds: int = 0
     _queue: asyncio.Queue[tuple[FillRecord, TradeDecision]] = field(
         default_factory=asyncio.Queue,
     )
@@ -61,10 +77,7 @@ class EvalSpool:
             fill, decision = await self._queue.get()
             try:
                 if fill.resolved_outcome is None:
-                    logger.info(
-                        "skipping unresolved fill in evaluator spool: %s",
-                        fill.trade_id,
-                    )
+                    await self._record_quote_eval(fill, decision)
                     continue
                 await self.store.append(self.scorer.score(fill, decision))
                 try:
@@ -81,3 +94,36 @@ class EvalSpool:
         if not metrics_by_strategy:
             return
         await self.feedback_generator.generate(metrics_by_strategy)
+
+    async def _record_quote_eval(
+        self,
+        fill: FillRecord,
+        decision: TradeDecision,
+    ) -> None:
+        if self.quote_store is None or self.quote_reader is None:
+            logger.info(
+                "skipping unresolved fill in evaluator spool: %s",
+                fill.trade_id,
+            )
+            return
+        try:
+            quote = await self.quote_reader.latest_book_summary(
+                fill.market_id,
+                fill.token_id,
+            )
+            if quote is None:
+                logger.info(
+                    "skipping unresolved fill without quote in evaluator spool: %s",
+                    fill.trade_id,
+                )
+                return
+            await self.quote_store.append(
+                self.quote_scorer.score(
+                    fill,
+                    decision,
+                    quote,
+                    quote_lag_seconds=self.quote_lag_seconds,
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("quote evaluation failed in evaluator spool")

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -65,6 +65,7 @@ from pms.evaluation.metrics import (
     StrategyMetricsSnapshot,
     StrategyVersionKey,
 )
+from pms.evaluation.quote_reader import TokenBookQuoteReader
 from pms.evaluation.spool import EvalSpool
 from pms.event_stream import RuntimeEventBus
 from pms.factors.catalog import ensure_factor_catalog
@@ -90,6 +91,7 @@ from pms.storage.market_data_store import PostgresMarketDataStore
 from pms.storage.market_subscription_store import PostgresMarketSubscriptionStore
 from pms.storage.opportunity_store import OpportunityStore
 from pms.storage.order_store import OrderStore
+from pms.storage.quote_eval_store import QuoteEvalStore
 from pms.storage.strategy_registry import PostgresStrategyRegistry
 from pms.strategies.aggregate import Strategy
 from pms.strategies.defaults import DEFAULT_STRATEGY_COMPOSITION
@@ -227,6 +229,7 @@ class Runner:
     decision_store: DecisionStore = field(default_factory=DecisionStore)
     order_store: OrderStore = field(default_factory=OrderStore)
     fill_store: FillStore = field(default_factory=FillStore)
+    quote_eval_store: QuoteEvalStore = field(default_factory=QuoteEvalStore)
     opportunity_store: OpportunityStore = field(default_factory=OpportunityStore)
     venue_account_reconciler: VenueAccountReconciler | None = None
     portfolio: Portfolio = field(default_factory=lambda: Portfolio(
@@ -301,6 +304,7 @@ class Runner:
             scorer=Scorer(),
             feedback_generator=EvaluatorFeedback(self.feedback_store),
             metrics_provider=self._metrics_by_strategy,
+            quote_store=self.quote_eval_store,
         )
         self._decision_queue = asyncio.Queue()
         self._stop_event = asyncio.Event()
@@ -884,6 +888,12 @@ class Runner:
             self.order_store.bind_pool(self._pg_pool)
         if isinstance(self.fill_store, FillStore):
             self.fill_store.bind_pool(self._pg_pool)
+        if isinstance(self.quote_eval_store, QuoteEvalStore):
+            self.quote_eval_store.bind_pool(self._pg_pool)
+            self._evaluator_spool.quote_store = self.quote_eval_store
+            self._evaluator_spool.quote_reader = TokenBookQuoteReader(
+                PostgresMarketDataStore(self._pg_pool)
+            )
         if isinstance(self.opportunity_store, OpportunityStore):
             self.opportunity_store.bind_pool(self._pg_pool)
         self.actuator_executor = self._build_executor(self.config.mode)
@@ -901,6 +911,9 @@ class Runner:
             self.order_store.pool = None
         if isinstance(self.fill_store, FillStore):
             self.fill_store.pool = None
+        if isinstance(self.quote_eval_store, QuoteEvalStore):
+            self.quote_eval_store.pool = None
+            self._evaluator_spool.quote_reader = None
         if isinstance(self.opportunity_store, OpportunityStore):
             self.opportunity_store.pool = None
         self.actuator_executor = self._build_executor(self.config.mode)

--- a/src/pms/storage/quote_eval_store.py
+++ b/src/pms/storage/quote_eval_store.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from typing import Any, SupportsFloat, cast
+
+import asyncpg
+
+from pms.core.models import QuoteEvalRecord
+
+
+_CREATE_QUOTE_EVAL_RECORDS_TABLE = """
+CREATE TABLE IF NOT EXISTS quote_eval_records (
+    fill_id TEXT NOT NULL,
+    decision_id TEXT NOT NULL,
+    market_id TEXT NOT NULL,
+    token_id TEXT,
+    strategy_id TEXT NOT NULL,
+    strategy_version_id TEXT NOT NULL,
+    prob_estimate DOUBLE PRECISION NOT NULL,
+    quote_price DOUBLE PRECISION NOT NULL,
+    quote_source TEXT NOT NULL,
+    quote_lag_seconds INTEGER NOT NULL,
+    quote_score DOUBLE PRECISION NOT NULL,
+    mtm_pnl DOUBLE PRECISION NOT NULL,
+    book_ts TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    citations JSONB NOT NULL DEFAULT '[]'::jsonb,
+    category TEXT,
+    model_id TEXT,
+    PRIMARY KEY (fill_id, quote_lag_seconds),
+    CONSTRAINT quote_eval_records_strategy_identity_check
+        CHECK (strategy_id != '' AND strategy_version_id != '')
+)
+"""
+
+_SELECT_COLUMNS = """
+SELECT
+    fill_id,
+    decision_id,
+    market_id,
+    token_id,
+    strategy_id,
+    strategy_version_id,
+    prob_estimate,
+    quote_price,
+    quote_source,
+    quote_lag_seconds,
+    quote_score,
+    mtm_pnl,
+    book_ts,
+    recorded_at,
+    citations,
+    category,
+    model_id
+FROM quote_eval_records
+"""
+
+
+@dataclass
+class QuoteEvalStore:
+    pool: asyncpg.Pool | None = None
+
+    def bind_pool(self, pool: asyncpg.Pool) -> None:
+        self.pool = pool
+
+    async def append(self, record: QuoteEvalRecord) -> None:
+        async with self._pool().acquire() as connection:
+            await _ensure_quote_eval_records_table(connection)
+            await connection.execute(
+                """
+                INSERT INTO quote_eval_records (
+                    fill_id,
+                    decision_id,
+                    market_id,
+                    token_id,
+                    strategy_id,
+                    strategy_version_id,
+                    prob_estimate,
+                    quote_price,
+                    quote_source,
+                    quote_lag_seconds,
+                    quote_score,
+                    mtm_pnl,
+                    book_ts,
+                    recorded_at,
+                    citations,
+                    category,
+                    model_id
+                ) VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+                    $15::jsonb, $16, $17
+                )
+                ON CONFLICT (fill_id, quote_lag_seconds) DO UPDATE
+                SET decision_id = EXCLUDED.decision_id,
+                    market_id = EXCLUDED.market_id,
+                    token_id = EXCLUDED.token_id,
+                    strategy_id = EXCLUDED.strategy_id,
+                    strategy_version_id = EXCLUDED.strategy_version_id,
+                    prob_estimate = EXCLUDED.prob_estimate,
+                    quote_price = EXCLUDED.quote_price,
+                    quote_source = EXCLUDED.quote_source,
+                    quote_score = EXCLUDED.quote_score,
+                    mtm_pnl = EXCLUDED.mtm_pnl,
+                    book_ts = EXCLUDED.book_ts,
+                    recorded_at = EXCLUDED.recorded_at,
+                    citations = EXCLUDED.citations,
+                    category = EXCLUDED.category,
+                    model_id = EXCLUDED.model_id
+                """,
+                record.fill_id,
+                record.decision_id,
+                record.market_id,
+                record.token_id,
+                record.strategy_id,
+                record.strategy_version_id,
+                record.prob_estimate,
+                record.quote_price,
+                record.quote_source,
+                record.quote_lag_seconds,
+                record.quote_score,
+                record.mtm_pnl,
+                record.book_ts,
+                record.recorded_at,
+                json.dumps(record.citations),
+                record.category,
+                record.model_id,
+            )
+
+    async def all(self) -> list[QuoteEvalRecord]:
+        if self.pool is None:
+            return []
+
+        async with self.pool.acquire() as connection:
+            rows = await connection.fetch(
+                _SELECT_COLUMNS + "\nORDER BY recorded_at ASC, fill_id ASC"
+            )
+        return [_quote_eval_record_from_row(row) for row in rows]
+
+    async def all_for_strategy(
+        self,
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> list[QuoteEvalRecord]:
+        if self.pool is None:
+            return []
+
+        async with self.pool.acquire() as connection:
+            rows = await connection.fetch(
+                _SELECT_COLUMNS
+                + """
+                WHERE strategy_id = $1 AND strategy_version_id = $2
+                ORDER BY recorded_at ASC, fill_id ASC
+                """,
+                strategy_id,
+                strategy_version_id,
+            )
+        return [_quote_eval_record_from_row(row) for row in rows]
+
+    def _pool(self) -> asyncpg.Pool:
+        if self.pool is None:
+            msg = "QuoteEvalStore pool is not bound"
+            raise RuntimeError(msg)
+        return self.pool
+
+
+async def _ensure_quote_eval_records_table(connection: asyncpg.Connection) -> None:
+    await connection.execute(_CREATE_QUOTE_EVAL_RECORDS_TABLE)
+    await connection.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_quote_eval_records_strategy_identity_recorded_at
+            ON quote_eval_records(strategy_id, strategy_version_id, recorded_at DESC)
+        """
+    )
+
+
+def _quote_eval_record_from_row(row: Mapping[str, Any]) -> QuoteEvalRecord:
+    citations_value = row["citations"]
+    citations: list[str]
+    if isinstance(citations_value, list):
+        citations = [str(item) for item in citations_value]
+    elif isinstance(citations_value, str):
+        loaded = json.loads(citations_value)
+        citations = [str(item) for item in loaded] if isinstance(loaded, list) else []
+    else:
+        citations = []
+
+    return QuoteEvalRecord(
+        fill_id=cast(str, row["fill_id"]),
+        decision_id=cast(str, row["decision_id"]),
+        market_id=cast(str, row["market_id"]),
+        token_id=cast(str | None, row["token_id"]),
+        strategy_id=cast(str, row["strategy_id"]),
+        strategy_version_id=cast(str, row["strategy_version_id"]),
+        prob_estimate=float(cast(SupportsFloat, row["prob_estimate"])),
+        quote_price=float(cast(SupportsFloat, row["quote_price"])),
+        quote_source=cast(str, row["quote_source"]),
+        quote_lag_seconds=int(row["quote_lag_seconds"]),
+        quote_score=float(cast(SupportsFloat, row["quote_score"])),
+        mtm_pnl=float(cast(SupportsFloat, row["mtm_pnl"])),
+        book_ts=cast(datetime, row["book_ts"]),
+        recorded_at=cast(datetime, row["recorded_at"]),
+        citations=citations,
+        category=cast(str | None, row["category"]),
+        model_id=cast(str | None, row["model_id"]),
+    )

--- a/tests/integration/test_schema_apply_inner.py
+++ b/tests/integration/test_schema_apply_inner.py
@@ -20,6 +20,7 @@ STRATEGY_TABLES = [
     "order_intents",
     "opportunities",
     "orders",
+    "quote_eval_records",
     "strategy_execution_artifacts",
     "strategy_judgement_artifacts",
 ]
@@ -29,6 +30,7 @@ CHECK_CONSTRAINTS = [
     "fills_strategy_identity_check",
     "opportunities_strategy_identity_check",
     "orders_strategy_identity_check",
+    "quote_eval_records_strategy_identity_check",
     "strategy_execution_artifacts_strategy_identity_check",
     "strategy_judgement_artifacts_strategy_identity_check",
 ]
@@ -38,6 +40,7 @@ STRATEGY_INDEXES = [
     "idx_fills_strategy_identity",
     "idx_opportunities_strategy_identity",
     "idx_orders_strategy_identity",
+    "idx_quote_eval_records_strategy_identity_recorded_at",
     "idx_strategy_execution_artifacts_strategy_created_at",
     "idx_strategy_judgement_artifacts_strategy_created_at",
 ]

--- a/tests/integration/test_schema_apply_inner.py
+++ b/tests/integration/test_schema_apply_inner.py
@@ -242,6 +242,7 @@ def test_schema_sql_applies_inner_ring_strategy_identity_constraints() -> None:
                 'orders',
                 'fills',
                 'opportunities',
+                'quote_eval_records',
                 'strategy_execution_artifacts',
                 'strategy_judgement_artifacts'
               )
@@ -267,6 +268,8 @@ def test_schema_sql_applies_inner_ring_strategy_identity_constraints() -> None:
             ("opportunities", "strategy_version_id", "NO"),
             ("orders", "strategy_id", "NO"),
             ("orders", "strategy_version_id", "NO"),
+            ("quote_eval_records", "strategy_id", "NO"),
+            ("quote_eval_records", "strategy_version_id", "NO"),
             ("strategy_execution_artifacts", "strategy_id", "NO"),
             ("strategy_execution_artifacts", "strategy_version_id", "NO"),
             ("strategy_judgement_artifacts", "strategy_id", "NO"),
@@ -286,6 +289,7 @@ def test_schema_sql_applies_inner_ring_strategy_identity_constraints() -> None:
                 'orders_strategy_identity_check',
                 'fills_strategy_identity_check',
                 'opportunities_strategy_identity_check',
+                'quote_eval_records_strategy_identity_check',
                 'strategy_execution_artifacts_strategy_identity_check',
                 'strategy_judgement_artifacts_strategy_identity_check'
             )
@@ -308,6 +312,7 @@ def test_schema_sql_applies_inner_ring_strategy_identity_constraints() -> None:
                 'idx_orders_strategy_identity',
                 'idx_fills_strategy_identity',
                 'idx_opportunities_strategy_identity',
+                'idx_quote_eval_records_strategy_identity_recorded_at',
                 'idx_strategy_execution_artifacts_strategy_created_at',
                 'idx_strategy_judgement_artifacts_strategy_created_at'
             )

--- a/tests/unit/test_api_cp09.py
+++ b/tests/unit/test_api_cp09.py
@@ -18,6 +18,8 @@ from pms.core.models import (
     Feedback,
     FillRecord,
     MarketSignal,
+    Position,
+    QuoteEvalRecord,
     TradeDecision,
 )
 from pms.metrics import (
@@ -29,6 +31,8 @@ from pms.metrics import (
 from pms.runner import Runner
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
+from pms.storage.fill_store import FillStore
+from pms.storage.quote_eval_store import QuoteEvalStore
 from pms.storage.schema_check import SchemaVersionMismatchError
 from tests.support.fake_stores import InMemoryEvalStore, InMemoryFeedbackStore
 
@@ -181,6 +185,79 @@ def _feedback(feedback_id: str) -> Feedback:
         created_at=datetime(2026, 4, 14, tzinfo=UTC),
         category="brier:model-a",
     )
+
+
+def _quote_eval_record() -> QuoteEvalRecord:
+    return QuoteEvalRecord(
+        fill_id="trade-api",
+        decision_id="decision-api",
+        market_id="api-market",
+        token_id="yes-token",
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        prob_estimate=0.7,
+        quote_price=0.64,
+        quote_source="postgres_snapshot",
+        quote_lag_seconds=3600,
+        quote_score=0.0036,
+        mtm_pnl=1.2,
+        book_ts=datetime(2026, 4, 14, 1, tzinfo=UTC),
+        recorded_at=datetime(2026, 4, 14, 1, tzinfo=UTC),
+        citations=["trade-api"],
+        category="model-a",
+        model_id="model-a",
+    )
+
+
+class _PositionStore:
+    async def read_positions(self) -> list[Position]:
+        return [
+            Position(
+                market_id="api-market",
+                token_id="yes-token",
+                venue="polymarket",
+                side=Side.BUY.value,
+                shares_held=10.0,
+                avg_entry_price=0.50,
+                unrealized_pnl=1.2,
+                locked_usdc=5.0,
+            )
+        ]
+
+
+class _QuoteEvalStore:
+    async def all(self) -> list[QuoteEvalRecord]:
+        return [_quote_eval_record()]
+
+
+@pytest.mark.asyncio
+async def test_api_quality_payload_separates_brier_mtm_and_quote_calibration() -> None:
+    runner = _runner_with_state()
+    runner.fill_store = cast(FillStore, _PositionStore())
+    runner.quote_eval_store = cast(QuoteEvalStore, _QuoteEvalStore())
+    app = create_app(runner)
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        status = (await client.get("/status")).json()
+        metrics = (await client.get("/metrics")).json()
+
+    assert status["quality"]["final_brier"] == {
+        "record_count": 1,
+        "brier_overall": 0.09,
+    }
+    assert status["quality"]["mark_to_market"] == {
+        "open_positions": 1,
+        "locked_usdc": 5.0,
+        "unrealized_pnl": 1.2,
+    }
+    assert status["quality"]["quote_calibration"] == {
+        "record_count": 1,
+        "quote_score_overall": 0.0036,
+        "mtm_pnl": 1.2,
+    }
+    assert metrics["mark_to_market"]["unrealized_pnl"] == 1.2
+    assert metrics["quote_calibration"]["quote_score_overall"] == 0.0036
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_evaluation_cp07.py
+++ b/tests/unit/test_evaluation_cp07.py
@@ -8,13 +8,14 @@ from typing import cast
 import pytest
 
 from pms.core.enums import FeedbackSource, FeedbackTarget, OrderStatus, Side, TimeInForce
-from pms.core.models import EvalRecord, Feedback, FillRecord, TradeDecision
+from pms.core.models import BookSummary, EvalRecord, Feedback, FillRecord, TradeDecision
 from pms.evaluation.adapters.scoring import Scorer
 from pms.evaluation.feedback import EvaluatorFeedback
 from pms.evaluation.metrics import (
     MetricsCollector,
     StrategyMetricsSnapshot,
 )
+from pms.evaluation.quote_scoring import QuoteScorer
 from pms.evaluation.spool import EvalSpool
 from pms.storage.eval_store import EvalStore
 from pms.storage.feedback_store import FeedbackStore
@@ -157,6 +158,32 @@ def test_scorer_brier_known_values() -> None:
 
     assert first.brier_score == pytest.approx(0.09)
     assert second.brier_score == pytest.approx(0.25)
+
+
+def test_quote_scorer_uses_midpoint_for_calibration_and_bid_for_buy_mtm() -> None:
+    quote = BookSummary(
+        best_bid=0.62,
+        best_ask=0.66,
+        spread_bps=625.0,
+        depth_usdc=250.0,
+        timestamp=datetime(2026, 4, 14, 11, 0, tzinfo=UTC),
+    )
+
+    record = QuoteScorer().score(
+        _fill(decision_id="d-quote", resolved_outcome=None, fill_price=0.50),
+        _decision(decision_id="d-quote", prob=0.70, price=0.50),
+        quote,
+        quote_lag_seconds=3600,
+        recorded_at=datetime(2026, 4, 14, 11, 0, tzinfo=UTC),
+    )
+
+    assert record.fill_id == "trade-d-quote"
+    assert record.quote_lag_seconds == 3600
+    assert record.prob_estimate == pytest.approx(0.70)
+    assert record.quote_price == pytest.approx(0.64)
+    assert record.quote_score == pytest.approx((0.70 - 0.64) ** 2)
+    assert record.mtm_pnl == pytest.approx((0.62 - 0.50) * 10.0)
+    assert record.category == "model-a"
 
 
 def test_scorer_pnl_for_buy_no_uses_complementary_contract_outcome() -> None:

--- a/tests/unit/test_quote_eval_store.py
+++ b/tests/unit/test_quote_eval_store.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+
+import asyncpg
+import pytest
+
+from pms.core.models import QuoteEvalRecord
+from pms.storage.quote_eval_store import QuoteEvalStore
+
+
+class _RecordingConnection:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetch_calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fetch_rows: list[object] = []
+
+    async def execute(self, query: str, *args: object) -> str:
+        self.execute_calls.append((query, args))
+        return "OK"
+
+    async def fetch(self, query: str, *args: object) -> list[object]:
+        self.fetch_calls.append((query, args))
+        return list(self.fetch_rows)
+
+
+class _AcquireContext:
+    def __init__(self, connection: _RecordingConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> _RecordingConnection:
+        return self._connection
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        del exc_type, exc, tb
+
+
+class _RecordingPool:
+    def __init__(self, connection: _RecordingConnection) -> None:
+        self._connection = connection
+
+    def acquire(self) -> _AcquireContext:
+        return _AcquireContext(self._connection)
+
+
+def _record() -> QuoteEvalRecord:
+    return QuoteEvalRecord(
+        fill_id="fill-quote-unit",
+        decision_id="decision-quote-unit",
+        market_id="market-quote-unit",
+        token_id="token-quote-unit",
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        prob_estimate=0.70,
+        quote_price=0.64,
+        quote_source="postgres_snapshot",
+        quote_lag_seconds=3600,
+        quote_score=0.0036,
+        mtm_pnl=1.2,
+        book_ts=datetime(2026, 4, 14, 11, 0, tzinfo=UTC),
+        recorded_at=datetime(2026, 4, 14, 11, 0, tzinfo=UTC),
+        citations=["trade-quote-unit"],
+        category="model-a",
+        model_id="model-a",
+    )
+
+
+@pytest.mark.asyncio
+async def test_quote_eval_store_requires_bound_pool_for_append() -> None:
+    with pytest.raises(RuntimeError, match="QuoteEvalStore pool is not bound"):
+        await QuoteEvalStore().append(_record())
+
+
+@pytest.mark.asyncio
+async def test_quote_eval_store_appends_idempotent_rows() -> None:
+    connection = _RecordingConnection()
+    store = QuoteEvalStore(cast(asyncpg.Pool, _RecordingPool(connection)))
+
+    await store.append(_record())
+
+    assert "CREATE TABLE IF NOT EXISTS quote_eval_records" in connection.execute_calls[0][0]
+    assert "idx_quote_eval_records_strategy_identity_recorded_at" in connection.execute_calls[1][0]
+    insert_query, insert_args = connection.execute_calls[2]
+    assert "ON CONFLICT (fill_id, quote_lag_seconds) DO UPDATE" in insert_query
+    assert len(insert_args) == 17
+    assert insert_args[:4] == (
+        "fill-quote-unit",
+        "decision-quote-unit",
+        "market-quote-unit",
+        "token-quote-unit",
+    )
+
+
+@pytest.mark.asyncio
+async def test_quote_eval_store_maps_rows() -> None:
+    connection = _RecordingConnection()
+    connection.fetch_rows = [
+        {
+            "fill_id": "fill-quote-unit",
+            "decision_id": "decision-quote-unit",
+            "market_id": "market-quote-unit",
+            "token_id": "token-quote-unit",
+            "strategy_id": "default",
+            "strategy_version_id": "default-v1",
+            "prob_estimate": 0.70,
+            "quote_price": 0.64,
+            "quote_source": "postgres_snapshot",
+            "quote_lag_seconds": 3600,
+            "quote_score": 0.0036,
+            "mtm_pnl": 1.2,
+            "book_ts": datetime(2026, 4, 14, 11, 0, tzinfo=UTC),
+            "recorded_at": datetime(2026, 4, 14, 11, 0, tzinfo=UTC),
+            "citations": ["trade-quote-unit"],
+            "category": "model-a",
+            "model_id": "model-a",
+        }
+    ]
+    store = QuoteEvalStore(cast(asyncpg.Pool, _RecordingPool(connection)))
+
+    assert await store.all() == [_record()]
+    assert "ORDER BY recorded_at ASC, fill_id ASC" in connection.fetch_calls[0][0]

--- a/tests/unit/test_schema_invariant_8.py
+++ b/tests/unit/test_schema_invariant_8.py
@@ -80,6 +80,7 @@ def test_inner_ring_product_tables_continue_to_carry_strategy_tags() -> None:
     expected_per_row_tables = {
         "feedback",
         "eval_records",
+        "quote_eval_records",
         "orders",
         "fills",
         "opportunities",


### PR DESCRIPTION
## Summary
- add a separate quote-based evaluation path for unresolved fills without changing final resolved-outcome Brier semantics
- persist `quote_eval_records` with strategy identity, quote score, MtM PnL, quote source, lag, and book timestamp
- expose final Brier, mark-to-market, and quote calibration separately in `/status` and `/metrics`

## Why
The evaluator previously skipped unresolved paper fills, so active positions could have no strategy-quality signal until final market resolution. This preserves final Brier as the audited terminal score while adding earlier operator-facing signals from CLOB quotes and current positions.

## Validation
- `uv sync`
- `uv run pytest -q` (`1219 passed, 168 skipped`)
- `uv run mypy src/ tests/ --strict`
- `git diff --check`

## Notes
- Untracked `pms-api.log.*.archive` files were intentionally left out of this PR.
- `uv sync` removed optional live-extra packages from the local environment; run `uv sync --extra live` before live-path testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quote evaluation pipeline: capture, score and store quote-level evaluation records; surfaced quote calibration, mark-to-market and final brier in /status and /metrics.
* **Chores (Schema & Storage)**
  * Introduced new persistent quote_eval_records table with strategy identity checks and index; new quote eval store with upsert/queries.
* **Tests**
  * Added unit and integration tests covering scoring, storage, schema and API quality payloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/prediction-market-system/pull/72)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->