### PR TITLE
docs(ops): document paper-soak subscription bootstrap step

### DIFF
--- a/docs/operations/fly-deploy-runbook.md
+++ b/docs/operations/fly-deploy-runbook.md
@@ -109,6 +109,40 @@ volume-backed `/secure/pms/first-order.json` path.
 The Fly health check targets `/readiness`, not `/health`. A process that is
 alive but has not started the runner and halt subscriber should stay unready.
 
+## Paper soak: seed initial subscriptions
+
+A freshly deployed paper soak idles at zero decisions until at least one market
+is subscribed. This is by design, not a fault: active-perception auto-selection
+only subscribes to markets that already have a streamed two-sided book
+(`MarketSelector._market_passes_filters` filters out any market whose
+`get_latest_book_summary` is `None`; the `missing-book` case in
+`tests/unit/test_market_selector.py` pins this). A cold database has no streamed
+books, so auto-selection has nothing to expand from.
+
+Bootstrap it once per soak by seeding user subscriptions, which merge unfiltered
+(`UnionMergePolicy`) and start the book stream; auto-selection expands from
+there. Subscribe each token you want to soak (authenticate with `PMS_API_TOKEN`
+because the soak binds `PMS_API_HOST=0.0.0.0`):
+
+```bash
+curl -fsS -X POST \
+  -H "Authorization: Bearer $PMS_API_TOKEN" \
+  "https://pms-paper-soak.fly.dev/markets/<token_id>/subscribe"
+```
+
+Then confirm the stream and decision flow are live before walking away:
+
+```bash
+# book_snapshots should climb; decisions_total should move off zero once the
+# strategy factors warm up against the streamed book.
+curl -fsS -H "Authorization: Bearer $PMS_API_TOKEN" \
+  https://pms-paper-soak.fly.dev/status | jq '.controller, .actuator'
+```
+
+Pick the seed markets to match the strategy's edge (e.g. the H1 FLB longshot/
+favorite price extremes), not arbitrarily — a soak of markets the strategy never
+trades produces no usable Go/No-Go evidence.
+
 ## Logs
 
 ```bash


### PR DESCRIPTION
A freshly deployed paper soak idles at zero decisions until a market is subscribed, because active-perception auto-selection only picks markets that already have a streamed two-sided book (by design; pinned by the missing-book case in test_market_selector). Document the one-time user-subscription seed (which merges unfiltered and starts the book stream) so an operator does not mistake an idle soak for a broken one, and note that seed markets must match the strategy edge to produce usable Go/No-Go evidence.

# Pull Request

**Open as Ready for review, never as Draft. Any section left empty means the PR is not ready for review.**

## Summary

<one paragraph: what user-visible or API-visible state changes when this merges>

## Why

<one paragraph: the user pain or constraint that justifies this change. Cite the issue: closes #NNN or the Multica issue link>

## Approach

<one or two paragraphs: how it was implemented. Name modules touched, key design choices, alternatives rejected with the constraint that ruled them out, and anything intentionally deferred>

## How I Tested

<for frontend changes: include ### Before / ### After screenshots, numbered manual flows, browser matrix>

<for backend changes: include end-to-end test case table with test file:line, verbatim test output redacted as needed, and curl or multica CLI evidence for new endpoints>

<for any change: include existing tests run, new tests added with file:line, and lint/typecheck output>

A PR with no validation evidence in this section is rejected at first read.

## Rollback Plan

<how to revert. State two things explicitly:

1. **Maximum blast radius** of a wrong merge (zero / single feature / data integrity / cross-tenant — pick the most severe accurate label)
2. **Time-to-rollback** (under one minute / one deploy cycle / requires data migration — be honest)

If rollback requires anything beyond `git revert`, list the steps in order.>

## Out of Scope

- <thing this PR explicitly does not change>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fly deploy runbook to include new section on seeding initial subscriptions for freshly deployed paper soak instances. Added operator guidance with example commands and status-check procedures to verify proper initialization and confirm data flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/prediction-market-system/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->