### PR TITLE
fix: soak-killer and evidence-integrity bugs from 2026-06-10 logic audit (batch 1)

### DIFF
--- a/src/pms/actuator/adapters/paper.py
+++ b/src/pms/actuator/adapters/paper.py
@@ -76,11 +76,6 @@ def _vwap_fill(
     )
     action = decision.action or decision.side
     is_buy = action == Side.BUY.value
-    effective_limit = _slippage_adjusted_limit(
-        limit_price,
-        decision.max_slippage_bps,
-        is_buy=is_buy,
-    )
     side_key = "asks" if is_buy else "bids"
     raw_levels = orderbook.get(side_key)
     if not isinstance(raw_levels, list) or not raw_levels:
@@ -108,10 +103,14 @@ def _vwap_fill(
     filled_notional = Decimal("0")
     filled_quantity = Decimal("0")
     epsilon = Decimal("1e-9")
+    # Live parity: the Polymarket adapter submits at the raw decision limit
+    # and its pre-submit guard rejects any book where the best executable
+    # price crosses that limit; max_slippage_bps never widens the live bound.
+    # Paper must enforce the same strict limit or soak evidence is biased.
     for price, size in levels:
-        if is_buy and price > effective_limit:
+        if is_buy and price > limit_price:
             break
-        if not is_buy and price < effective_limit:
+        if not is_buy and price < limit_price:
             break
         if is_buy:
             take_notional = min(remaining_notional, price * size)
@@ -134,28 +133,13 @@ def _vwap_fill(
     if remaining > epsilon or filled_quantity <= 0:
         raise InsufficientLiquidityError(
             f"{side_key} executable depth is insufficient at "
-            f"limit={decision.limit_price} effective={float(effective_limit):.6f} "
-            f"(slippage={decision.max_slippage_bps}bps)"
+            f"limit={decision.limit_price}"
         )
     return (
         float(filled_notional / filled_quantity),
         float(filled_quantity),
         float(filled_notional),
     )
-
-
-def _slippage_adjusted_limit(
-    limit_price: Decimal,
-    max_slippage_bps: int,
-    *,
-    is_buy: bool,
-) -> Decimal:
-    if max_slippage_bps <= 0:
-        return limit_price
-    slippage = Decimal(max_slippage_bps) / Decimal("10000")
-    if is_buy:
-        return limit_price * (Decimal("1") + slippage)
-    return limit_price * (Decimal("1") - slippage)
 
 
 def _matched_order_state(

--- a/src/pms/actuator/executor.py
+++ b/src/pms/actuator/executor.py
@@ -10,7 +10,7 @@ from pms.actuator.adapters.polymarket import PolymarketSubmissionUnknownError
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import InsufficientLiquidityError, RiskManager
 from pms.alerting.events import HaltEvent as AlertHaltEvent
-from pms.core.enums import OrderStatus, Venue
+from pms.core.enums import OrderStatus, TimeInForce, Venue
 from pms.core.exceptions import KalshiStubError
 from pms.core.interfaces import DedupStore
 from pms.core.models import OrderState, Portfolio, TradeDecision
@@ -255,8 +255,25 @@ def _record_order_lifecycle(risk: RiskManager, order_state: OrderState) -> None:
             OrderStatus.PARTIAL.value,
         }
         and order_state.remaining_notional_usdc > 1e-9
+        and not is_terminal_partial_fill(order_state)
     ):
         risk.record_order_placed(order_state.order_id, at=order_state.submitted_at)
         return
 
     risk.record_order_filled(order_state.order_id)
+
+
+def is_terminal_partial_fill(order_state: OrderState) -> bool:
+    """True when a PARTIAL order state is already terminal at the venue.
+
+    Non-GTC (IOC/FOK) orders never rest: the venue cancels the unfilled
+    remainder on arrival, so a PARTIAL response is the final state for that
+    order_id and no further fill will ever arrive. Treating it as an open
+    order would arm a stale-order timer and exposure reservation that
+    nothing can clear.
+    """
+    if _normalize_order_status(order_state.status) != OrderStatus.PARTIAL.value:
+        return False
+    if order_state.time_in_force is None:
+        return False
+    return order_state.time_in_force.strip().upper() != TimeInForce.GTC.value

--- a/src/pms/evaluation/adapters/scoring.py
+++ b/src/pms/evaluation/adapters/scoring.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from decimal import Decimal
 from math import isfinite
 from typing import cast
 
@@ -116,11 +117,18 @@ def _probability_or_none(value: object) -> float | None:
 def _pnl(fill: FillRecord, decision: TradeDecision) -> float:
     if fill.resolved_outcome is None:
         return 0.0
-    contract_outcome = _contract_outcome(fill.resolved_outcome, decision)
+    contract_outcome = Decimal(
+        str(_contract_outcome(fill.resolved_outcome, decision))
+    )
+    fill_price = Decimal(str(fill.fill_price))
+    fill_quantity = Decimal(str(fill.fill_quantity))
+    fees = Decimal("0") if fill.fees is None else Decimal(str(fill.fees))
     action = decision.action if decision.action is not None else decision.side
     if action == Side.SELL.value:
-        return (fill.fill_price - contract_outcome) * fill.fill_quantity
-    return (contract_outcome - fill.fill_price) * fill.fill_quantity
+        pnl = (fill_price - contract_outcome) * fill_quantity - fees
+    else:
+        pnl = (contract_outcome - fill_price) * fill_quantity - fees
+    return float(pnl)
 
 
 def _slippage_bps(fill: FillRecord, decision: TradeDecision) -> float:

--- a/src/pms/evaluation/spool.py
+++ b/src/pms/evaluation/spool.py
@@ -93,15 +93,22 @@ class EvalSpool:
                         decision_evidence,
                     )
                     continue
