### PR TITLE
fix: production-readiness pass — risk_group_id Gamma parse, controller diagnostics, paper fees

### DIFF
--- a/agent_docs/production-readiness-2026-05.md
+++ b/agent_docs/production-readiness-2026-05.md
@@ -455,6 +455,74 @@ live, validating one of the items called out in the original review.
 
 ---
 
+## 10. Work block — 2026-05-30 (production-readiness pass)
+
+Goal: *no bugs, paper trading passes, production code ready to interact
+with Polymarket* (credentials deferred). Findings came from a 6-dimension
+parallel investigation cross-checked against the **live** Gamma API
+(runtime behaviour > design intent).
+
+### 10.1 Code fixes landed (3 commits, all TDD + atomic)
+
+| Commit | Subject | Why it mattered |
+| --- | --- | --- |
+| `0a96d80` | `fix(sensor): derive risk_group_id from Gamma events[] array` | **Linchpin bug.** Live Gamma `/markets` returns the event grouping as `events:[{id,ticker,...}]`, not a scalar `eventId`/`category`. The parser read the scalar → every market got `risk_group_id=NULL` → under production `max_exposure_per_risk_group=15.0` the actuator rejected **every** order with `missing_risk_group_id`. The existing regression test invented a scalar `row['eventId']` fixture the real API never sends, so CI was green while production could not trade. Verified live: 0/100 → 100/101 markets carry a risk group. |
+| `2d03df2` | `fix(controller): emit diagnostics for the remaining on_signal drops` | 5 operationally-meaningful silent returns (composition-failed [error], calibration-clamp, edge≤0, size<min, cooldown) left `/status` showing 0 diagnostics while every signal was being dropped — "idle" was indistinguishable from "all filtered". Pure observability; no decision-logic change. |
+| `697c759` | `fix(runner): model Polymarket fee on paper/backtest fills` | Paper fills carried `fees=None`/`fee_bps=None`, so `average_net_edge_bps`/`average_fee_bps` rendered N/A and a paper GO was unreachable; paper P&L also overstated edge vs live. Paper/backtest fills now carry the configured `strategies.flb_fee_rate` fee (LIVE keeps venue reconciliation as source of truth). |
+
+### 10.2 Verified production-ready *as code* (no fix needed)
+
+- **LIVE Polymarket adapter** (`actuator/adapters/polymarket.py`): fail-closed;
+  `live_trading_enabled` gate first, credential validation before approval,
+  exact 8-field every-order approval matching, lock-protected approve+submit,
+  pre-submit quote guard. No path moves money without all gates passing.
+- **Credentialed preflight + live config gating** (`live_cli.py`,
+  `live_preflight.py`, `config.py`): exits non-zero on any failed check,
+  `--skip-venue` invalid for final go/no-go, operator-readiness fields enforced
+  fail-closed at startup, risk-metadata check joins `markets` on `condition_id`
+  (commit `a8feb8d`).
+
+### 10.3 Verification (this block)
+
+- **Gates:** `pytest` 2259 passed / 174 skipped; `mypy --strict` clean
+  (444 files); `lint-imports` 9/9.
+- **Config restored** to production-tight caps (the 2026-05-28 paper-link
+  hacks reverted); guard test `test_live_soak_config_loads_tight_first_live_risk_caps`
+  passes.
+- **Live end-to-end under production-tight config** (`config.live-soak.yaml`,
+  `max_exposure_per_risk_group=15.0` ON, `pms_soak` DB with
+  `risk_group_id` reset to NULL first): live discovery backfilled
+  `risk_group_id` to 100/101 markets (`event:30615`=48 World-Cup markets,
+  etc.); 15 decisions → 8 fills across 5 markets; order payloads carry the
+  risk group (`event:23784`, …); **0 `missing_risk_group_id` rejections**
+  (only legitimate `insufficient_liquidity`/`min_order_usdc`). This proves
+  the linchpin fix end-to-end: Gamma `events[]` → discovery → markets table
+  → sensor signal → decision → actuator order.
+
+### 10.4 Open decisions for the credential phase (non-blocking now)
+
+Both are product/domain choices that mainly bind at the live GO, which needs
+credentials anyway. Surfaced explicitly so they are not silently assumed:
+
+1. **Live operational strategy.** `default` is intentionally **fail-closed**
+   without external enrichment — `test_default_strategy_does_not_trade_when_required_raw_factors_missing`
+   asserts this is correct. Its required factors (`metaculus_prior`,
+   `fair_value_spread`, `subset_pricing_violation`, `yes_count`, `no_count`)
+   need an external-data pipeline not wired for Polymarket. The strategies
+   that *do* trade on Polymarket-only signals (`paper_multi_factor_v1`,
+   `paper_canary_v1`) are `live_allowed: false`. **Decision needed:** (a)
+   harden `paper_multi_factor_v1` → `live_allowed`, (b) wire external
+   enrichment so `default` trades, or (c) ship FLB live. Until then, paper
+   trades via `paper_multi_factor_v1`; no LIVE-allowed Polymarket-only
+   strategy exists.
+2. **Polymarket fee rate.** Paper fills now use `strategies.flb_fee_rate=0.04`
+   (the repo's own canonical estimate, also in `ExecutionModel.polymarket_live_estimate`).
+   **Decision needed:** confirm `0.04` against Polymarket's actual fee
+   schedule before the final GO (operator-tunable via config; set to `0`
+   if Polymarket charges no taker fee on the target markets).
+
+---
+
 ## Provenance
 
 This doc consolidates an external production-readiness review pasted

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -6,16 +6,16 @@ from datetime import UTC, datetime
 from hashlib import sha256
 import json
 import uuid
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Literal, TypeVar, cast
+from typing import Any, Literal, TypeVar, cast
 
 from pms.config import PMSSettings
 from pms.controller._price_utils import best_ask, spread_bps_at_decision
 from pms.controller.calibrators.extreme_clamp import ExtremeProbClamp
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.calibrators.shrinkage import LogitShrinkageCalibrator
-from pms.controller.diagnostics import ControllerDiagnostic
+from pms.controller.diagnostics import ControllerDiagnostic, DiagnosticSeverity
 from pms.controller.factor_snapshot import (
     FactorKey,
     FactorSnapshotReader,
@@ -85,6 +85,39 @@ class ControllerPipeline:
             self.sizer = KellySizer(risk=self.settings.risk)
         if self.router is None:
             self.router = Router(self.settings.controller)
+
+    def _set_drop_diagnostic(
+        self,
+        signal: MarketSignal,
+        *,
+        code: str,
+        message: str,
+        severity: DiagnosticSeverity = "info",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Record (and log) a ControllerDiagnostic for a signal that the
+        pipeline drops without emitting a decision.
+
+        Every operationally-meaningful early return in ``on_signal`` calls this
+        so an operator watching ``state.controller_diagnostics`` can tell *why*
+        order flow stopped — distinguishing 'idle' from 'every signal filtered'.
+        """
+        self.last_diagnostic = ControllerDiagnostic(
+            code=code,
+            message=message,
+            market_id=signal.market_id,
+            strategy_id=self.strategy_id,
+            strategy_version_id=self.strategy_version_id,
+            token_id=signal.token_id,
+            severity=severity,
+            metadata=dict(metadata or {}),
+        )
+        logger.info(
+            "controller diagnostic %s for %s",
+            code,
+            signal.market_id,
+            extra={"controller_diagnostic": self.last_diagnostic},
+        )
 
     async def on_signal(
         self,
@@ -296,6 +329,19 @@ class ControllerPipeline:
                     }
             except (KeyError, ValueError) as exc:
                 logger.warning("composition resolution failed: %s", exc)
+                self._set_drop_diagnostic(
+                    signal,
+                    code="composition_resolution_failed",
+                    message=(
+                        "Skipping decision because factor composition could not "
+                        "resolve a probability."
+                    ),
+                    severity="error",
+                    metadata={
+                        "error_type": type(exc).__name__,
+                        "error": str(exc),
+                    },
+                )
                 _log_pipeline_funnel(
                     signal,
                     forecasted_count=len(probabilities),
@@ -313,6 +359,16 @@ class ControllerPipeline:
             signal=signal,
         )
         if calibrated_estimate is None:
+            self._set_drop_diagnostic(
+                signal,
+                code="calibration_clamp_rejected",
+                message=(
+                    "Skipping decision because pre-calibration rejected the "
+                    "forecast (extreme probability with insufficient resolved "
+                    "samples to trust it)."
+                ),
+                metadata={"raw_probability": prob_estimate},
+            )
             _log_pipeline_funnel(
                 signal,
                 forecasted_count=len(probabilities),
@@ -370,6 +426,20 @@ class ControllerPipeline:
             decision_price = max(1e-6, min(1.0 - 1e-6, 1.0 - yes_reference_price))
             decision_edge = decision_probability - decision_price
         if decision_edge <= 0.0:
+            self._set_drop_diagnostic(
+                signal,
+                code="decision_edge_not_positive",
+                message=(
+                    "Skipping decision because the best available edge after "
+                    "side selection is not positive."
+                ),
+                metadata={
+                    "decision_edge": decision_edge,
+                    "decision_outcome": decision_outcome,
+                    "decision_probability": decision_probability,
+                    "decision_price": decision_price,
+                },
+            )
             _log_pipeline_funnel(
                 signal,
                 forecasted_count=len(probabilities),
@@ -386,6 +456,19 @@ class ControllerPipeline:
             min_order_usdc = self.strategy.risk.min_order_size_usdc
         if size <= 0.0 or size < min_order_usdc:
             self.suppressed_zero_size += 1
+            self._set_drop_diagnostic(
+                signal,
+                code="order_size_below_minimum",
+                message=(
+                    "Skipping decision because the sized order is below the "
+                    "minimum order notional."
+                ),
+                metadata={
+                    "size_usdc": size,
+                    "min_order_usdc": min_order_usdc,
+                    "decision_outcome": decision_outcome,
+                },
+            )
             _log_pipeline_funnel(
                 signal,
                 forecasted_count=len(probabilities),
@@ -405,6 +488,18 @@ class ControllerPipeline:
             current_ts=signal.timestamp,
             settings=self.settings,
         ):
+            self._set_drop_diagnostic(
+                signal,
+                code="within_decision_cooldown",
+                message=(
+                    "Skipping decision because an identical decision was emitted "
+                    "within the configured cooldown window."
+                ),
+                metadata={
+                    "cooldown_s": self.settings.controller.decision_cooldown_s,
+                    "decision_outcome": decision_outcome,
+                },
+            )
             _log_pipeline_funnel(
                 signal,
                 forecasted_count=len(probabilities),

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -1389,7 +1389,17 @@ class Runner:
                             error=error,
                         )
                     logger.warning("order persistence failed: %s", error)
-                fill = _fill_from_order(order_state, decision, signal)
+                # LIVE fills get their real fee from venue reconciliation; for
+                # paper/backtest, model it from the configured rate so net-edge
+                # metrics are not inflated.
+                fill_fee_rate = (
+                    None
+                    if self.config.mode == RunMode.LIVE
+                    else self.config.strategies.flb_fee_rate
+                )
+                fill = _fill_from_order(
+                    order_state, decision, signal, fee_rate=fill_fee_rate
+                )
                 if fill is not None:
                     _append_bounded(self.state.fills, fill)
                     try:
@@ -2801,6 +2811,8 @@ def _fill_from_order(
     order_state: OrderState,
     decision: TradeDecision,
     signal: MarketSignal | None,
+    *,
+    fee_rate: float | None = None,
 ) -> FillRecord | None:
     # Emit a FillRecord whenever the venue reports a non-zero positive
     # fill, regardless of the order's terminal status. Polymarket can
@@ -2813,6 +2825,21 @@ def _fill_from_order(
         return None
     if order_state.filled_notional_usdc <= 0.0:
         return None
+
+    # Simulated (paper/backtest) fills carry the modelled Polymarket fee so the
+    # evaluator's net-edge gate can compute instead of rendering N/A, and so
+    # paper P&L is not inflated relative to live. fee_rate is None for LIVE
+    # fills — there the venue reports the real fee via reconciliation, and we
+    # must not synthesize over it. Formula matches ExecutionModel.compute_fee.
+    fees: float | None = None
+    fee_bps: int | None = None
+    if fee_rate is not None:
+        fees = (
+            order_state.filled_notional_usdc
+            * fee_rate
+            * (1.0 - order_state.fill_price)
+        )
+        fee_bps = int(fee_rate * 10_000)
 
     return FillRecord(
         trade_id=order_state.order_id,
@@ -2833,6 +2860,8 @@ def _fill_from_order(
         strategy_version_id=decision.strategy_version_id,
         resolved_outcome=_resolved_outcome(signal),
         risk_group_id=decision.risk_group_id,
+        fees=fees,
+        fee_bps=fee_bps,
     )
 
 

--- a/src/pms/sensor/adapters/market_discovery.py
+++ b/src/pms/sensor/adapters/market_discovery.py
@@ -194,6 +194,7 @@ def _gamma_market_to_market(row: dict[str, Any], fetched_at: datetime) -> Market
         _first_non_empty_value(
             row.get("eventId"),
             row.get("event_id"),
+            _gamma_first_event_id(row),
         )
     )
     category = _optional_text(
@@ -501,6 +502,29 @@ def _optional_text(value: object) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _gamma_first_event_id(row: dict[str, Any]) -> str | None:
+    """Extract the event id from the Gamma ``events`` array.
+
+    The live Gamma ``/markets`` endpoint returns the event grouping as
+    ``events: [{"id": ..., "ticker": ...}, ...]`` rather than a scalar
+    ``eventId``. Every market belongs to an event, and all markets under one
+    event share that ``id`` — making it the natural risk-group key (markets in
+    one event, e.g. a single tournament or neg-risk group, are correlated, so
+    they should share the ``max_exposure_per_risk_group`` budget). Returns the
+    first event's id, or ``None`` when the array is absent, empty, or malformed.
+    """
+    events = row.get("events")
+    if not isinstance(events, list):
+        return None
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_id = event.get("id")
+        if event_id is not None and str(event_id).strip() != "":
+            return str(event_id)
+    return None
 
 
 def _market_risk_group_id(

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -3929,6 +3929,59 @@ def test_fill_from_order_drops_zero_filled_state() -> None:
     assert _fill_from_order(no_fill_state, decision, None) is None
 
 
+def _filled_state(decision: object) -> OrderState:
+    d = cast("TradeDecision", decision)
+    return OrderState(
+        order_id="paper-fee-1",
+        decision_id=d.decision_id,
+        status="matched",
+        market_id=d.market_id,
+        token_id=d.token_id,
+        venue=d.venue,
+        requested_notional_usdc=d.notional_usdc,
+        filled_notional_usdc=4.0,
+        remaining_notional_usdc=0.0,
+        fill_price=0.5,
+        submitted_at=datetime(2026, 4, 25, tzinfo=UTC),
+        last_updated_at=datetime(2026, 4, 25, tzinfo=UTC),
+        raw_status="matched",
+        strategy_id=d.strategy_id,
+        strategy_version_id=d.strategy_version_id,
+        filled_quantity=8.0,
+    )
+
+
+def test_fill_from_order_applies_configured_fee_rate() -> None:
+    """Paper/backtest fills must carry the configured Polymarket fee so the
+    evaluator's net-edge gate (average_net_edge_bps) can compute instead of
+    rendering N/A. Fee matches ExecutionModel.compute_fee:
+    notional * fee_rate * (1 - fill_price); fee_bps is the nominal rate."""
+    from pms.runner import _fill_from_order
+
+    decision = _decision(notional_usdc=10.0)
+    fill = _fill_from_order(
+        _filled_state(decision), decision, None, fee_rate=0.04
+    )
+
+    assert fill is not None
+    # 4.0 notional * 0.04 * (1 - 0.5) = 0.08
+    assert fill.fees == pytest.approx(0.08)
+    assert fill.fee_bps == 400
+
+
+def test_fill_from_order_omits_fee_when_rate_is_none() -> None:
+    """LIVE fills (fee_rate=None) leave fees unset; venue reconciliation owns
+    the real fee. Default preserves the prior fee-free behaviour."""
+    from pms.runner import _fill_from_order
+
+    decision = _decision(notional_usdc=10.0)
+    fill = _fill_from_order(_filled_state(decision), decision, None)
+
+    assert fill is not None
+    assert fill.fees is None
+    assert fill.fee_bps is None
+
+
 # --- review-loop round-2 follow-ups (codex findings f7 and f8) ---
 
 

--- a/tests/unit/test_controller_cp02.py
+++ b/tests/unit/test_controller_cp02.py
@@ -231,3 +231,103 @@ async def test_on_signal_emits_diagnostic_when_no_forecaster_output_and_no_facto
     assert diagnostic.code == "no_forecaster_output"
     assert diagnostic.market_id == "market-cp02"
     assert diagnostic.token_id == "token-cp02"
+
+
+class _EqualToMarketForecaster:
+    """Returns exactly the market YES price so the resulting edge is zero,
+    exercising the decision_edge <= 0 silent-return branch."""
+
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return (0.4, 0.9, "no-edge")
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        return 0.4
+
+
+@pytest.mark.asyncio
+async def test_on_signal_emits_diagnostic_when_decision_edge_not_positive() -> None:
+    pipeline = ControllerPipeline(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        forecasters=[_EqualToMarketForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+    )
+
+    # _signal() has yes_price=0.4; a forecast of 0.4 yields zero edge.
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is None
+    diagnostic = pipeline.last_diagnostic
+    assert diagnostic is not None, (
+        "a zero/negative-edge drop must surface as a diagnostic so operators can "
+        "distinguish 'no opportunity' from 'controller idle'"
+    )
+    assert diagnostic.code == "decision_edge_not_positive"
+    assert diagnostic.severity == "info"
+    assert diagnostic.market_id == "market-cp02"
+    assert diagnostic.metadata.get("decision_edge") == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_on_signal_emits_diagnostic_when_order_size_below_minimum() -> None:
+    pipeline = ControllerPipeline(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        forecasters=[StaticForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(min_volume=100.0),
+            # Force the computed Kelly size (~$137) below the floor.
+            risk=RiskSettings(min_order_usdc=500.0),
+        ),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is None
+    diagnostic = pipeline.last_diagnostic
+    assert diagnostic is not None, (
+        "a sub-minimum order-size drop must surface as a diagnostic"
+    )
+    assert diagnostic.code == "order_size_below_minimum"
+    assert diagnostic.severity == "info"
+    assert diagnostic.metadata.get("min_order_usdc") == pytest.approx(500.0)
+
+
+@pytest.mark.asyncio
+async def test_on_signal_emits_diagnostic_when_within_decision_cooldown() -> None:
+    first_ts = datetime(2026, 4, 19, tzinfo=UTC)
+    pipeline = ControllerPipeline(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        forecasters=[StaticForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0)),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(min_volume=100.0, decision_cooldown_s=60.0),
+        ),
+    )
+
+    first = await pipeline.on_signal(_signal(fetched_at=first_ts), portfolio=_portfolio())
+    duplicate = await pipeline.on_signal(
+        _signal(fetched_at=first_ts + timedelta(seconds=30)),
+        portfolio=_portfolio(),
+    )
+
+    assert first is not None
+    assert duplicate is None
+    diagnostic = pipeline.last_diagnostic
+    assert diagnostic is not None, (
+        "a cooldown-suppressed duplicate must surface as a diagnostic so the "
+        "suppression is observable, not silent"
+    )
+    assert diagnostic.code == "within_decision_cooldown"
+    assert diagnostic.severity == "info"

--- a/tests/unit/test_live_trading_blockers.py
+++ b/tests/unit/test_live_trading_blockers.py
@@ -55,6 +55,7 @@ from pms.storage.feedback_store import FeedbackStore
 from pms.strategies.defaults import DEFAULT_STRATEGY_COMPOSITION
 from pms.strategies.projections import (
     ActiveStrategy,
+    CalibrationSpec,
     EvalSpec,
     FactorCompositionStep,
     ForecasterSpec,
@@ -290,6 +291,113 @@ async def test_strategy_does_not_trade_when_required_raw_factor_is_stale() -> No
     assert emission is None
     assert pipeline.last_diagnostic is not None
     assert pipeline.last_diagnostic.code == "stale_required_factors"
+
+
+@pytest.mark.asyncio
+async def test_on_signal_emits_diagnostic_when_composition_resolution_fails() -> None:
+    """A composition that cannot resolve a probability (e.g. a weighted step
+    whose factor is absent and has no threshold gate, raising inside
+    apply_composition) must surface as an ``error``-severity diagnostic. Without
+    it, a broken strategy config looks identical to an idle controller — unsafe
+    for real-money operation.
+    """
+    strategy = _active_strategy(
+        composition=(
+            FactorCompositionStep(
+                factor_id="orderbook_imbalance",
+                role="weighted",
+                param="",
+                weight=1.0,
+                threshold=None,
+            ),
+        )
+    )
+    pipeline = ControllerPipeline(
+        strategy=strategy,
+        factor_reader=SnapshotReader(
+            FactorSnapshot(
+                values={},
+                missing_factors=(("orderbook_imbalance", ""),),
+                snapshot_hash="composition-unresolvable",
+            )
+        ),
+        forecasters=(ConstantForecaster(0.5),),
+        calibrator=NetcalCalibrator(),
+        sizer=FixedSizer(),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(min_volume=0.0, strict_factor_gates=False),
+            risk=RiskSettings(min_order_usdc=1.0),
+        ),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is None
+    diagnostic = pipeline.last_diagnostic
+    assert diagnostic is not None, (
+        "a composition resolution failure must surface as a diagnostic, not a "
+        "silent drop — it may indicate a broken strategy config"
+    )
+    assert diagnostic.code == "composition_resolution_failed"
+    assert diagnostic.severity == "error"
+
+
+@pytest.mark.asyncio
+async def test_on_signal_emits_diagnostic_when_calibration_clamp_rejects() -> None:
+    """When the extreme-probability clamp rejects a forecast (too few resolved
+    samples to trust a near-0/near-1 estimate), the drop must surface as a
+    diagnostic so the operator sees calibration is gating order flow."""
+    strategy = ActiveStrategy(
+        strategy_id="clamp-probe",
+        strategy_version_id="clamp-probe-v1",
+        config=StrategyConfig(
+            strategy_id="clamp-probe",
+            factor_composition=(),
+            metadata=(("owner", "system"), ("live_allowed", "false")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=1_000.0,
+            max_daily_drawdown_pct=0.0,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl")),
+        forecaster=ForecasterSpec(forecasters=(("rules", ()),)),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=30,
+            volume_min_usdc=0.0,
+        ),
+        calibration=CalibrationSpec(
+            enabled=True,
+            shrinkage_factor=1.0,  # no shrinkage, so 0.99 stays extreme
+            shrinkage_bias=0.0,
+            extreme_clamp_low=0.08,
+            extreme_clamp_high=0.92,
+            min_resolved_for_extreme=500,  # 0 resolved samples << 500 -> reject
+        ),
+    )
+    pipeline = ControllerPipeline(
+        strategy=strategy,
+        forecasters=(ConstantForecaster(0.99),),
+        calibrator=NetcalCalibrator(),
+        sizer=FixedSizer(),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(min_volume=0.0),
+            risk=RiskSettings(min_order_usdc=1.0),
+        ),
+    )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is None
+    diagnostic = pipeline.last_diagnostic
+    assert diagnostic is not None, (
+        "an extreme-probability clamp rejection must surface as a diagnostic"
+    )
+    assert diagnostic.code == "calibration_clamp_rejected"
+    assert diagnostic.severity == "info"
 
 
 def test_disabled_llm_forecaster_does_not_emit_neutral_runtime_factor() -> None:

--- a/tests/unit/test_market_discovery_sensor.py
+++ b/tests/unit/test_market_discovery_sensor.py
@@ -138,6 +138,42 @@ def test_gamma_row_to_market_derives_risk_group_metadata() -> None:
     assert market.risk_group_id == "event:2028-us-presidential-election"
 
 
+def test_gamma_row_derives_event_id_from_events_array() -> None:
+    """Live Gamma /markets returns the event grouping as an ``events`` array of
+    objects (``events[0].id``), NOT a scalar ``eventId``/``category``. Without
+    parsing the array, ``risk_group_id`` is NULL for every market and the
+    production ``max_exposure_per_risk_group`` cap rejects every order with
+    ``missing_risk_group_id``. Regression for the all-NULL risk_group_id bug
+    confirmed against the real Gamma payload on 2026-05-30.
+    """
+    fetched_at = datetime(2026, 4, 24, 9, 0, tzinfo=UTC)
+    row = _gamma_market("pm-gta-event")
+    # Mirror the real Gamma shape: no scalar eventId/category fields at all.
+    row["events"] = [
+        {
+            "id": "23784",
+            "ticker": "what-will-happen-before-gta-vi",
+            "slug": "what-will-happen-before-gta-vi",
+            "title": "What will happen before GTA VI?",
+        }
+    ]
+
+    market = _gamma_market_to_market(row, fetched_at)
+
+    assert market.event_id == "23784"
+    assert market.risk_group_id == "event:23784"
+
+
+def test_gamma_row_without_event_grouping_has_null_risk_group() -> None:
+    """A market with neither an events array nor scalar grouping fields yields
+    a None risk_group_id (the Actuator then rejects only when the cap is set)."""
+    fetched_at = datetime(2026, 4, 24, 9, 0, tzinfo=UTC)
+    market = _gamma_market_to_market(_gamma_market("pm-ungrouped"), fetched_at)
+
+    assert market.event_id is None
+    assert market.risk_group_id is None
+
+
 def test_gamma_row_missing_outcome_prices_falls_back_to_none() -> None:
     fetched_at = datetime(2026, 4, 24, 9, 0, tzinfo=UTC)
     market = _gamma_market_to_market(


### PR DESCRIPTION
## Summary

Production-readiness pass: fixes one real launch blocker plus two
observability/fidelity gaps, and records that the LIVE Polymarket adapter +
credentialed preflight are already production-ready as code. Findings came
from a multi-dimension investigation cross-checked against the **live** Gamma
API (runtime behaviour > design intent).

All three fixes are TDD + atomic. Credentials are not required for any of
this; the two genuinely credential-bound decisions are documented (not
guessed) for the live-GO phase.

## The fixes

### 🔴 `fix(sensor): derive risk_group_id from Gamma events[] array` — the linchpin

The live Gamma `/markets` endpoint returns the event grouping as
`events: [{id, ticker, ...}]`, **not** a scalar `eventId`/`category`. The
discovery parser only read the scalar, so every discovered market got
`risk_group_id = NULL`. Under the production-tight `max_exposure_per_risk_group: 15.0`
cap, the actuator then rejected **every** order with
`raw_status=missing_risk_group_id` — i.e. nothing could trade.

The existing regression test invented a scalar `row['eventId']` fixture the
real API never sends, so CI was green while production was broken. Fix adds
`_gamma_first_event_id` to extract `events[0].id` (keeping the scalar
fallbacks) + realistic tests mirroring the live payload.

**Verified against the live API:** 0/100 markets carried a risk group before;
30/30 do after.

### 🟡 `fix(controller): emit diagnostics for the remaining on_signal drops`

Commit `3f019ed` covered 3 early returns; 5 operationally-meaningful silent
returns remained, so from `/status → controller.diagnostic_counts` an operator
couldn't distinguish "idle" from "every signal filtered":

- `composition_resolution_failed` (severity=error — a broken config looked
  identical to no signal; the critical one for real-money operation)
- `calibration_clamp_rejected`, `decision_edge_not_positive`,
  `order_size_below_minimum`, `within_decision_cooldown`

Pure observability — no decision-logic or return-condition change.

### 🟡 `fix(runner): model Polymarket fee on paper/backtest fills`

Paper/backtest fills carried `fees=None`/`fee_bps=None`, so the evaluator's
`average_net_edge_bps`/`average_fee_bps` rendered N/A (a paper GO was
unreachable) and paper P&L overstated edge vs live. Paper/backtest fills now
carry the configured `strategies.flb_fee_rate` fee (matching
`ExecutionModel.compute_fee`); LIVE keeps venue reconciliation as the source
of truth for real fees.

## Already production-ready (verified, no change)

- **LIVE Polymarket adapter** — fail-closed: `live_trading_enabled` gate first,
  credential validation before approval, exact 8-field every-order approval
  matching, lock-protected approve+submit, pre-submit quote guard.
- **Credentialed preflight + live config gating** — exits non-zero on any
  failed check, `--skip-venue` invalid for final go/no-go, operator-readiness
  fields enforced fail-closed.

## Test plan

- [x] `uv run pytest -q` — **2259 passed, 174 skipped**
- [x] `uv run mypy src/ tests/ --strict` — clean (444 files)
- [x] `uv run lint-imports` — 9 contracts kept, 0 broken
- [x] `(cd dashboard && npm run test)` — 65 tests passed
- [x] **Live end-to-end under production-tight config** (risk-group cap ON,
  `risk_group_id` reset to NULL first): discovery backfilled `risk_group_id`
  to 100/101 markets; 15 decisions → 8 fills across 5 markets; order payloads
  carry the risk group; **0 `missing_risk_group_id` rejections** (only
  legitimate `insufficient_liquidity`/`min_order`). Proves the full chain:
  Gamma `events[]` → discovery → markets table → sensor → decision → actuator.

## Open decisions for the credential phase (non-blocking)

Documented in `agent_docs/production-readiness-2026-05.md §10.4`; both bind
only at the live GO:

1. **Live operational strategy** — `default` is intentionally fail-closed
   without external enrichment (a test asserts this); the strategies that
   trade on Polymarket-only signals are `live_allowed: false`. Choose: harden
   `paper_multi_factor_v1` → live, wire external enrichment, or ship FLB.
2. **Polymarket fee rate** — paper now uses the repo's `flb_fee_rate=0.04`
   estimate; confirm against Polymarket's actual schedule before GO
   (operator-tunable via config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fee calculations now modeled in backtests and paper trading for realistic performance metrics.
  * Improved event and risk-group identification from market data sources via fallback extraction.

* **Bug Fixes**
  * Centralized diagnostic reporting for rejection scenarios (calibration failures, minimum order size, decision timing).

* **Documentation**
  * Production-readiness verification updates with live performance findings and resolved issues.

* **Tests**
  * Added coverage for fee modeling, diagnostic emissions, and market metadata extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->