### PR TITLE
docs: fix inverted precedence_rank semantics in authoring guide

### DIFF
--- a/agent_docs/strategy-authoring-guide.md
+++ b/agent_docs/strategy-authoring-guide.md
@@ -589,7 +589,7 @@ calibrator participates).
 | Role | Kind | What it does |
 |---|---|---|
 | `weighted` | raw | Linear contribution to a weighted score |
-| `precedence_rank` | raw | Higher-weight steps preempt lower-weight ones if both fire |
+| `precedence_rank` | raw | Ordinal rank for `threshold_edge` evaluation: **lower** weight = **higher** priority. Steps are tried in ascending rank order and the first firing edge wins (reproduces legacy `RulesForecaster.predict` precedence) |
 | `threshold_edge` | raw | Fires when `value >= threshold` (or `<= -threshold` for sign-aware factors) |
 | `posterior_prior` | raw | Beta prior `α` contribution |
 | `posterior_success` | raw | Beta prior `β`-success contribution |


### PR DESCRIPTION
## Summary
- `agent_docs/strategy-authoring-guide.md` §5.2 documented `precedence_rank` as "Higher-weight steps preempt lower-weight ones if both fire" — the **opposite** of the implemented, regression-locked semantics.
- `_apply_threshold_precedence` (`src/pms/factors/composition.py:163-201`) sorts `threshold_edge` steps **ascending** by their `precedence_rank` weight and returns the first firing step, so **lower weight = higher priority** (rank 1 fires first).
- The ordering is intentional: it reproduces the legacy `RulesForecaster.predict` precedence (price_spread before subset_violation), per `.harness/pms-factor-panel-v1/spec.md`, and is pinned by `tests/unit/test_forecaster_migration_matrix.py` (both_rules_present cell, 1e-9 tolerance) and `tests/unit/test_factor_composition.py:99-120`.

## Changes
Doc-only, single line: the §5.2 role-table cell now states the weight is an ordinal rank — lower weight = higher priority, ascending evaluation order, first firing `threshold_edge` wins. No code or test changes (they encode the intended behavior). Verified the inverted claim appears nowhere else in repo markdown (`grep -rn preempt --include='*.md'` → only this line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `precedence_rank` semantics in the Strategy Authoring Guide. Corrected description to accurately reflect that lower rank values correspond to higher priority, with steps evaluated in ascending order and the first firing edge taking precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->