-                await self.store.append(
-                    self.scorer.score(
-                        fill,
-                        decision,
-                        baseline_prob_estimates=_baseline_prob_estimates_from_evidence(
-                            decision_evidence,
-                        ),
+                try:
+                    await self.store.append(
+                        self.scorer.score(
+                            fill,
+                            decision,
+                            baseline_prob_estimates=_baseline_prob_estimates_from_evidence(
+                                decision_evidence,
+                            ),
+                        )
                     )
-                )
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "fill evaluation failed in evaluator spool: %s",
+                        fill.trade_id,
+                    )
+                    continue
                 try:
                     await self._generate_feedback()
                 except Exception:  # noqa: BLE001

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -32,7 +32,11 @@ from pms.actuator.adapters.polymarket import (
     PolymarketSubmissionUnknownError,
     PolymarketVenueAccountReconciler,
 )
-from pms.actuator.executor import ActuatorAdapter, ActuatorExecutor
+from pms.actuator.executor import (
+    ActuatorAdapter,
+    ActuatorExecutor,
+    is_terminal_partial_fill,
+)
 from pms.actuator.exit_monitor import (
     PositionExitMonitor,
     build_exit_decision,
@@ -3669,6 +3673,8 @@ def _decision_status_from_order(order_state: OrderState) -> str:
 
 def _is_open_order_state(order_state: OrderState) -> bool:
     if order_state.remaining_notional_usdc <= 1e-9:
+        return False
+    if is_terminal_partial_fill(order_state):
         return False
     normalized_status = order_state.status.lower()
     raw_status = order_state.raw_status.lower()

--- a/src/pms/sensor/adapters/market_data.py
+++ b/src/pms/sensor/adapters/market_data.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, cast
 
+import asyncpg
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed, InvalidHandshake
 
@@ -181,6 +182,7 @@ class MarketDataSensor:
                     OSError,
                     TimeoutError,
                     InvalidHandshake,
+                    asyncpg.PostgresError,
                 ) as error:
                     _log_reconnectable_error(error)
                     await self._sleep(backoff)
