### PR TITLE
feat(supervision): WorkerSupervisor with per-worker liveness in heartbeat/readiness/status (PR-B)

### DIFF
--- a/src/pms/api/app.py
+++ b/src/pms/api/app.py
@@ -86,7 +86,8 @@ from pms.core.models import (
 from pms.evaluation.metrics import MetricsCollector, MetricsSnapshot
 from pms.evaluation.quote_metrics import QuoteMetricsCollector, QuoteMetricsSnapshot
 from pms.metrics import metrics_snapshot
-from pms.runner import Runner
+from pms.runner import READINESS_REQUIRED_WORKERS, Runner
+from pms.supervision import ALIVE_WORKER_STATES
 from pms.storage.schema_check import ensure_schema_current
 from pms.storage.decision_store import DecisionStore
 from pms.storage.market_data_store import PostgresMarketDataStore
@@ -231,7 +232,12 @@ def create_app(
         return {
             "mode": active_runner.state.mode.value,
             "runner_started_at": _jsonable(active_runner.state.runner_started_at),
+            # `running` keeps its historical any-task-alive semantics for
+            # smoke-script back-compat; `healthy`/`workers` are additive and
+            # carry per-worker supervision truth.
             "running": _is_runner_running(active_runner),
+            "healthy": _runner_workers_healthy(active_runner),
+            "workers": active_runner.worker_component_payload(),
             "autostart_attempted": getattr(
                 request.app.state, "autostart_attempted", False
             ),
@@ -1252,6 +1258,19 @@ def _should_use_durable_decisions(runner: Runner) -> bool:
 
 def _is_runner_running(runner: Runner) -> bool:
     return any(not task.done() for task in runner.tasks)
+
+
+def _runner_workers_healthy(runner: Runner) -> bool:
+    """True iff the runner is running and every spawned required worker is
+    alive. Stays additive: `/status.running` semantics are untouched."""
+    if not _is_runner_running(runner):
+        return False
+    snapshot = runner.worker_health_snapshot()
+    return all(
+        snapshot[name].state in ALIVE_WORKER_STATES
+        for name in READINESS_REQUIRED_WORKERS
+        if name in snapshot
+    )
 
 
 async def _ensure_runner_pool(runner: Runner) -> None:

--- a/src/pms/api/health.py
+++ b/src/pms/api/health.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from pms.runner import Runner
+from pms.runner import READINESS_REQUIRED_WORKERS, Runner
+from pms.supervision import ALIVE_WORKER_STATES
 
 
 def health_payload(*, shutting_down: bool) -> tuple[int, dict[str, Any]]:
@@ -22,16 +23,21 @@ def readiness_payload(
 ) -> tuple[int, dict[str, Any]]:
     if shutting_down:
         return 503, {"status": "shutting_down", "checks": {}}
+    worker_status, worker_detail = _worker_readiness(
+        runner,
+        forced_running=forced_running,
+    )
     checks = {
         "sensors": _sensor_readiness(runner, forced_running=forced_running),
         "event_loop": _event_loop_readiness(runner, forced_running=forced_running),
+        "workers": worker_status,
         "halt_subscriber": _task_readiness(halt_subscriber_task),
         "eod_scheduler": _task_readiness(eod_scheduler_task),
     }
     ready_values = {"ready", "disabled"}
     status = "ready" if all(value in ready_values for value in checks.values()) else "not_ready"
     code = 200 if status == "ready" else 503
-    return code, {"status": status, "checks": checks}
+    return code, {"status": status, "checks": checks, "workers": worker_detail}
 
 
 def _sensor_readiness(runner: Runner, *, forced_running: bool) -> str:
@@ -50,6 +56,33 @@ def _event_loop_readiness(runner: Runner, *, forced_running: bool) -> str:
     if any(not task.done() for task in runner.tasks):
         return "ready"
     return "not_started"
+
+
+def _worker_readiness(
+    runner: Runner,
+    *,
+    forced_running: bool,
+) -> tuple[str, dict[str, Any]]:
+    """Ready iff every spawned required worker (dispatcher, actuator,
+    factor service when PG runtime, heartbeat writer in PAPER/LIVE) is
+    `running` or `restarting`. The detail names dead workers so process
+    supervisors and alerting can act on the 503."""
+    if forced_running:
+        return "ready", {"required": {}, "dead": []}
+    snapshot = runner.worker_health_snapshot()
+    required = [name for name in READINESS_REQUIRED_WORKERS if name in snapshot]
+    if not required:
+        return "not_started", {"required": {}, "dead": []}
+    states = {name: snapshot[name].state for name in required}
+    dead = [
+        name
+        for name, state in states.items()
+        if state not in ALIVE_WORKER_STATES
+    ]
+    detail = {"required": states, "dead": dead}
+    if dead:
+        return "not_ready", detail
+    return "ready", detail
 
 
 def _task_readiness(task: asyncio.Task[None] | None) -> str:

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -2405,11 +2405,16 @@ class Runner:
                 sensor_running
                 and len(self._controller_runtimes) > 0
                 and not self._stop_event.is_set()
+                # Dead trading workers (dispatcher/actuator/factor) must
+                # count as unhealthy heartbeat periods: this is the
+                # correction of the false-green the 2026-06-10 audit found.
+                and self._trading_workers_ok()
             ),
             "sensor_running": sensor_running,
             "sensor_tasks": running_tasks,
             "sensor_tasks_total": len(tasks),
             "sensor_task_failures": failed_tasks,
+            "workers": self._supervisor.component_payload(),
         }
 
     def _record_position_exit_reentry_quarantine(

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -113,7 +113,7 @@ from pms.sensor.adapters.direct_book import (
 from pms.sensor.adapters.historical import HistoricalSensor
 from pms.sensor.adapters.market_data import MarketDataSensor
 from pms.sensor.adapters.market_discovery import MarketDiscoverySensor
-from pms.sensor.stream import SensorStream
+from pms.sensor.stream import SensorStream, SignalSubscription
 from pms.storage.dedup_store import InMemoryDedupStore, PgDedupStore
 from pms.storage.decision_store import DecisionStore
 from pms.storage.eval_store import EvalStore
@@ -181,6 +181,13 @@ from pms.strategies.ripple.source import (
 )
 from pms.strategies.runtime_bridge import StrategyRunResult
 from pms.strategies.versioning import compute_strategy_version_id
+from pms.supervision import (
+    ALIVE_WORKER_STATES,
+    WorkerFactory,
+    WorkerHealth,
+    WorkerSpec,
+    WorkerSupervisor,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -193,6 +200,39 @@ DECISION_PENDING_TTL = timedelta(minutes=15)
 DECISION_SWEEP_INTERVAL_S = 5.0
 RUNTIME_HEARTBEAT_INTERVAL_S = 60.0
 DEFAULT_OPERATIONAL_MARKET_SELECTION_HORIZON_DAYS = 90
+
+# --- Worker supervision (see pms.supervision) -------------------------------
+# Restart only on this transient set, within budget, with exponential
+# backoff. Inner per-cycle catches stay the first line of defence; the
+# supervisor is the last resort.
+WORKER_TRANSIENT_ERRORS: tuple[type[BaseException], ...] = (
+    asyncpg.PostgresError,
+    OSError,
+    TimeoutError,
+)
+WORKER_MAX_RESTARTS = 5
+WORKER_RESTART_WINDOW_S = 600.0
+WORKER_RESTART_BACKOFF_INITIAL_S = 1.0
+WORKER_RESTART_BACKOFF_MAX_S = 60.0
+WORKER_FACTOR_SERVICE = "factor_service"
+WORKER_CONTROLLER_DISPATCHER = "controller_dispatcher"
+WORKER_ACTUATOR = "actuator"
+WORKER_DECISION_EXPIRY = "decision_expiry"
+WORKER_RUNTIME_HEARTBEAT = "runtime_heartbeat"
+# Workers the trading path cannot live without: used to tighten the
+# heartbeat `running` flag. The factor service only counts when it was
+# actually spawned (PostgreSQL runtime).
+TRADING_REQUIRED_WORKERS: tuple[str, ...] = (
+    WORKER_CONTROLLER_DISPATCHER,
+    WORKER_ACTUATOR,
+    WORKER_FACTOR_SERVICE,
+)
+# Readiness additionally requires the heartbeat writer when it was spawned
+# (PAPER/LIVE with PostgreSQL).
+READINESS_REQUIRED_WORKERS: tuple[str, ...] = (
+    *TRADING_REQUIRED_WORKERS,
+    WORKER_RUNTIME_HEARTBEAT,
+)
 RAW_FACTOR_COMPOSITION_ROLES = frozenset(
     {
         "weighted",
@@ -320,7 +360,9 @@ class Runner:
     _controller_task: asyncio.Task[None] | None = field(init=False, default=None)
     _actuator_task: asyncio.Task[None] | None = field(init=False, default=None)
     _factor_service: FactorService | None = field(init=False, default=None)
+    _factor_service_fresh: bool = field(init=False, default=False)
     _factor_service_task: asyncio.Task[None] | None = field(init=False, default=None)
+    _supervisor: WorkerSupervisor = field(init=False)
     _task: asyncio.Task[None] | None = field(init=False, default=None)
     _pg_pool: asyncpg.Pool | None = field(init=False, default=None)
     _owns_pg_pool: bool = field(init=False, default=False)
@@ -426,6 +468,9 @@ class Runner:
             self.config
         )
         self._flb_calibration_model = _flb_calibration_model_from_settings(self.config)
+        self._supervisor = WorkerSupervisor(
+            event_publisher=self._publish_worker_event,
+        )
         self.actuator_executor = self._build_executor(self.config.mode)
 
     @property
@@ -557,6 +602,11 @@ class Runner:
         )
         self._paper_orderbooks.clear()
         self._latest_signal_by_token.clear()
+        # Fresh supervisor per run: stop() latches its no-respawn flag, so a
+        # restarted runner needs a new instance with clean health state.
+        self._supervisor = WorkerSupervisor(
+            event_publisher=self._publish_worker_event,
+        )
 
         try:
             self._assert_no_legacy_jsonl_paths()
@@ -582,15 +632,14 @@ class Runner:
                 if self._pg_pool is None:
                     msg = "Runner PostgreSQL pool is not initialized"
                     raise RuntimeError(msg)
-                factor_signal_stream = self.sensor_stream.subscribe()
-                self._factor_service = FactorService(
-                    pool=self._pg_pool,
-                    store=PostgresMarketDataStore(self._pg_pool),
-                    cadence_s=self.config.factor_cadence_s,
-                    factors=REGISTERED,
-                    signal_stream=factor_signal_stream,
+                self._factor_service = self._build_factor_service()
+                self._factor_service_fresh = True
+                self._factor_service_task = self._supervisor.spawn(
+                    self._worker_spec(
+                        WORKER_FACTOR_SERVICE,
+                        self._run_factor_service_worker,
+                    )
                 )
-                self._factor_service_task = asyncio.create_task(self._factor_service.run())
                 # Rebuild the portfolio from persisted fills BEFORE sensors
                 # start producing signals. Without this, a restart in LIVE
                 # mode would forget open Polymarket exposure: every new BUY
@@ -604,14 +653,39 @@ class Runner:
             self._wire_active_perception(self._active_sensors)
             await self._configure_controllers()
             await self.sensor_stream.start(self._active_sensors)
+            for index, (sensor, sensor_task) in enumerate(
+                zip(self._active_sensors, self.sensor_stream.tasks, strict=True)
+            ):
+                # Watch-only: sensor _consume tasks carry their own reconnect
+                # loops, and restarting them would fight SensorStream's
+                # _active_consumers bookkeeping.
+                self._supervisor.observe(
+                    sensor_task,
+                    name=f"sensor:{index}:{type(sensor).__name__}",
+                )
             await self._evaluator_spool.start()
-            self._controller_task = asyncio.create_task(self._controller_loop())
-            self._actuator_task = asyncio.create_task(self._actuator_loop())
+            self._controller_task = self._supervisor.spawn(
+                self._worker_spec(
+                    WORKER_CONTROLLER_DISPATCHER,
+                    self._controller_loop,
+                )
+            )
+            self._actuator_task = self._supervisor.spawn(
+                self._worker_spec(WORKER_ACTUATOR, self._actuator_loop)
+            )
             if self._pg_pool is not None:
-                self._decision_expiry_task = asyncio.create_task(self._decision_expiry_loop())
+                self._decision_expiry_task = self._supervisor.spawn(
+                    self._worker_spec(
+                        WORKER_DECISION_EXPIRY,
+                        self._decision_expiry_loop,
+                    )
+                )
             if self._pg_pool is not None and self.config.mode in {RunMode.PAPER, RunMode.LIVE}:
-                self._runtime_heartbeat_task = asyncio.create_task(
-                    self._runtime_heartbeat_loop()
+                self._runtime_heartbeat_task = self._supervisor.spawn(
+                    self._worker_spec(
+                        WORKER_RUNTIME_HEARTBEAT,
+                        self._runtime_heartbeat_loop,
+                    )
                 )
         except Exception:
             self._live_preflight_artifact_validated = False
@@ -620,6 +694,9 @@ class Runner:
             raise
 
     async def stop(self, *, close_pool: bool = True) -> None:
+        # Block respawns before any cancellation so a supervised restart
+        # cannot race the teardown ordering below.
+        self._supervisor.stop()
         self._stop_event.set()
         error: BaseException | None = None
 
@@ -1088,6 +1165,70 @@ class Runner:
         if self.config.mode != RunMode.BACKTEST:
             return True
         return "database" in self.config.model_fields_set
+
+    def worker_health_snapshot(self) -> dict[str, WorkerHealth]:
+        return self._supervisor.snapshot()
+
+    def worker_component_payload(self) -> dict[str, object]:
+        return self._supervisor.component_payload()
+
+    def _worker_spec(self, name: str, factory: WorkerFactory) -> WorkerSpec:
+        return WorkerSpec(
+            name=name,
+            factory=factory,
+            transient=WORKER_TRANSIENT_ERRORS,
+            max_restarts=WORKER_MAX_RESTARTS,
+            restart_window_s=WORKER_RESTART_WINDOW_S,
+            backoff_initial_s=WORKER_RESTART_BACKOFF_INITIAL_S,
+            backoff_max_s=WORKER_RESTART_BACKOFF_MAX_S,
+        )
+
+    async def _publish_worker_event(self, event_type: str, summary: str) -> None:
+        await self.event_bus.publish(event_type, summary)
+
+    def _trading_workers_ok(self) -> bool:
+        snapshot = self._supervisor.snapshot()
+        return all(
+            health.state in ALIVE_WORKER_STATES
+            for name, health in snapshot.items()
+            if name in TRADING_REQUIRED_WORKERS
+        )
+
+    def _build_factor_service(self) -> FactorService:
+        pool = self._pg_pool
+        if pool is None:
+            msg = "Runner PostgreSQL pool is not initialized"
+            raise RuntimeError(msg)
+        return FactorService(
+            pool=pool,
+            store=PostgresMarketDataStore(pool),
+            cadence_s=self.config.factor_cadence_s,
+            factors=REGISTERED,
+            signal_stream=self.sensor_stream.subscribe(),
+        )
+
+    async def _run_factor_service_worker(self) -> None:
+        service = self._factor_service
+        if service is None or not self._factor_service_fresh:
+            # FactorService instances are single-use: _stream_exhausted
+            # latches once the subscription ends, so a supervised restart
+            # must rebuild the instance with a fresh subscription. Close the
+            # dead subscription so SensorStream stops buffering into it.
+            self._close_factor_signal_subscription(service)
+            service = self._build_factor_service()
+            self._factor_service = service
+        self._factor_service_fresh = False
+        await service.run()
+
+    def _close_factor_signal_subscription(
+        self,
+        service: FactorService | None,
+    ) -> None:
+        if service is None:
+            return
+        stream = service.signal_stream
+        if isinstance(stream, SignalSubscription):
+            stream.close()
 
     async def _ensure_default_v2_version(self) -> None:
         if not self.config.auto_migrate_default_v2:
@@ -2548,6 +2689,7 @@ class Runner:
         await self.close_pg_pool()
 
     async def _cleanup_after_start_failure(self) -> None:
+        self._supervisor.stop()
         stop_error: BaseException | None = None
         if self._factor_service_task is not None and not self._factor_service_task.done():
             self._factor_service_task.cancel()
@@ -2807,6 +2949,12 @@ class Runner:
             name=f"controller-pipeline:{runtime.strategy_id}",
         )
         task.add_done_callback(self._capture_controller_pipeline_exception)
+        # Watch-only: pipeline tasks already have capture/release/re-attach
+        # machinery; the supervisor only tracks their health.
+        self._supervisor.observe(
+            task,
+            name=f"controller-pipeline:{runtime.strategy_id}",
+        )
         self._controller_pipeline_tasks[runtime.strategy_id] = task
 
     def _capture_controller_pipeline_exception(

--- a/src/pms/supervision.py
+++ b/src/pms/supervision.py
@@ -1,0 +1,277 @@
+"""Unified worker supervision for runner-owned asyncio tasks.
+
+`WorkerSupervisor.spawn` wraps a worker coroutine factory in a wrapper task
+with a declarative restart policy (`WorkerSpec`). The wrapper has exactly
+four exit paths, each tested:
+
+- **clean return** — the worker finished its work; the wrapper returns
+  without respawning (preserves backtest wind-down semantics where a
+  completed task means "done", not "dead").
+- **listed transient within budget** — restart with exponential backoff;
+  the wrapper task stays pending, so ``task.done()`` predicates downstream
+  never observe a restart as a shutdown.
+- **cancellation** — propagates unchanged (shutdown path).
+- **unlisted exception or exhausted budget** — permanent failure: health is
+  marked ``failed``, an ``error`` event is published, and the wrapper
+  re-raises so the task completes loudly.
+
+`observe` registers watch-only health tracking for tasks whose lifecycle is
+owned elsewhere (sensor consume tasks, controller pipeline tasks).
+
+The supervisor is strategy-agnostic: it knows nothing beyond coroutine
+factories and exception types.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from collections.abc import Awaitable, Callable, Coroutine
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+WorkerState = Literal["running", "restarting", "stopped", "cancelled", "failed"]
+
+ALIVE_WORKER_STATES: frozenset[str] = frozenset({"running", "restarting"})
+
+WorkerFactory = Callable[[], Coroutine[Any, Any, None]]
+EventPublisher = Callable[[str, str], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class WorkerSpec:
+    name: str
+    factory: WorkerFactory
+    transient: tuple[type[BaseException], ...]
+    max_restarts: int = 5
+    restart_window_s: float = 600.0
+    backoff_initial_s: float = 1.0
+    backoff_max_s: float = 60.0
+
+
+@dataclass(frozen=True)
+class WorkerHealth:
+    state: WorkerState
+    restarts: int = 0
+    last_error_class: str | None = None
+    last_transition_at: datetime = field(
+        default_factory=lambda: datetime.now(tz=UTC)
+    )
+
+
+@dataclass
+class WorkerSupervisor:
+    event_publisher: EventPublisher | None = None
+    _health: dict[str, WorkerHealth] = field(init=False, default_factory=dict)
+    _stop_requested: asyncio.Event = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._stop_requested = asyncio.Event()
+
+    def spawn(self, spec: WorkerSpec) -> asyncio.Task[None]:
+        self._transition(spec.name, "running", restarts=0)
+        task = asyncio.create_task(
+            self._supervise(spec),
+            name=f"supervised:{spec.name}",
+        )
+        # A task cancelled before its first tick never executes the wrapper
+        # body, so the in-coroutine transitions cannot run. Reconcile the
+        # terminal state from the done callback in that case.
+        task.add_done_callback(
+            lambda done: self._reconcile_wrapper_outcome(done, spec.name)
+        )
+        return task
+
+    def observe(self, task: asyncio.Task[None], name: str) -> None:
+        """Track health for a task owned elsewhere. Watch-only: no restart."""
+        self._transition(name, "running")
+        task.add_done_callback(
+            lambda done: self._record_observed_outcome(done, name)
+        )
+
+    def stop(self) -> None:
+        """Block all respawns. Call before cancelling worker tasks so a
+        restart cannot race the teardown."""
+        self._stop_requested.set()
+
+    def snapshot(self) -> dict[str, WorkerHealth]:
+        return dict(self._health)
+
+    def component_payload(self) -> dict[str, object]:
+        return {
+            name: {
+                "state": health.state,
+                "restarts": health.restarts,
+                "last_error_class": health.last_error_class,
+            }
+            for name, health in self._health.items()
+        }
+
+    async def _supervise(self, spec: WorkerSpec) -> None:
+        try:
+            await self._supervise_attempts(spec)
+        except asyncio.CancelledError:
+            self._transition(spec.name, "cancelled")
+            raise
+
+    async def _supervise_attempts(self, spec: WorkerSpec) -> None:
+        restarts = 0
+        restart_times: deque[float] = deque()
+        while True:
+            self._transition(spec.name, "running", restarts=restarts)
+            try:
+                await spec.factory()
+            except asyncio.CancelledError:
+                raise
+            except spec.transient as error:
+                now = time.monotonic()
+                while (
+                    restart_times
+                    and now - restart_times[0] > spec.restart_window_s
+                ):
+                    restart_times.popleft()
+                if len(restart_times) >= spec.max_restarts:
+                    await self._record_permanent_failure(
+                        spec.name,
+                        error,
+                        restarts=restarts,
+                        reason="restart budget exhausted",
+                    )
+                    raise
+                restart_times.append(now)
+                restarts += 1
+                self._transition(
+                    spec.name,
+                    "restarting",
+                    restarts=restarts,
+                    error=error,
+                )
+                backoff_s = min(
+                    spec.backoff_initial_s * 2 ** (len(restart_times) - 1),
+                    spec.backoff_max_s,
+                )
+                logger.warning(
+                    "worker %s hit transient %s; restart %d/%d in %.1fs",
+                    spec.name,
+                    type(error).__name__,
+                    restarts,
+                    spec.max_restarts,
+                    backoff_s,
+                )
+                await self._publish_event(
+                    f"worker {spec.name} restarting after "
+                    f"{type(error).__name__} (restart {restarts})",
+                )
+                stop_requested = await self._backoff_wait(backoff_s)
+                if stop_requested or self._stop_requested.is_set():
+                    self._transition(spec.name, "stopped", restarts=restarts)
+                    return
+            except BaseException as error:
+                await self._record_permanent_failure(
+                    spec.name,
+                    error,
+                    restarts=restarts,
+                    reason="unlisted exception",
+                )
+                raise
+            else:
+                self._transition(spec.name, "stopped", restarts=restarts)
+                return
+
+    async def _backoff_wait(self, delay_s: float) -> bool:
+        """Sleep for `delay_s` unless stop is requested earlier. Returns
+        True when the wait ended because stop was requested."""
+        try:
+            await asyncio.wait_for(self._stop_requested.wait(), timeout=delay_s)
+        except TimeoutError:
+            return False
+        return True
+
+    async def _record_permanent_failure(
+        self,
+        name: str,
+        error: BaseException,
+        *,
+        restarts: int,
+        reason: str,
+    ) -> None:
+        self._transition(name, "failed", restarts=restarts, error=error)
+        logger.error(
+            "worker %s failed permanently (%s): %s",
+            name,
+            reason,
+            error,
+        )
+        await self._publish_event(
+            f"worker {name} failed permanently ({reason}): "
+            f"{type(error).__name__}",
+        )
+
+    async def _publish_event(self, message: str) -> None:
+        publisher = self.event_publisher
+        if publisher is None:
+            return
+        try:
+            await publisher("error", message)
+        except Exception as publish_error:  # noqa: BLE001
+            logger.warning(
+                "worker event publish failed: %s",
+                publish_error,
+            )
+
+    def _reconcile_wrapper_outcome(
+        self,
+        task: asyncio.Task[None],
+        name: str,
+    ) -> None:
+        health = self._health.get(name)
+        if health is not None and health.state not in ALIVE_WORKER_STATES:
+            return
+        self._record_observed_outcome(task, name)
+
+    def _record_observed_outcome(
+        self,
+        task: asyncio.Task[None],
+        name: str,
+    ) -> None:
+        if task.cancelled():
+            self._transition(name, "cancelled")
+            return
+        error = task.exception()
+        if error is not None:
+            self._transition(name, "failed", error=error)
+            return
+        self._transition(name, "stopped")
+
+    def _transition(
+        self,
+        name: str,
+        state: WorkerState,
+        *,
+        restarts: int | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        previous = self._health.get(name)
+        self._health[name] = WorkerHealth(
+            state=state,
+            restarts=(
+                restarts
+                if restarts is not None
+                else (previous.restarts if previous is not None else 0)
+            ),
+            last_error_class=(
+                type(error).__name__
+                if error is not None
+                else (
+                    previous.last_error_class
+                    if previous is not None
+                    else None
+                )
+            ),
+            last_transition_at=datetime.now(tz=UTC),
+        )

--- a/tests/integration/test_runtime_heartbeat_store.py
+++ b/tests/integration/test_runtime_heartbeat_store.py
@@ -230,3 +230,84 @@ async def test_runtime_continuity_measures_healthy_days_to_report_clock(
     assert continuity.last_observed_at == last_observed_at
     assert continuity.healthy_days == 30
     assert continuity.max_gap_seconds == pytest.approx(2_592_000.0 - 60.0)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_runtime_continuity_counts_dead_worker_heartbeat_unhealthy(
+    pg_pool: asyncpg.Pool,
+) -> None:
+    """Round-trip the exact component_status shape the runner writes when a
+    required worker is dead: the tightened `running:false` must count as an
+    unhealthy heartbeat in the continuity gate, and the additive `workers`
+    payload must be invisible to the COALESCE-based SQL."""
+    run_id = "runtime-heartbeat-dead-worker"
+    started_at = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    observed_until = started_at + timedelta(minutes=2)
+    store = RuntimeHeartbeatStore(pg_pool)
+    async with pg_pool.acquire() as connection:
+        await connection.execute(
+            "DELETE FROM runtime_heartbeats WHERE run_id = $1",
+            run_id,
+        )
+
+    healthy_status: dict[str, object] = {
+        "running": True,
+        "sensor_running": True,
+        "sensor_tasks": 1,
+        "sensor_tasks_total": 1,
+        "sensor_task_failures": 0,
+        "controller_runtimes": 1,
+        "workers": {
+            "controller_dispatcher": {
+                "state": "running",
+                "restarts": 0,
+                "last_error_class": None,
+            },
+            "actuator": {
+                "state": "running",
+                "restarts": 0,
+                "last_error_class": None,
+            },
+        },
+    }
+    dead_worker_status: dict[str, object] = {
+        "running": False,
+        "sensor_running": True,
+        "sensor_tasks": 1,
+        "sensor_tasks_total": 1,
+        "sensor_task_failures": 0,
+        "controller_runtimes": 1,
+        "workers": {
+            "controller_dispatcher": {
+                "state": "failed",
+                "restarts": 0,
+                "last_error_class": "RuntimeError",
+            },
+            "actuator": {
+                "state": "running",
+                "restarts": 0,
+                "last_error_class": None,
+            },
+        },
+    }
+    for observed_at, component_status in (
+        (started_at, healthy_status),
+        (started_at + timedelta(minutes=1), dead_worker_status),
+    ):
+        await store.append(
+            run_id=run_id,
+            mode="paper",
+            started_at=started_at,
+            observed_at=observed_at,
+            strategy_fingerprint="strategy-fingerprint",
+            component_status=component_status,
+        )
+
+    continuity = await store.continuity(
+        run_id=run_id,
+        observed_until=observed_until,
+    )
+
+    assert continuity is not None
+    assert continuity.heartbeat_count == 2
+    assert continuity.unhealthy_heartbeat_count == 1

--- a/tests/unit/test_runner_worker_supervision.py
+++ b/tests/unit/test_runner_worker_supervision.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from typing import Any, cast
 
 import asyncpg
+import httpx
 import pytest
 
 import pms.runner as runner_module
+from pms.api.app import create_app
+from pms.api.health import readiness_payload
 from pms.config import PMSSettings, RiskSettings
 from pms.core.enums import MarketStatus, RunMode
 from pms.core.models import MarketSignal, Portfolio, TradeDecision
@@ -342,6 +345,148 @@ async def test_stop_during_dispatcher_backoff_blocks_respawn(
         "cancelled",
     }
     assert runner.tasks == ()
+
+
+async def _kill_dispatcher(
+    runner: Runner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail the dispatcher with an unlisted error so its wrapper completes
+    as `failed` while every other worker keeps running."""
+
+    def broken_remember(signal: MarketSignal) -> None:
+        del signal
+        msg = "unexpected bug"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        runner,
+        "_remember_signal_for_decision_evidence",
+        broken_remember,
+    )
+    await runner.sensor_stream.queue.put(_signal())
+    await _wait_until(
+        lambda: runner.worker_health_snapshot()[
+            WORKER_CONTROLLER_DISPATCHER
+        ].state
+        == "failed"
+    )
+    dispatcher_task = runner.controller_task
+    assert dispatcher_task is not None
+    await _wait_until(lambda: dispatcher_task.done())
+    dispatcher_task.exception()
+
+
+# --- Monitoring surface (heartbeat / readiness / status) --------------------
+
+
+@pytest.mark.asyncio
+async def test_component_status_running_requires_alive_trading_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The heartbeat continuity gate keys on component_status.running: a
+    dead dispatcher must flip it false even while sensors stay healthy,
+    so dead-worker periods count as unhealthy in paper_report."""
+    runner = _runner()
+    try:
+        await runner.start()
+        status = runner._runtime_sensor_component_status()  # noqa: SLF001
+        assert status["running"] is True
+        workers = cast(dict[str, dict[str, object]], status["workers"])
+        assert workers[WORKER_CONTROLLER_DISPATCHER]["state"] == "running"
+
+        await _kill_dispatcher(runner, monkeypatch)
+
+        status = runner._runtime_sensor_component_status()  # noqa: SLF001
+        assert status["running"] is False
+        assert status["sensor_running"] is True
+        workers = cast(dict[str, dict[str, object]], status["workers"])
+        assert workers[WORKER_CONTROLLER_DISPATCHER]["state"] == "failed"
+        assert (
+            workers[WORKER_CONTROLLER_DISPATCHER]["last_error_class"]
+            == "RuntimeError"
+        )
+    finally:
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_readiness_fails_closed_on_dead_required_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner()
+    try:
+        await runner.start()
+        code, payload = readiness_payload(
+            runner,
+            halt_subscriber_task=None,
+            eod_scheduler_task=None,
+        )
+        assert code == 200
+        assert payload["checks"]["workers"] == "ready"
+        assert payload["workers"]["dead"] == []
+
+        await _kill_dispatcher(runner, monkeypatch)
+
+        code, payload = readiness_payload(
+            runner,
+            halt_subscriber_task=None,
+            eod_scheduler_task=None,
+        )
+        assert code == 503
+        assert payload["status"] == "not_ready"
+        assert payload["checks"]["workers"] == "not_ready"
+        assert WORKER_CONTROLLER_DISPATCHER in payload["workers"]["dead"]
+    finally:
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_readiness_workers_check_not_started_before_runner_start() -> None:
+    runner = _runner()
+    code, payload = readiness_payload(
+        runner,
+        halt_subscriber_task=None,
+        eod_scheduler_task=None,
+    )
+    assert code == 503
+    assert payload["checks"]["workers"] == "not_started"
+
+
+@pytest.mark.asyncio
+async def test_status_surfaces_worker_health_without_touching_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`/status.running` semantics stay untouched (smoke-script
+    back-compat); the additive `healthy`/`workers` keys carry the truth."""
+    runner = _runner()
+    app = create_app(runner, auto_start=False)
+    transport = httpx.ASGITransport(app=app)
+    try:
+        await runner.start()
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            status = (await client.get("/status")).json()
+            assert status["running"] is True
+            assert status["healthy"] is True
+            assert (
+                status["workers"][WORKER_CONTROLLER_DISPATCHER]["state"]
+                == "running"
+            )
+
+            await _kill_dispatcher(runner, monkeypatch)
+
+            status = (await client.get("/status")).json()
+            assert status["running"] is True
+            assert status["healthy"] is False
+            assert (
+                status["workers"][WORKER_CONTROLLER_DISPATCHER]["state"]
+                == "failed"
+            )
+    finally:
+        await runner.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_worker_supervision.py
+++ b/tests/unit/test_runner_worker_supervision.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import asyncpg
+import pytest
+
+import pms.runner as runner_module
+from pms.config import PMSSettings, RiskSettings
+from pms.core.enums import MarketStatus, RunMode
+from pms.core.models import MarketSignal, Portfolio, TradeDecision
+from pms.factors.service import FactorService
+from pms.runner import (
+    WORKER_ACTUATOR,
+    WORKER_CONTROLLER_DISPATCHER,
+    WORKER_DECISION_EXPIRY,
+    WORKER_FACTOR_SERVICE,
+    WORKER_RUNTIME_HEARTBEAT,
+    Runner,
+)
+from pms.sensor.stream import SignalSubscription
+
+
+FIXTURE_PATH = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
+
+
+class IdleSensor:
+    def __aiter__(self) -> AsyncIterator[MarketSignal]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[MarketSignal]:
+        while True:
+            await asyncio.sleep(60.0)
+            yield _signal()
+
+
+class NullController:
+    async def decide(
+        self,
+        signal: MarketSignal,
+        portfolio: Portfolio | None = None,
+    ) -> TradeDecision | None:
+        del signal, portfolio
+        return None
+
+
+def _settings() -> PMSSettings:
+    return PMSSettings(
+        mode=RunMode.PAPER,
+        auto_migrate_default_v2=False,
+        risk=RiskSettings(
+            max_position_per_market=1000.0,
+            max_total_exposure=10_000.0,
+        ),
+    )
+
+
+def _runner() -> Runner:
+    return Runner(
+        config=_settings(),
+        historical_data_path=FIXTURE_PATH,
+        sensors=[IdleSensor()],
+        controller=cast(Any, NullController()),
+    )
+
+
+def _signal(*, market_id: str = "market-supervised") -> MarketSignal:
+    return MarketSignal(
+        market_id=market_id,
+        token_id=f"{market_id}-yes",
+        venue="polymarket",
+        title=f"Will {market_id} settle YES?",
+        yes_price=0.41,
+        volume_24h=1500.0,
+        resolves_at=datetime(2026, 6, 30, tzinfo=UTC),
+        orderbook={
+            "bids": [{"price": 0.40, "size": 100.0}],
+            "asks": [{"price": 0.41, "size": 100.0}],
+        },
+        external_signal={},
+        fetched_at=datetime(2026, 6, 10, 10, 0, tzinfo=UTC),
+        market_status=MarketStatus.OPEN.value,
+    )
+
+
+async def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float = 2.0,
+) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while not predicate():
+        if loop.time() >= deadline:
+            msg = "timed out waiting for runner worker state"
+            raise AssertionError(msg)
+        await asyncio.sleep(0.005)
+
+
+@pytest.mark.asyncio
+async def test_start_registers_all_workers_with_supervisor() -> None:
+    """Every runner-owned worker is supervised and every watch-only task
+    (sensor consume, controller pipelines) is observed, so a dead worker
+    can never again be invisible to monitoring."""
+    runner = _runner()
+    try:
+        await runner.start()
+        snapshot = runner.worker_health_snapshot()
+        for name in (
+            WORKER_CONTROLLER_DISPATCHER,
+            WORKER_ACTUATOR,
+            WORKER_FACTOR_SERVICE,
+            WORKER_DECISION_EXPIRY,
+            WORKER_RUNTIME_HEARTBEAT,
+        ):
+            assert snapshot[name].state == "running"
+        assert any(name.startswith("sensor:") for name in snapshot)
+        assert snapshot["controller-pipeline:default"].state == "running"
+    finally:
+        await runner.stop()
+
+    snapshot = runner.worker_health_snapshot()
+    assert all(
+        health.state in {"stopped", "cancelled"}
+        for health in snapshot.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_transient_restart_preserves_pipelines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A listed transient that escapes the dispatcher loop restarts the
+    dispatcher under supervision; the wrapper task stays pending, so
+    pipeline loops never observe dispatcher_done and keep running. Signal
+    routing must resume after the restart."""
+    monkeypatch.setattr(
+        runner_module,
+        "WORKER_RESTART_BACKOFF_INITIAL_S",
+        0.01,
+    )
+    runner = _runner()
+
+    routed: list[MarketSignal] = []
+    failures = 0
+
+    def flaky_remember(signal: MarketSignal) -> None:
+        nonlocal failures
+        if failures == 0:
+            failures += 1
+            msg = "transient os error"
+            raise OSError(msg)
+        routed.append(signal)
+
+    monkeypatch.setattr(
+        runner,
+        "_remember_signal_for_decision_evidence",
+        flaky_remember,
+    )
+
+    try:
+        await runner.start()
+        dispatcher_wrapper = runner.controller_task
+        assert dispatcher_wrapper is not None
+        pipeline_tasks = runner.controller_pipeline_tasks
+        assert len(pipeline_tasks) == 1
+
+        await runner.sensor_stream.queue.put(_signal())
+        await _wait_until(
+            lambda: runner.worker_health_snapshot()[
+                WORKER_CONTROLLER_DISPATCHER
+            ].restarts
+            == 1
+        )
+        await _wait_until(
+            lambda: runner.worker_health_snapshot()[
+                WORKER_CONTROLLER_DISPATCHER
+            ].state
+            == "running"
+        )
+
+        assert runner.controller_task is dispatcher_wrapper
+        assert not dispatcher_wrapper.done()
+        assert runner.controller_pipeline_tasks == pipeline_tasks
+        assert all(not task.done() for task in pipeline_tasks)
+
+        await runner.sensor_stream.queue.put(_signal())
+        await _wait_until(lambda: len(routed) >= 1)
+    finally:
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_unlisted_failure_is_loud_and_cascade_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unlisted exception keeps today's cascade semantics (wrapper task
+    completes; pipelines and actuator wind down) but the failure is now
+    recorded as `failed` instead of looking like a clean shutdown."""
+    runner = _runner()
+
+    def broken_remember(signal: MarketSignal) -> None:
+        del signal
+        msg = "unexpected bug"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(
+        runner,
+        "_remember_signal_for_decision_evidence",
+        broken_remember,
+    )
+
+    try:
+        await runner.start()
+        dispatcher_wrapper = runner.controller_task
+        assert dispatcher_wrapper is not None
+        pipeline_tasks = runner.controller_pipeline_tasks
+
+        await runner.sensor_stream.queue.put(_signal())
+        await _wait_until(lambda: dispatcher_wrapper.done())
+        assert isinstance(dispatcher_wrapper.exception(), RuntimeError)
+
+        snapshot = runner.worker_health_snapshot()
+        assert snapshot[WORKER_CONTROLLER_DISPATCHER].state == "failed"
+        assert (
+            snapshot[WORKER_CONTROLLER_DISPATCHER].last_error_class
+            == "RuntimeError"
+        )
+
+        # Cascade preserved: pipelines treat dispatcher-done as shutdown.
+        await _wait_until(
+            lambda: all(task.done() for task in pipeline_tasks)
+        )
+        actuator_wrapper = runner.actuator_task
+        assert actuator_wrapper is not None
+        await _wait_until(lambda: actuator_wrapper.done())
+        assert runner.worker_health_snapshot()[WORKER_ACTUATOR].state == "stopped"
+    finally:
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_factor_service_restart_rebuilds_instance_and_subscription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FactorService instances are single-use (_stream_exhausted): a
+    supervised restart must build a fresh instance with a fresh
+    sensor_stream.subscribe(), and close the dead subscription."""
+    monkeypatch.setattr(
+        runner_module,
+        "WORKER_RESTART_BACKOFF_INITIAL_S",
+        0.01,
+    )
+    runner = _runner()
+
+    seen: list[FactorService] = []
+
+    async def flaky_run(self: FactorService) -> None:
+        seen.append(self)
+        if len(seen) == 1:
+            msg = "transient pg error"
+            raise asyncpg.PostgresError(msg)
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(FactorService, "run", flaky_run)
+
+    try:
+        await runner.start()
+        await _wait_until(lambda: len(seen) >= 2)
+
+        assert seen[0] is not seen[1]
+        first_stream = seen[0].signal_stream
+        second_stream = seen[1].signal_stream
+        assert first_stream is not second_stream
+        assert isinstance(first_stream, SignalSubscription)
+        assert first_stream._close_requested  # noqa: SLF001
+        assert isinstance(second_stream, SignalSubscription)
+        assert not second_stream._close_requested  # noqa: SLF001
+        assert runner._factor_service is seen[1]  # noqa: SLF001
+
+        health = runner.worker_health_snapshot()[WORKER_FACTOR_SERVICE]
+        assert health.state == "running"
+        assert health.restarts == 1
+        assert health.last_error_class == "PostgresError"
+    finally:
+        await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_stop_during_dispatcher_backoff_blocks_respawn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner.stop() must block respawn before teardown: a worker sitting
+    in restart backoff exits without being restarted."""
+    monkeypatch.setattr(
+        runner_module,
+        "WORKER_RESTART_BACKOFF_INITIAL_S",
+        30.0,
+    )
+    runner = _runner()
+
+    def always_transient(signal: MarketSignal) -> None:
+        del signal
+        msg = "transient os error"
+        raise OSError(msg)
+
+    monkeypatch.setattr(
+        runner,
+        "_remember_signal_for_decision_evidence",
+        always_transient,
+    )
+
+    entries = 0
+    original_loop = runner._controller_loop  # noqa: SLF001
+
+    async def counting_loop() -> None:
+        nonlocal entries
+        entries += 1
+        await original_loop()
+
+    monkeypatch.setattr(runner, "_controller_loop", counting_loop)
+
+    await runner.start()
+    await runner.sensor_stream.queue.put(_signal())
+    await _wait_until(
+        lambda: runner.worker_health_snapshot()[
+            WORKER_CONTROLLER_DISPATCHER
+        ].state
+        == "restarting"
+    )
+
+    await asyncio.wait_for(runner.stop(), timeout=2.0)
+
+    assert entries == 1
+    snapshot = runner.worker_health_snapshot()
+    assert snapshot[WORKER_CONTROLLER_DISPATCHER].state in {
+        "stopped",
+        "cancelled",
+    }
+    assert runner.tasks == ()
+
+
+@pytest.mark.asyncio
+async def test_runner_restart_resets_supervision_state() -> None:
+    runner = _runner()
+    await runner.start()
+    await runner.stop()
+
+    await runner.start()
+    try:
+        snapshot = runner.worker_health_snapshot()
+        assert snapshot[WORKER_CONTROLLER_DISPATCHER].state == "running"
+        assert snapshot[WORKER_ACTUATOR].state == "running"
+        assert snapshot[WORKER_CONTROLLER_DISPATCHER].restarts == 0
+    finally:
+        await runner.stop()

--- a/tests/unit/test_worker_supervision.py
+++ b/tests/unit/test_worker_supervision.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+from pms.supervision import (
+    ALIVE_WORKER_STATES,
+    WorkerSpec,
+    WorkerSupervisor,
+)
+
+
+async def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float = 2.0,
+) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while not predicate():
+        if loop.time() >= deadline:
+            msg = "timed out waiting for supervised worker state"
+            raise AssertionError(msg)
+        await asyncio.sleep(0.005)
+
+
+@pytest.mark.asyncio
+async def test_clean_return_completes_wrapper_without_restart() -> None:
+    """A worker that returns cleanly must not be restarted: backtest
+    wind-down relies on wrapper completion meaning 'work is finished'."""
+    calls = 0
+
+    async def worker() -> None:
+        nonlocal calls
+        calls += 1
+
+    supervisor = WorkerSupervisor()
+    task = supervisor.spawn(
+        WorkerSpec(name="w", factory=worker, transient=(OSError,))
+    )
+
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert calls == 1
+    health = supervisor.snapshot()["w"]
+    assert health.state == "stopped"
+    assert health.restarts == 0
+    assert health.last_error_class is None
+
+
+@pytest.mark.asyncio
+async def test_listed_transient_restarts_with_exponential_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Listed transients within budget restart the worker with exponential
+    backoff; the wrapper task stays pending so downstream done()-predicates
+    never observe a restart as a shutdown."""
+    backoffs: list[float] = []
+
+    async def fake_backoff(self: WorkerSupervisor, delay_s: float) -> bool:
+        del self
+        backoffs.append(delay_s)
+        return False
+
+    monkeypatch.setattr(WorkerSupervisor, "_backoff_wait", fake_backoff)
+
+    calls = 0
+    healthy = asyncio.Event()
+
+    async def worker() -> None:
+        nonlocal calls
+        calls += 1
+        if calls <= 2:
+            raise OSError("transient")
+        healthy.set()
+        await asyncio.Event().wait()
+
+    supervisor = WorkerSupervisor()
+    task = supervisor.spawn(
+        WorkerSpec(
+            name="w",
+            factory=worker,
+            transient=(OSError,),
+            backoff_initial_s=0.5,
+            backoff_max_s=8.0,
+        )
+    )
+
+    await asyncio.wait_for(healthy.wait(), timeout=1.0)
+    await _wait_until(lambda: supervisor.snapshot()["w"].state == "running")
+
+    assert calls == 3
+    assert not task.done()
+    health = supervisor.snapshot()["w"]
+    assert health.state == "running"
+    assert health.restarts == 2
+    assert health.last_error_class == "OSError"
+    assert backoffs == [0.5, 1.0]
+
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_unlisted_exception_fails_loud_and_reraises() -> None:
+    """An unlisted exception is permanent: state `failed`, an error event is
+    published, and the wrapper re-raises so today's cascade semantics are
+    preserved — but loud."""
+    events: list[tuple[str, str]] = []
+
+    async def publish(kind: str, message: str) -> None:
+        events.append((kind, message))
+
+    async def worker() -> None:
+        msg = "not transient"
+        raise ValueError(msg)
+
+    supervisor = WorkerSupervisor(event_publisher=publish)
+    task = supervisor.spawn(
+        WorkerSpec(name="w", factory=worker, transient=(OSError,))
+    )
+
+    with pytest.raises(ValueError, match="not transient"):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    health = supervisor.snapshot()["w"]
+    assert health.state == "failed"
+    assert health.last_error_class == "ValueError"
+    assert health.state not in ALIVE_WORKER_STATES
+    assert any(kind == "error" and "w" in message for kind, message in events)
+
+
+@pytest.mark.asyncio
+async def test_restart_budget_exhausted_fails_and_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_backoff(self: WorkerSupervisor, delay_s: float) -> bool:
+        del self, delay_s
+        return False
+
+    monkeypatch.setattr(WorkerSupervisor, "_backoff_wait", fake_backoff)
+
+    events: list[tuple[str, str]] = []
+
+    async def publish(kind: str, message: str) -> None:
+        events.append((kind, message))
+
+    calls = 0
+
+    async def worker() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "always transient"
+        raise OSError(msg)
+
+    supervisor = WorkerSupervisor(event_publisher=publish)
+    task = supervisor.spawn(
+        WorkerSpec(
+            name="w",
+            factory=worker,
+            transient=(OSError,),
+            max_restarts=2,
+        )
+    )
+
+    with pytest.raises(OSError, match="always transient"):
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert calls == 3  # initial attempt + 2 restarts
+    health = supervisor.snapshot()["w"]
+    assert health.state == "failed"
+    assert health.restarts == 2
+    assert health.last_error_class == "OSError"
+    assert any(kind == "error" for kind, _ in events)
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_without_respawn() -> None:
+    calls = 0
+
+    async def worker() -> None:
+        nonlocal calls
+        calls += 1
+        await asyncio.Event().wait()
+
+    supervisor = WorkerSupervisor()
+    task = supervisor.spawn(
+        WorkerSpec(name="w", factory=worker, transient=(OSError,))
+    )
+    await _wait_until(lambda: calls == 1)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert calls == 1
+    assert supervisor.snapshot()["w"].state == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_stop_during_backoff_prevents_respawn() -> None:
+    calls = 0
+
+    async def worker() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "transient"
+        raise OSError(msg)
+
+    supervisor = WorkerSupervisor()
+    task = supervisor.spawn(
+        WorkerSpec(
+            name="w",
+            factory=worker,
+            transient=(OSError,),
+            backoff_initial_s=30.0,
+        )
+    )
+    await _wait_until(lambda: supervisor.snapshot()["w"].state == "restarting")
+
+    supervisor.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert calls == 1
+    assert supervisor.snapshot()["w"].state == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_stop_before_respawn_check_prevents_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with the backoff wait already satisfied, a stop request wins:
+    no worker may respawn during teardown."""
+
+    async def fake_backoff(self: WorkerSupervisor, delay_s: float) -> bool:
+        del delay_s
+        self.stop()
+        return True
+
+    monkeypatch.setattr(WorkerSupervisor, "_backoff_wait", fake_backoff)
+
+    calls = 0
+
+    async def worker() -> None:
+        nonlocal calls
+        calls += 1
+        msg = "transient"
+        raise OSError(msg)
+
+    supervisor = WorkerSupervisor()
+    task = supervisor.spawn(
+        WorkerSpec(name="w", factory=worker, transient=(OSError,))
+    )
+
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert calls == 1
+    assert supervisor.snapshot()["w"].state == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_first_tick_still_records_cancelled() -> None:
+    """A wrapper cancelled before its coroutine ever runs cannot execute
+    its in-coroutine transitions; the done callback must still reconcile
+    the terminal state so health never reads `running` for a dead task."""
+
+    async def worker() -> None:
+        await asyncio.Event().wait()
+
+    supervisor = WorkerSupervisor()
+    task = supervisor.spawn(
+        WorkerSpec(name="w", factory=worker, transient=(OSError,))
+    )
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    await _wait_until(lambda: supervisor.snapshot()["w"].state == "cancelled")
+
+
+@pytest.mark.asyncio
+async def test_observe_records_watch_only_outcomes() -> None:
+    """observe() tracks health without restart semantics: sensor _consume
+    tasks and pipeline tasks have their own lifecycle machinery."""
+
+    async def clean() -> None:
+        return None
+
+    async def failing() -> None:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    async def forever() -> None:
+        await asyncio.Event().wait()
+
+    supervisor = WorkerSupervisor()
+    clean_task = asyncio.create_task(clean())
+    failing_task = asyncio.create_task(failing())
+    cancelled_task = asyncio.create_task(forever())
+    supervisor.observe(clean_task, name="clean")
+    supervisor.observe(failing_task, name="failing")
+    supervisor.observe(cancelled_task, name="cancelled")
+
+    assert supervisor.snapshot()["clean"].state == "running"
+
+    cancelled_task.cancel()
+    await asyncio.gather(
+        clean_task,
+        failing_task,
+        cancelled_task,
+        return_exceptions=True,
+    )
+    await _wait_until(
+        lambda: supervisor.snapshot()["cancelled"].state == "cancelled"
+    )
+
+    snapshot = supervisor.snapshot()
+    assert snapshot["clean"].state == "stopped"
+    assert snapshot["failing"].state == "failed"
+    assert snapshot["failing"].last_error_class == "RuntimeError"
+    assert snapshot["cancelled"].state == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_component_payload_is_json_shaped() -> None:
+    async def worker() -> None:
+        return None
+
+    supervisor = WorkerSupervisor()
+    task = supervisor.spawn(
+        WorkerSpec(name="w", factory=worker, transient=(OSError,))
+    )
+    await asyncio.wait_for(task, timeout=1.0)
+
+    payload = supervisor.component_payload()
+    assert payload == {
+        "w": {
+            "state": "stopped",
+            "restarts": 0,
+            "last_error_class": None,
+        }
+    }


### PR DESCRIPTION
## Summary

PR-B of the worker-supervision plan (stacked on #85; GitHub will retarget to main when #85 merges). Implements Option 2 of the supervision design: a thin `WorkerSupervisor` (restart + backoff + permanent-failure escalation) plus per-worker liveness surfaced in `runtime_heartbeats` / `/readiness` / `/status` — ending the "monitoring stays green while trading is dead" failure mode confirmed in the 2026-06-10 lifecycle audit.

- **`src/pms/supervision.py`** (new): `WorkerSpec`/`WorkerHealth` (frozen), `WorkerSupervisor` — restart only on listed transients (`asyncpg.PostgresError`, `OSError`, `TimeoutError`) within 5-per-600s budget, exponential backoff 1s→60s; clean return → no restart; `CancelledError` propagates; unlisted/budget-exhausted → `failed`, re-raised (cascade preserved, now loud).
- **Runner**: dispatcher/actuator/factor-service/decision-expiry/heartbeat spawned under supervision (wrapper tasks keep feeding `self._*_task`, so `_should_stop_*`/`wait_until_idle` semantics are byte-compatible); sensor-stream + pipeline tasks observed watch-only; factor-service restarts rebuild the instance **and close the dead subscription** before re-subscribing.
- **Monitoring**: heartbeat `running` now additionally requires dispatcher+actuator(+factor when PG) alive — dead-worker periods finally count as unhealthy in `paper_report` continuity (this is the intended behavior change); `/readiness` 503s naming dead required workers; `/status` adds additive `workers` + `healthy`, `running` untouched (smoke-script back-compat, pinned by test).

## Verification

- TDD throughout (every group watched red first): **+21 tests** covering all four wrapper exit paths, stop-during-backoff, dispatcher-restart-preserves-pipelines, factor-service rebuild, readiness fail-closed, status back-compat
- `uv run pytest -q` → **2678 passed, 0 failed**; `mypy --strict` clean; `lint-imports` 9 contracts kept
- PG-backed: heartbeat-store integration suite 6 passed; design's integration subset 14 passed

## Reviewer follow-ups (adversarial review verdict: approve, 0 blockers)

Filed as acknowledged follow-ups, not in this PR: restart-window-expiry boundary test; stricter latch-ordering test for stop-during-backoff; pruning of watch-only health entries on pipeline detach; pruning closed `SignalSubscription`s in `SensorStream` across factor-service restarts (slow-flapping-DB soak could accumulate dead subscriptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)