### PR TITLE
feat(strategy): add wc_flb_tail_fade_v1 World Cup tail-fade strategy

### DIFF
--- a/scripts/install_wc_flb_tail_fade_strategy.py
+++ b/scripts/install_wc_flb_tail_fade_strategy.py
@@ -1,0 +1,120 @@
+"""Register the PAPER-only World Cup 2026 FLB tail-fade strategy."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+import asyncpg
+
+from pms.factors.catalog import ensure_factor_catalog
+from pms.factors.definitions import REGISTERED
+from pms.storage.strategy_registry import PostgresStrategyRegistry
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import FactorCompositionStep, StrategyVersion
+from pms.strategies.wc_flb_tail_fade import build_wc_flb_tail_fade_strategy
+
+_RAW_FACTOR_ROLES = frozenset(
+    {
+        "weighted",
+        "precedence_rank",
+        "threshold_edge",
+        "posterior_prior",
+        "posterior_success",
+        "posterior_failure",
+        "rule_delta",
+    }
+)
+_REGISTERED_FACTOR_IDS = frozenset(factor_cls.factor_id for factor_cls in REGISTERED)
+
+
+async def install_wc_flb_tail_fade_strategy(
+    database_url: str,
+    *,
+    archive_default: bool = False,
+) -> StrategyVersion:
+    pool = await asyncpg.create_pool(
+        dsn=database_url,
+        min_size=1,
+        max_size=2,
+    )
+    try:
+        registry = PostgresStrategyRegistry(pool)
+        strategy = build_wc_flb_tail_fade_strategy()
+        factor_steps = _strategy_factor_steps(strategy)
+        await ensure_factor_catalog(
+            pool,
+            factor_ids=tuple(
+                dict.fromkeys(step.factor_id for step in factor_steps)
+            ),
+        )
+        version = await registry.create_version(strategy, activate=False)
+        await registry.populate_strategy_factors(
+            strategy.config.strategy_id,
+            version.strategy_version_id,
+            factor_steps,
+        )
+        if archive_default:
+            await registry.archive_strategy("default")
+        await registry.set_active(
+            strategy.config.strategy_id,
+            version.strategy_version_id,
+        )
+        return version
+    finally:
+        await pool.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Register wc_flb_tail_fade_v1 as an active PAPER strategy."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="PostgreSQL DSN. Defaults to DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--archive-default",
+        action="store_true",
+        help=(
+            "Archive the seeded default strategy so this PAPER strategy is the "
+            "only active paper-soak controller."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    database_url = args.database_url
+    if not database_url:
+        print("error: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    version = _run_install(database_url, archive_default=args.archive_default)
+    print(f"strategy_id: {version.strategy_id}")
+    print(f"strategy_version_id: {version.strategy_version_id}")
+    print(f"created_at: {version.created_at.isoformat()}")
+    print(f"archived_default: {str(args.archive_default).lower()}")
+    return 0
+
+
+def _run_install(database_url: str, *, archive_default: bool = False) -> StrategyVersion:
+    return asyncio.run(
+        install_wc_flb_tail_fade_strategy(
+            database_url,
+            archive_default=archive_default,
+        )
+    )
+
+
+def _strategy_factor_steps(strategy: Strategy) -> tuple[FactorCompositionStep, ...]:
+    return tuple(
+        step
+        for step in strategy.config.factor_composition
+        if step.role in _RAW_FACTOR_ROLES and step.factor_id in _REGISTERED_FACTOR_IDS
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pms/strategies/wc_flb_tail_fade.py
+++ b/src/pms/strategies/wc_flb_tail_fade.py
@@ -99,12 +99,8 @@ def build_wc_flb_tail_fade_strategy() -> Strategy:
         ),
         # Wide clamp mirrors h1_flb (src/pms/strategies/flb/projection.py).
         # The whole edge lives in the tails (<0.10 / >0.90), so the default
-        # [0.08, 0.92] clamp would reject every tail forecast. The clamp can
-        # never unlock at runtime because calibration feedback is never wired
-        # into NetcalCalibrator.add_samples
-        # (src/pms/controller/calibrators/netcal.py:13), so
-        # resolved_sample_count stays below min_resolved_for_extreme forever —
-        # the clamp window itself must admit the tails outright.
+        # [0.08, 0.92] clamp would reject every initial tail forecast before
+        # the strategy has accumulated resolved calibration samples.
         calibration=CalibrationSpec(
             enabled=True,
             shrinkage_factor=1.0,

--- a/src/pms/strategies/wc_flb_tail_fade.py
+++ b/src/pms/strategies/wc_flb_tail_fade.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    CalibrationSpec,
+    EvalSpec,
+    FactorCompositionStep,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+WC_FLB_TAIL_FADE_STRATEGY_ID = "wc_flb_tail_fade_v1"
+_FLB_FRESHNESS_S = 300.0
+_FLB_EDGE_SCALE = 2.0
+_FLB_MIN_ABS_DELTA = 0.01
+_ORDERBOOK_IMBALANCE_FRESHNESS_S = 60.0
+_ORDERBOOK_IMBALANCE_EDGE_SCALE = 0.05
+_ORDERBOOK_IMBALANCE_MIN_ABS = 0.50
+_RESOLUTION_HORIZON_DAYS = 4
+_ROUTER_MIN_YES_PRICE = 0.02
+_ROUTER_MAX_YES_PRICE = 0.98
+
+
+def build_wc_flb_tail_fade_strategy() -> Strategy:
+    """Favorite-longshot-bias tail fade for World Cup 2026 markets.
+
+    Thesis: tournament retail flow overprices longshot YES tails and
+    underprices favorites. The favorite_longshot_bias factor emits signed
+    values only in the tails (negative below yes_price 0.10 — fade the
+    longshot via a negative delta; positive above 0.90 — back the
+    favorite), so the strategy is inert across the mid-range by
+    construction.
+    """
+    return Strategy(
+        config=StrategyConfig(
+            strategy_id=WC_FLB_TAIL_FADE_STRATEGY_ID,
+            factor_composition=(
+                FactorCompositionStep(
+                    factor_id="favorite_longshot_bias",
+                    role="rule_delta",
+                    param="",
+                    weight=_FLB_EDGE_SCALE,
+                    threshold=_FLB_MIN_ABS_DELTA,
+                    required=True,
+                    freshness_sla_s=_FLB_FRESHNESS_S,
+                    allow_neutral_fallback=False,
+                ),
+                FactorCompositionStep(
+                    factor_id="orderbook_imbalance",
+                    role="rule_delta",
+                    param="",
+                    weight=_ORDERBOOK_IMBALANCE_EDGE_SCALE,
+                    threshold=_ORDERBOOK_IMBALANCE_MIN_ABS,
+                    required=False,
+                    freshness_sla_s=_ORDERBOOK_IMBALANCE_FRESHNESS_S,
+                    allow_neutral_fallback=True,
+                ),
+                FactorCompositionStep(
+                    factor_id="rules",
+                    role="blend_weighted",
+                    param="",
+                    weight=1.0,
+                    threshold=None,
+                    required=False,
+                    allow_neutral_fallback=True,
+                ),
+            ),
+            metadata=(
+                ("owner", "Researcher-Ciga"),
+                ("tier", "paper"),
+                ("purpose", "wc2026_flb_tail_fade_paper_soak"),
+                ("price_reference", "best_ask"),
+                ("live_allowed", "false"),
+                ("requires_strict_factor_gates", "false"),
+            ),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=1.0,
+            max_daily_drawdown_pct=20.0,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(
+            metrics=("brier", "pnl", "fill_rate"),
+            max_brier_score=0.30,
+            slippage_threshold_bps=50.0,
+            min_win_rate=0.45,
+        ),
+        forecaster=ForecasterSpec(
+            forecasters=(("rules", (("threshold", "0.55"),)),)
+        ),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=_RESOLUTION_HORIZON_DAYS,
+            volume_min_usdc=1_000.0,
+            yes_price_min=_ROUTER_MIN_YES_PRICE,
+            yes_price_max=_ROUTER_MAX_YES_PRICE,
+        ),
+        # Wide clamp mirrors h1_flb (src/pms/strategies/flb/projection.py).
+        # The whole edge lives in the tails (<0.10 / >0.90), so the default
+        # [0.08, 0.92] clamp would reject every tail forecast. The clamp can
+        # never unlock at runtime because calibration feedback is never wired
+        # into NetcalCalibrator.add_samples
+        # (src/pms/controller/calibrators/netcal.py:13), so
+        # resolved_sample_count stays below min_resolved_for_extreme forever —
+        # the clamp window itself must admit the tails outright.
+        calibration=CalibrationSpec(
+            enabled=True,
+            shrinkage_factor=1.0,
+            shrinkage_bias=0.0,
+            extreme_clamp_low=0.001,
+            extreme_clamp_high=0.999,
+            min_resolved_for_extreme=20,
+        ),
+    )

--- a/tests/unit/strategies/test_install_wc_flb_tail_fade_strategy.py
+++ b/tests/unit/strategies/test_install_wc_flb_tail_fade_strategy.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pms.strategies.projections import StrategyVersion
+from pms.strategies.wc_flb_tail_fade import build_wc_flb_tail_fade_strategy
+from scripts import install_wc_flb_tail_fade_strategy
+
+
+def test_wc_flb_tail_fade_factor_rows_exclude_runtime_rules() -> None:
+    strategy = build_wc_flb_tail_fade_strategy()
+
+    factor_rows = install_wc_flb_tail_fade_strategy._strategy_factor_steps(strategy)
+
+    assert tuple(step.factor_id for step in factor_rows) == (
+        "favorite_longshot_bias",
+        "orderbook_imbalance",
+    )
+
+
+def test_install_wc_flb_tail_fade_requires_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    result = install_wc_flb_tail_fade_strategy.main([])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "DATABASE_URL is not set" in captured.err
+
+
+def test_install_wc_flb_tail_fade_prints_registered_version(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    observed_archive_default: list[bool] = []
+
+    def _fake_install(
+        database_url: str,
+        *,
+        archive_default: bool = False,
+    ) -> StrategyVersion:
+        assert database_url == "postgresql://example/pms"
+        observed_archive_default.append(archive_default)
+        return StrategyVersion(
+            strategy_id="wc_flb_tail_fade_v1",
+            strategy_version_id="version-789",
+            created_at=datetime(2026, 6, 10, 13, 0, tzinfo=UTC),
+        )
+
+    monkeypatch.setattr(
+        install_wc_flb_tail_fade_strategy,
+        "_run_install",
+        _fake_install,
+    )
+
+    result = install_wc_flb_tail_fade_strategy.main(
+        [
+            "--database-url",
+            "postgresql://example/pms",
+            "--archive-default",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert observed_archive_default == [True]
+    assert "strategy_id: wc_flb_tail_fade_v1" in captured.out
+    assert "strategy_version_id: version-789" in captured.out
+    assert "archived_default: true" in captured.out

--- a/tests/unit/strategies/test_install_wc_flb_tail_fade_strategy.py
+++ b/tests/unit/strategies/test_install_wc_flb_tail_fade_strategy.py
@@ -71,4 +71,5 @@ def test_install_wc_flb_tail_fade_prints_registered_version(
     assert observed_archive_default == [True]
     assert "strategy_id: wc_flb_tail_fade_v1" in captured.out
     assert "strategy_version_id: version-789" in captured.out
+    assert "created_at: 2026-06-10T13:00:00+00:00" in captured.out
     assert "archived_default: true" in captured.out

--- a/tests/unit/strategies/test_wc_flb_tail_fade.py
+++ b/tests/unit/strategies/test_wc_flb_tail_fade.py
@@ -145,10 +145,9 @@ def test_wc_flb_tail_fade_version_id_is_content_addressed() -> None:
 
 def test_wc_flb_tail_fade_calibration_clamp_preserves_tail_probabilities() -> None:
     # Business invariant: the strategy only trades the tails, and the
-    # calibration-feedback loop never feeds NetcalCalibrator.add_samples
-    # (src/pms/controller/calibrators/netcal.py:13), so resolved_sample_count
-    # stays below min_resolved_for_extreme forever. The clamp window itself
-    # must therefore admit tail probabilities.
+    # strategy starts with fewer than min_resolved_for_extreme resolved
+    # samples. The clamp window itself must therefore admit initial tail
+    # probabilities.
     strategy = build_wc_flb_tail_fade_strategy()
 
     assert strategy.calibration.enabled is True

--- a/tests/unit/strategies/test_wc_flb_tail_fade.py
+++ b/tests/unit/strategies/test_wc_flb_tail_fade.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from pms.config import PMSSettings
+from pms.controller.calibrators.extreme_clamp import ExtremeProbClamp
+from pms.controller.factor_snapshot import FactorSnapshot
+from pms.controller.factory import ControllerPipelineFactory
+from pms.core.enums import RunMode
+from pms.core.models import MarketSignal, Portfolio
+from pms.strategies.aggregate import Strategy
+from pms.strategies.projections import (
+    CalibrationContext,
+    CalibrationSpec,
+    FactorCompositionStep,
+)
+from pms.strategies.versioning import compute_strategy_version_id
+from pms.strategies.wc_flb_tail_fade import (
+    WC_FLB_TAIL_FADE_STRATEGY_ID,
+    build_wc_flb_tail_fade_strategy,
+)
+
+
+def _signal(
+    *,
+    yes_price: float,
+    orderbook: dict[str, object],
+) -> MarketSignal:
+    return MarketSignal(
+        market_id="wc-2026-market",
+        token_id="wc-2026-token",
+        venue="polymarket",
+        title="Will the longshot win its World Cup 2026 group match?",
+        yes_price=yes_price,
+        volume_24h=5_000.0,
+        resolves_at=datetime(2026, 6, 12, tzinfo=UTC),
+        orderbook=orderbook,
+        external_signal={"raw_event_type": "book"},
+        fetched_at=datetime(2026, 6, 10, 12, 0, tzinfo=UTC),
+        market_status="open",
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1_000.0,
+        free_usdc=1_000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+class StaticFactorReader:
+    def __init__(self, snapshot: FactorSnapshot) -> None:
+        self.snapshot_calls: list[Sequence[FactorCompositionStep]] = []
+        self._snapshot = snapshot
+
+    async def snapshot(
+        self,
+        *,
+        market_id: str,
+        as_of: datetime,
+        required: Sequence[FactorCompositionStep],
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> Any:
+        del market_id, as_of, strategy_id, strategy_version_id
+        self.snapshot_calls.append(required)
+        return self._snapshot
+
+
+def test_wc_flb_tail_fade_composition_weights_and_thresholds() -> None:
+    strategy = build_wc_flb_tail_fade_strategy()
+
+    assert strategy.config.strategy_id == WC_FLB_TAIL_FADE_STRATEGY_ID
+    assert tuple(
+        (
+            step.factor_id,
+            step.role,
+            step.weight,
+            step.threshold,
+            step.required,
+            step.freshness_sla_s,
+            step.allow_neutral_fallback,
+        )
+        for step in strategy.config.factor_composition
+    ) == (
+        ("favorite_longshot_bias", "rule_delta", 2.0, 0.01, True, 300.0, False),
+        ("orderbook_imbalance", "rule_delta", 0.05, 0.50, False, 60.0, True),
+        ("rules", "blend_weighted", 1.0, None, False, None, True),
+    )
+    assert strategy.forecaster.forecasters == (
+        ("rules", (("threshold", "0.55"),)),
+    )
+    metadata = dict(strategy.config.metadata)
+    assert metadata["purpose"] == "wc2026_flb_tail_fade_paper_soak"
+    assert metadata["price_reference"] == "best_ask"
+    assert metadata["live_allowed"] == "false"
+    assert strategy.risk.max_position_notional_usdc == pytest.approx(1.0)
+    assert strategy.risk.max_daily_drawdown_pct == pytest.approx(20.0)
+    assert strategy.risk.min_order_size_usdc == pytest.approx(1.0)
+    assert strategy.eval_spec.metrics == ("brier", "pnl", "fill_rate")
+    assert strategy.eval_spec.max_brier_score == pytest.approx(0.30)
+    assert strategy.eval_spec.min_win_rate == pytest.approx(0.45)
+    assert strategy.eval_spec.slippage_threshold_bps == pytest.approx(50.0)
+    assert strategy.market_selection.venue == "polymarket"
+    assert strategy.market_selection.resolution_time_max_horizon_days == 4
+    assert strategy.market_selection.volume_min_usdc == pytest.approx(1_000.0)
+    assert strategy.market_selection.yes_price_min == pytest.approx(0.02)
+    assert strategy.market_selection.yes_price_max == pytest.approx(0.98)
+
+
+def test_wc_flb_tail_fade_version_id_is_content_addressed() -> None:
+    first = build_wc_flb_tail_fade_strategy()
+    second = build_wc_flb_tail_fade_strategy()
+
+    assert compute_strategy_version_id(*first.snapshot()) == (
+        compute_strategy_version_id(*second.snapshot())
+    )
+
+    config, risk, eval_spec, forecaster, market_selection, calibration = (
+        first.snapshot()
+    )
+    mutated_config = replace(
+        config,
+        factor_composition=(
+            replace(config.factor_composition[0], threshold=0.02),
+            *config.factor_composition[1:],
+        ),
+    )
+    assert compute_strategy_version_id(
+        mutated_config,
+        risk,
+        eval_spec,
+        forecaster,
+        market_selection,
+        calibration,
+    ) != compute_strategy_version_id(*first.snapshot())
+
+
+def test_wc_flb_tail_fade_calibration_clamp_preserves_tail_probabilities() -> None:
+    # Business invariant: the strategy only trades the tails, and the
+    # calibration-feedback loop never feeds NetcalCalibrator.add_samples
+    # (src/pms/controller/calibrators/netcal.py:13), so resolved_sample_count
+    # stays below min_resolved_for_extreme forever. The clamp window itself
+    # must therefore admit tail probabilities.
+    strategy = build_wc_flb_tail_fade_strategy()
+
+    assert strategy.calibration.enabled is True
+    assert strategy.calibration.shrinkage_factor == pytest.approx(1.0)
+    assert strategy.calibration.shrinkage_bias == pytest.approx(0.0)
+    assert strategy.calibration.extreme_clamp_low == pytest.approx(0.001)
+    assert strategy.calibration.extreme_clamp_high == pytest.approx(0.999)
+    assert strategy.calibration.min_resolved_for_extreme == 20
+
+    context = CalibrationContext(resolved_sample_count=0, model_id="rules-v1")
+    clamp = ExtremeProbClamp(strategy.calibration)
+    assert clamp.calibrate(0.03, context=context) == pytest.approx(0.03)
+    assert clamp.calibrate(0.97, context=context) == pytest.approx(0.97)
+    assert clamp.calibrate(0.0005, context=context) is None
+
+    default_clamp = ExtremeProbClamp(CalibrationSpec(enabled=True))
+    assert default_clamp.calibrate(0.03, context=context) is None
+    assert default_clamp.calibrate(0.97, context=context) is None
+
+
+@pytest.mark.asyncio
+async def test_wc_flb_tail_fade_emits_capped_tail_decision() -> None:
+    strategy = build_wc_flb_tail_fade_strategy()
+    factor_reader = StaticFactorReader(
+        FactorSnapshot(
+            values={("favorite_longshot_bias", ""): 0.02},
+            missing_factors=(),
+            snapshot_hash="wc-flb-tail-snapshot",
+        )
+    )
+    pipeline = ControllerPipelineFactory(
+        settings=PMSSettings(mode=RunMode.PAPER),
+        factor_reader=factor_reader,
+    ).build(strategy.to_active(strategy_version_id="wc-flb-v1"))
+
+    signal = _signal(
+        yes_price=0.93,
+        orderbook={
+            "bids": [{"price": 0.928, "size": 100.0}],
+            "asks": [{"price": 0.932, "size": 100.0}],
+        },
+    )
+
+    decision = await pipeline.decide(signal, portfolio=_portfolio())
+
+    assert decision is not None
+    assert decision.strategy_id == WC_FLB_TAIL_FADE_STRATEGY_ID
+    assert decision.outcome == "YES"
+    assert decision.prob_estimate == pytest.approx(0.97)
+    assert decision.limit_price == pytest.approx(0.932)
+    assert decision.notional_usdc == pytest.approx(1.0)
+    assert factor_reader.snapshot_calls
+
+    # Counterfactual: the same tail forecast dies under the default
+    # [0.08, 0.92] clamp — the wide clamp is what keeps the edge alive.
+    config, risk, eval_spec, forecaster, market_selection, calibration = (
+        strategy.snapshot()
+    )
+    narrow_strategy = Strategy(
+        config=config,
+        risk=risk,
+        eval_spec=eval_spec,
+        forecaster=forecaster,
+        market_selection=market_selection,
+        calibration=replace(
+            calibration,
+            extreme_clamp_low=0.08,
+            extreme_clamp_high=0.92,
+        ),
+    )
+    narrow_pipeline = ControllerPipelineFactory(
+        settings=PMSSettings(mode=RunMode.PAPER),
+        factor_reader=factor_reader,
+    ).build(narrow_strategy.to_active(strategy_version_id="wc-flb-v1-narrow"))
+
+    narrow_decision = await narrow_pipeline.decide(signal, portfolio=_portfolio())
+
+    assert narrow_decision is None
+    assert narrow_pipeline.last_diagnostic is not None
+    assert narrow_pipeline.last_diagnostic.code == "calibration_clamp_rejected"


### PR DESCRIPTION
## Summary

Rank-1 candidate from the World Cup 2026 strategy portfolio (`agent_docs/worldcup-strategy-portfolio-2026-06.md`, PR #82): favorite-longshot-bias tail fade, Channel A, built strictly from factors the live pipeline computes today.

- **Builder** `src/pms/strategies/wc_flb_tail_fade.py`: FLB `rule_delta` w=2.0/thr=0.01/required/SLA 300s + orderbook_imbalance confirmation w=0.05/thr=0.50/optional/neutral-fallback/SLA 60s + rules blend; rules-only forecaster (threshold 0.55); polymarket / 4-day horizon / vol≥$1000 / price band [0.02, 0.98]; risk 1.0 USDC per position / 20% drawdown / 1.0 min order; `live_allowed=false`.
- **Calibration**: wide clamp `0.001/0.999` mirroring `h1_flb` — load-bearing because the default `[0.08, 0.92]` clamp would reject every tail forecast and the clamp can never unlock at runtime (calibration feedback is never wired into `NetcalCalibrator.add_samples`, `netcal.py:13`, confirmed in the 2026-06-10 audit). Pinned by a behavioral test with a default-clamp counterfactual.
- **`price_reference=best_ask` metadata** so emitted limits are crossable under the strict live-parity paper fills from #83.
- **Installer** `scripts/install_wc_flb_tail_fade_strategy.py` mirrors the multi-factor installer (content-hash idempotent, `--archive-default` optional).

## Supporting data (2026-06-10 FLB feasibility, 681 resolved Gamma markets)

Sample gate passes (410 longshot / 193 favorite ≥ 100). Decile table hints the strongest mispricing sits in [0.10,0.20) BUY-NO (+11.8%) and [0.80,0.90) BUY-YES (−12.0%) rather than the extreme tails — the current factor only fires <0.10/>0.90, so **band placement is the pre-registered first hypothesis for backtest iteration**.

## Verification

- TDD (tests red first), 7 new tests incl. content-address and clamp-survival invariants
- `uv run pytest -q` → 2661 passed, 200 skipped; `uv run mypy src/ tests/ --strict` → clean (473 files); `lint-imports` → 9 contracts kept
- Not installed into any database — install into the paper soak happens after merge (soak deadline for an in-window GO: **2026-06-19**)

## Pre-registered kill criterion

If its 7-day Brier improvement vs baseline trails `h1_flb` on the same markets, it is dominated and dies (per portfolio doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new World Cup 2026 strategy for Polymarket prediction markets, optimized for tail probability trading
  * Added command-line installation tool to deploy and activate the strategy with support for archiving previous versions
  * Strategy includes automated calibration with configurable probability bounds for enhanced market performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->