@@ -615,6 +617,12 @@ def _log_reconnectable_error(error: BaseException) -> None:
     if isinstance(error, ConnectionClosed):
         logger.warning(
             "market data sensor websocket closed; reconnecting: %s",
+            error,
+        )
+        return
+    if isinstance(error, asyncpg.PostgresError):
+        logger.warning(
+            "market data sensor storage error; reconnecting: %s",
             error,
         )
         return

--- a/tests/integration/test_default_strategy_tagging.py
+++ b/tests/integration/test_default_strategy_tagging.py
@@ -283,7 +283,7 @@ async def test_runner_tags_inner_ring_rows_with_default_strategy(
                         token_id="depth-token",
                         orderbook={
                             "bids": [{"price": 0.399, "size": 250.0}],
-                            "asks": [{"price": 0.401, "size": 250.0}],
+                            "asks": [{"price": 0.40, "size": 250.0}],
                         },
                         external_signal={"metaculus_prob": 0.9, "resolved_outcome": 0.0},
                     ),

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -252,7 +252,7 @@ async def test_runner_start_resets_in_memory_session_state(
                     market_id="paper-state-reset",
                     orderbook={
                         "bids": [{"price": 0.399, "size": 250.0}],
-                        "asks": [{"price": 0.401, "size": 250.0}],
+                        "asks": [{"price": 0.40, "size": 250.0}],
                     },
                     external_signal={"metaculus_prob": 0.9, "resolved_outcome": 1.0},
                 )

--- a/tests/integration/test_strategy_tag_population_cp05.py
+++ b/tests/integration/test_strategy_tag_population_cp05.py
@@ -157,7 +157,7 @@ def _signal() -> MarketSignal:
         resolves_at=datetime(2026, 4, 30, tzinfo=UTC),
         orderbook={
             "bids": [{"price": 0.399, "size": 1000.0}],
-            "asks": [{"price": 0.401, "size": 1000.0}],
+            "asks": [{"price": 0.40, "size": 1000.0}],
         },
         external_signal={"fair_value": 0.7, "resolved_outcome": 1.0},
         fetched_at=datetime(2026, 4, 19, tzinfo=UTC),

--- a/tests/unit/test_actuator_cp06.py
+++ b/tests/unit/test_actuator_cp06.py
@@ -3570,6 +3570,80 @@ async def test_executor_tracks_open_status_as_live_order_lifecycle() -> None:
 
 
 @pytest.mark.asyncio
+async def test_executor_ioc_partial_fill_does_not_arm_stale_order_halt() -> None:
+    """A PARTIAL fill on a non-GTC (IOC/FOK) order is terminal: the venue
+    cancels the unfilled remainder on arrival, so no further fill will ever
+    arrive for that order_id. Arming the 30-minute order-without-fill timer
+    for it guarantees a spurious permanent auto-halt 30 minutes after any
+    routine IOC partial fill."""
+    store = cast(FeedbackStore, InMemoryFeedbackStore())
+    decision = _decision(decision_id="d-ioc-partial")
+    assert decision.time_in_force == TimeInForce.IOC
+    returned_state = _order_state(
+        decision,
+        status=OrderStatus.PARTIAL.value,
+        raw_status="partial",
+        fill_price=decision.limit_price,
+        filled_notional_usdc=decision.notional_usdc / 2,
+    )
+    risk = RiskManager(
+        RiskSettings(max_position_per_market=100.0, max_total_exposure=1000.0)
+    )
+    actuator = executor.ActuatorExecutor(
+        adapter=StaticAdapter(returned_state),
+        risk=risk,
+        feedback=ActuatorFeedback(store),
+        dedup_store=RecordingDedupStore(),
+    )
+
+    await actuator.execute(decision, _portfolio())
+
+    halt_state = risk.check_auto_halt(
+        _portfolio(),
+        now=returned_state.submitted_at + timedelta(minutes=31),
+    )
+    assert halt_state.halted is False, (
+        "terminal IOC partial fill must not trigger order_without_fill auto-halt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_gtc_partial_fill_still_arms_stale_order_halt() -> None:
+    """A PARTIAL fill on a GTC order leaves the remainder resting at the
+    venue, so the order-without-fill stale timer must still arm."""
+    store = cast(FeedbackStore, InMemoryFeedbackStore())
+    decision = replace(
+        _decision(decision_id="d-gtc-partial"),
+        time_in_force=TimeInForce.GTC,
+    )
+    returned_state = _order_state(
+        decision,
+        status=OrderStatus.PARTIAL.value,
+        raw_status="partial",
+        fill_price=decision.limit_price,
+        filled_notional_usdc=decision.notional_usdc / 2,
+    )
+    risk = RiskManager(
+        RiskSettings(max_position_per_market=100.0, max_total_exposure=1000.0)
+    )
+    actuator = executor.ActuatorExecutor(
+        adapter=StaticAdapter(returned_state),
+        risk=risk,
+        feedback=ActuatorFeedback(store),
+        dedup_store=RecordingDedupStore(),
+    )
+
+    await actuator.execute(decision, _portfolio())
+
+    halt_state = risk.check_auto_halt(
+        _portfolio(),
+        now=returned_state.submitted_at + timedelta(minutes=31),
+    )
+    assert halt_state.halted is True
+    assert halt_state.trigger_kind == "order_without_fill"
+
+
+@pytest.mark.asyncio
 async def test_executor_releases_invalid_for_risk_rejection() -> None:
     store = cast(FeedbackStore, InMemoryFeedbackStore())
     dedup_store = RecordingDedupStore()

--- a/tests/unit/test_evaluation_cp07.py
+++ b/tests/unit/test_evaluation_cp07.py
@@ -405,6 +405,43 @@ def test_scorer_pnl_for_buy_no_uses_complementary_contract_outcome() -> None:
     assert record.pnl == pytest.approx(6.2)
 
 
+def test_scorer_realized_pnl_is_net_of_fill_fees_for_buy() -> None:
+    record = Scorer().score(
+        _fill(resolved_outcome=1.0, fill_price=0.42, fees=0.15),
+        _decision(prob=0.7, price=0.4),
+    )
+
+    # Realized PnL must be net of fees: (1.0 - 0.42) * 10 - 0.15, not 5.8.
+    assert record.pnl == pytest.approx(5.65)
+
+
+def test_scorer_realized_pnl_is_net_of_fill_fees_for_sell() -> None:
+    record = Scorer().score(
+        _fill(
+            resolved_outcome=0.0,
+            fill_price=0.42,
+            side=Side.SELL.value,
+            fees=0.12,
+        ),
+        _decision(prob=0.3, price=0.45, side=Side.SELL.value),
+    )
+
+    # Realized PnL must be net of fees: (0.42 - 0.0) * 10 - 0.12, not 4.2.
+    assert record.pnl == pytest.approx(4.08)
+
+
+def test_scorer_scores_fee_dominated_fill_as_loss() -> None:
+    record = Scorer().score(
+        _fill(resolved_outcome=1.0, fill_price=0.99, fees=0.25),
+        _decision(prob=0.995, price=0.99),
+    )
+
+    # Gross edge (0.10) is smaller than fees (0.25): the trade is a loss and
+    # must not count as a win in win_rate (metrics count record.pnl > 0.0).
+    assert record.pnl == pytest.approx(-0.15)
+    assert record.pnl < 0.0
+
+
 def test_scorer_brier_for_buy_no_uses_yes_probability_basis() -> None:
     scorer = Scorer()
     decision = TradeDecision(

--- a/tests/unit/test_evaluation_cp07.py
+++ b/tests/unit/test_evaluation_cp07.py
@@ -139,6 +139,18 @@ class _InMemoryQuoteEvalStore:
         self.records.append(record)
 
 
+class _TransientFailureEvalStore(InMemoryEvalStore):
+    def __init__(self, failures: int) -> None:
+        super().__init__()
+        self._failures_remaining = failures
+
+    async def append(self, record: EvalRecord) -> None:
+        if self._failures_remaining > 0:
+            self._failures_remaining -= 1
+            raise RuntimeError("transient eval-store failure")
+        await super().append(record)
+
+
 class _StaticQuoteReader:
     def __init__(self, quote: BookSummary | None) -> None:
         self.quote = quote
@@ -782,6 +794,67 @@ async def test_eval_spool_logs_feedback_errors_and_keeps_scoring(
         "d-after-error",
     ]
     assert "feedback generation failed in evaluator spool" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_eval_spool_survives_transient_store_failure_and_keeps_scoring(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _TransientFailureEvalStore(failures=1)
+    spool = EvalSpool(store=cast(EvalStore, store), scorer=Scorer())
+    await spool.start()
+    try:
+        caplog.set_level("ERROR", logger="pms.evaluation.spool")
+        spool.enqueue(
+            _fill(decision_id="d-store-error", resolved_outcome=1.0),
+            _decision(decision_id="d-store-error"),
+        )
+        spool.enqueue(
+            _fill(decision_id="d-after-store-error", resolved_outcome=1.0),
+            _decision(decision_id="d-after-store-error"),
+        )
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+    finally:
+        await spool.stop()
+
+    records = await store.all()
+    assert [record.decision_id for record in records] == ["d-after-store-error"]
+    assert "fill evaluation failed in evaluator spool" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_eval_spool_survives_scoring_error_and_keeps_scoring(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = cast(EvalStore, InMemoryEvalStore())
+    spool = EvalSpool(store=store, scorer=Scorer())
+    await spool.start()
+    try:
+        caplog.set_level("ERROR", logger="pms.evaluation.spool")
+        spool.enqueue(
+            _fill(
+                decision_id="d-poison",
+                resolved_outcome=1.0,
+                strategy_id="alpha",
+                strategy_version_id="alpha-v1",
+            ),
+            _decision(
+                decision_id="d-poison",
+                strategy_id="beta",
+                strategy_version_id="beta-v1",
+            ),
+        )
+        spool.enqueue(
+            _fill(decision_id="d-after-poison", resolved_outcome=1.0),
+            _decision(decision_id="d-after-poison"),
+        )
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+    finally:
+        await spool.stop()
+
+    records = await cast(InMemoryEvalStore, store).all()
+    assert [record.decision_id for record in records] == ["d-after-poison"]
+    assert "fill evaluation failed in evaluator spool" in caplog.text
 
 
 def test_metrics_snapshot_by_strategy_returns_only_present_keys() -> None:

--- a/tests/unit/test_market_data_sensor.py
+++ b/tests/unit/test_market_data_sensor.py
@@ -1126,6 +1126,60 @@ async def test_market_data_sensor_retries_after_websocket_handshake_error(
 
 
 @pytest.mark.asyncio
+async def test_market_data_sensor_reconnects_after_transient_storage_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import asyncpg
+
+    store = _store_mock()
+    store_mock = cast(StoreMock, store)
+    store_mock.write_book_snapshot_mock.side_effect = [
+        asyncpg.PostgresError("deadlock detected"),
+        1,
+    ]
+
+    def _book_message(book_hash: str) -> str:
+        return json.dumps(
+            {
+                "event_type": "book",
+                "market": "m-storage",
+                "asset_id": "asset-storage",
+                "timestamp": "1757908892351",
+                "hash": book_hash,
+                "bids": [{"price": "0.40", "size": "5"}],
+                "asks": [{"price": "0.60", "size": "5"}],
+                "last_trade_price": "0.50",
+            }
+        )
+
+    first_websocket = FakeWebSocket([_book_message("book-before-db-error")])
+    second_websocket = FakeWebSocket([_book_message("book-after-db-error")])
+    monkeypatch.setattr(
+        "pms.sensor.adapters.market_data.connect",
+        ConnectSequence([first_websocket, second_websocket]),
+    )
+    sensor = MarketDataSensor(
+        store=store,
+        ws_url="ws://market-data.example.test",
+        asset_ids=["asset-storage"],
+    )
+    sensor._INITIAL_BACKOFF_S = 0.0
+    iterator = cast(Any, sensor.__aiter__())
+
+    with caplog.at_level(logging.WARNING):
+        signal = await asyncio.wait_for(anext(iterator), timeout=2.0)
+
+    await iterator.aclose()
+    await sensor.aclose()
+
+    assert signal.market_id == "m-storage"
+    assert store_mock.write_book_snapshot_mock.await_count == 2
+    assert "market data sensor storage error; reconnecting" in caplog.text
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+
+
+@pytest.mark.asyncio
 async def test_market_data_sensor_logs_expected_websocket_close_as_reconnect(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/unit/test_paper_actuator_cp12.py
+++ b/tests/unit/test_paper_actuator_cp12.py
@@ -284,8 +284,12 @@ def _decision_with_slippage(
 
 
 @pytest.mark.asyncio
-async def test_paper_buy_slippage_band_admits_ask_above_limit() -> None:
-    # limit=0.30 + 200bps = effective 0.306; best_ask 0.305 fits inside the band
+async def test_paper_buy_never_fills_above_limit_even_with_slippage_budget() -> None:
+    # Live parity: the Polymarket pre-submit guard rejects a BUY whenever the
+    # best executable price exceeds decision.limit_price, regardless of
+    # max_slippage_bps (polymarket.py _validate_pre_submit_quote). Paper must
+    # not book fills the live adapter would refuse — best_ask 0.305 > 0.30
+    # rejects even with a 200bps slippage budget.
     actuator = PaperActuator(
         orderbooks={
             "token-yes": {
@@ -295,28 +299,7 @@ async def test_paper_buy_slippage_band_admits_ask_above_limit() -> None:
         }
     )
 
-    state = await actuator.execute(
-        _decision_with_slippage(limit_price=0.30, max_slippage_bps=200),
-        _portfolio(),
-    )
-
-    assert state.fill_price == pytest.approx(0.305)
-    assert state.filled_notional_usdc == pytest.approx(100.0)
-
-
-@pytest.mark.asyncio
-async def test_paper_buy_slippage_band_still_rejects_beyond_band() -> None:
-    # limit=0.30 + 200bps = effective 0.306; best_ask 0.32 is outside band
-    actuator = PaperActuator(
-        orderbooks={
-            "token-yes": {
-                "bids": [{"price": 0.295, "size": 1_000.0}],
-                "asks": [{"price": 0.32, "size": 1_000.0}],
-            }
-        }
-    )
-
-    with pytest.raises(InsufficientLiquidityError, match="slippage=200bps"):
+    with pytest.raises(InsufficientLiquidityError, match="executable depth"):
         await actuator.execute(
             _decision_with_slippage(limit_price=0.30, max_slippage_bps=200),
             _portfolio(),
@@ -324,8 +307,32 @@ async def test_paper_buy_slippage_band_still_rejects_beyond_band() -> None:
 
 
 @pytest.mark.asyncio
+async def test_paper_buy_with_slippage_budget_fills_at_or_below_limit() -> None:
+    # The slippage budget never relaxes the limit: a book whose best ask sits
+    # exactly at the limit fills at the limit, never above it.
+    actuator = PaperActuator(
+        orderbooks={
+            "token-yes": {
+                "bids": [{"price": 0.295, "size": 1_000.0}],
+                "asks": [{"price": 0.30, "size": 1_000.0}],
+            }
+        }
+    )
+
+    state = await actuator.execute(
+        _decision_with_slippage(limit_price=0.30, max_slippage_bps=200),
+        _portfolio(),
+    )
+
+    assert state.fill_price is not None
+    assert state.fill_price == pytest.approx(0.30)
+    assert state.fill_price <= 0.30
+    assert state.filled_notional_usdc == pytest.approx(100.0)
+
+
+@pytest.mark.asyncio
 async def test_paper_zero_slippage_keeps_strict_limit() -> None:
-    # max_slippage_bps=0 → effective_limit == limit; ask above limit still rejects
+    # max_slippage_bps=0: ask above limit rejects (limit is always strict)
     actuator = PaperActuator(
         orderbooks={
             "token-yes": {
@@ -343,9 +350,10 @@ async def test_paper_zero_slippage_keeps_strict_limit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_paper_sell_slippage_band_admits_bid_below_limit() -> None:
-    # SELL side: effective_limit = 0.30 * (1 - 100/10000) = 0.297;
-    # best_bid 0.298 ≥ 0.297 → fills.
+async def test_paper_sell_never_fills_below_limit_even_with_slippage_budget() -> None:
+    # SELL mirror of the live guard: best executable below the limit rejects
+    # at submit regardless of max_slippage_bps — best_bid 0.298 < 0.30 rejects
+    # even with a 100bps slippage budget.
     actuator = PaperActuator(
         orderbooks={
             "token-yes": {
@@ -355,16 +363,15 @@ async def test_paper_sell_slippage_band_admits_bid_below_limit() -> None:
         }
     )
 
-    state = await actuator.execute(
-        _decision_with_slippage(
-            limit_price=0.30,
-            max_slippage_bps=100,
-            side="SELL",
-        ),
-        _portfolio(),
-    )
-
-    assert state.fill_price == pytest.approx(0.298)
+    with pytest.raises(InsufficientLiquidityError, match="executable depth"):
+        await actuator.execute(
+            _decision_with_slippage(
+                limit_price=0.30,
+                max_slippage_bps=100,
+                side="SELL",
+            ),
+            _portfolio(),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_position_capacity.py
+++ b/tests/unit/test_runner_position_capacity.py
@@ -182,6 +182,29 @@ class _RecordingRisk:
         self.filled_order_ids.append(order_id)
 
 
+class _RecordingFillStore:
+    def __init__(self) -> None:
+        self.fills: list[Any] = []
+
+    async def insert(self, fill: Any) -> None:
+        self.fills.append(fill)
+
+
+class _EvalSpoolDouble:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    def enqueue(
+        self,
+        fill: Any,
+        decision: TradeDecision,
+        *,
+        decision_evidence: dict[str, object] | None = None,
+    ) -> None:
+        del fill, decision_evidence
+        self.enqueued.append(decision.decision_id)
+
+
 class _StaticOpenOrderExecutor:
     def __init__(self, order_state: OrderState) -> None:
         self.order_state = order_state
@@ -466,6 +489,53 @@ class TestWouldExceedPositionCapacity:
         assert runner._would_exceed_position_capacity(second)  # noqa: SLF001
         assert executor.risk.open_orders == [order_state]
         assert executor.risk.filled_order_ids == []
+
+    @pytest.mark.asyncio
+    async def test_actuator_loop_releases_reservations_for_terminal_ioc_partial_fill(
+        self,
+    ) -> None:
+        """A PARTIAL fill on an IOC order is terminal — the venue cancelled
+        the unfilled remainder — so the runner must record the order as
+        filled (no permanent open-order risk reservation) and release the
+        pending position-capacity slot instead of leaking both forever."""
+        runner = _live_runner(max_open_positions=2)
+        runner.portfolio = replace(
+            runner.portfolio,
+            open_positions=[_position()],
+        )
+        first = _decision(market_id="market-b", token_id="token-b")
+        order_state = replace(
+            _open_order_state(first),
+            status=OrderStatus.PARTIAL.value,
+            raw_status="partial",
+            filled_notional_usdc=first.notional_usdc / 2,
+            remaining_notional_usdc=first.notional_usdc / 2,
+            fill_price=first.limit_price,
+            filled_quantity=(first.notional_usdc / 2) / first.limit_price,
+        )
+        assert order_state.time_in_force == TimeInForce.IOC.value
+        executor = _StaticOpenOrderExecutor(order_state)
+        runner.actuator_executor = cast(Any, executor)
+        runner.order_store = cast(Any, _RecordingOrderStore())
+        runner.decision_store = cast(Any, _RecordingDecisionStore())
+        runner.fill_store = cast(Any, _RecordingFillStore())
+        runner._evaluator_spool = cast(Any, _EvalSpoolDouble())  # noqa: SLF001
+        assert runner._reserve_position_capacity(first) is not None
+        await runner._decision_queue.put(  # noqa: SLF001
+            ActuatorWorkItem(decision=first, signal=None)
+        )
+
+        actuator_task = asyncio.create_task(runner._actuator_loop())  # noqa: SLF001
+        await asyncio.wait_for(runner._decision_queue.join(), timeout=1.0)  # noqa: SLF001
+        runner._stop_event.set()  # noqa: SLF001
+        await asyncio.wait_for(actuator_task, timeout=1.0)
+
+        assert executor.risk.open_orders == []
+        assert executor.risk.filled_order_ids == [order_state.order_id]
+        assert (
+            first.decision_id
+            not in runner._pending_open_position_keys_by_decision  # noqa: SLF001
+        )
 
     @pytest.mark.asyncio
     async def test_actuator_loop_keeps_live_open_exit_key_reserved(self) -> None:


### PR DESCRIPTION
## Summary

Five TDD fixes from the 2026-06-10 adversarially-verified logic audit (28 confirmed findings; this batch = the 5 that threaten paper-soak survival or corrupt profitability evidence). One atomic commit per fix; every fix adds a failing-first test encoding the violated invariant.

| Commit | Fix | Invariant now tested |
|---|---|---|
| `fix(actuator)` | IOC PARTIAL is terminal at the venue — no longer arms the 30-min stale-order timer / exposure reservation that nothing could clear (guaranteed spurious permanent auto-halt). GTC partials still arm it (intent pinned by existing tests). | `test_executor_ioc_partial_fill_does_not_arm_stale_order_halt` + GTC boundary + runner reservation release |
| `fix(actuator)` | Paper fill simulator now enforces the raw decision limit, matching the live adapter exactly (`polymarket.py:1581,1765,1856`); removed the `max_slippage_bps` band that let paper fill above limit → optimistic soak evidence. | `test_paper_buy_never_fills_above_limit_even_with_slippage_budget` (+sell side) |
| `fix(evaluation)` | EvalSpool survives per-fill scoring/persistence exceptions instead of dying permanently+silently on the first one. | `test_eval_spool_survives_transient_store_failure_and_keeps_scoring` (+scoring error) |
| `fix(evaluation)` | Realized PnL is now net of fill fees (Decimal internals, float boundary), consistent with the MTM path. | 3 fee-accounting tests |
| `fix(sensor)` | `asyncpg.PostgresError` added to the market-data reconnect set — one transient Postgres error no longer kills the live feed permanently. | `test_market_data_sensor` storage-error reconnect test |

## Verification

- `uv run pytest -q` → **2663 passed, 200 skipped, 0 failed** (baseline 2654 + 9 net new tests)
- `uv run mypy src/ tests/ --strict` → clean (469 files)
- Each fix also passed both gates independently on its own branch before integration.

## Known follow-ups (not in this PR)

- Paper fill rate will drop to live-faithful levels: controller defaults `limit_price = mid`; strategies wanting crossable limits should set `price_reference=best_ask` (`pipeline.py:1709`) — this is honest behavior, the old band was masking it.
- `live_preflight.py:2777` still counts terminal IOC partials as open orders in a report query (low stakes).
- Batch 2 queued: 7 lifecycle/supervision findings (worker tasks dying silently on transient DB errors while heartbeat stays green), spread double-count (`pipeline.py:1260`), calibration feedback wiring (`netcal.py:13`).

Full audit evidence: `~/.pms-audit-2026-06-10/logic-bug-audit.json` (28 confirmed / 3 refuted, adversarially verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)