### PR TITLE
fix(controller): stop double-charging spread for ask-frame decisions

### DIFF
--- a/scripts/paper_report.py
+++ b/scripts/paper_report.py
@@ -1575,14 +1575,10 @@ def _trade_costs_from_decision_rows(
 ) -> tuple[TradeCostBreakdown, ...]:
     costs: list[TradeCostBreakdown] = []
     for row in _entry_decision_rows(decisions):
-        spread_bps = _optional_float_from_mapping(row, "spread_bps_at_decision")
+        spread_cost = _spread_cost_for_decision(row)
         gross_edge = _decision_edge(row)
-        if spread_bps is None or gross_edge is None:
+        if spread_cost is None or gross_edge is None:
             continue
-        spread_cost = _price_space_cost(
-            bps=spread_bps,
-            price=_decision_price(row),
-        )
         evidence_obj = row.get("decision_evidence")
         evidence: Mapping[str, object] = (
             evidence_obj if isinstance(evidence_obj, Mapping) else {}
@@ -3350,7 +3346,19 @@ def _spread_cost_for_decision(row: Mapping[str, object]) -> float | None:
     spread_bps = _optional_float_from_mapping(row, "spread_bps_at_decision")
     if spread_bps is None:
         return None
+    if _spread_already_in_price(row):
+        # Ask-frame decisions persist spread_already_in_price=True because
+        # expected_edge = p - ask already pays the spread; re-deriving it
+        # from raw spread_bps here would double-charge the gate input.
+        return 0.0
     return _price_space_cost(bps=spread_bps, price=_decision_price(row))
+
+
+def _spread_already_in_price(row: Mapping[str, object]) -> bool:
+    evidence = row.get("decision_evidence")
+    if not isinstance(evidence, Mapping):
+        return False
+    return evidence.get("spread_already_in_price") is True
 
 
 def _average_slippage_cost_bps(

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -729,6 +729,16 @@ class ControllerPipeline:
                 emitted_count=0,
             )
             return None
+        # When decision_price is the executable best ask, decision_edge is
+        # already net of crossing the spread; charging spread_bps again would
+        # double-count it. The price-equality check (not metadata alone)
+        # covers the best_ask strategies whose pricing fell back to
+        # yes_price because no ask existed — there the spread is a real cost.
+        spread_already_in_price = (
+            _strategy_metadata(self.strategy).get("price_reference")
+            == "best_ask"
+            and decision_price == best_ask(execution_signal)
+        )
         decision_costs = _decision_cost_edges(
             decision_price=decision_price,
             spread_bps=decision_spread_bps,
@@ -737,6 +747,7 @@ class ControllerPipeline:
                 execution_signal.external_signal,
                 fallback_rate=self.settings.strategies.flb_fee_rate,
             ),
+            spread_already_in_price=spread_already_in_price,
         )
         net_edge_after_costs = decision_edge - decision_costs.total_edge
         if net_edge_after_costs <= 0.0:
@@ -751,6 +762,7 @@ class ControllerPipeline:
                     "gross_edge": decision_edge,
                     "spread_bps_at_decision": decision_spread_bps,
                     "spread_edge": decision_costs.spread_edge,
+                    "spread_already_in_price": spread_already_in_price,
                     "fee_rate": decision_costs.fee_rate,
                     "fee_edge": decision_costs.fee_edge,
                     "max_slippage_bps": self.settings.controller.max_slippage_bps,
@@ -981,6 +993,7 @@ class ControllerPipeline:
                 "gross_edge": decision_edge,
                 "spread_bps_at_decision": decision_spread_bps,
                 "spread_edge": decision_costs.spread_edge,
+                "spread_already_in_price": spread_already_in_price,
                 "fee_rate": decision_costs.fee_rate,
                 "fee_edge": decision_costs.fee_edge,
                 "max_slippage_bps": self.settings.controller.max_slippage_bps,
@@ -1247,6 +1260,7 @@ def _decision_cost_edges(
     spread_bps: int | None,
     settings: PMSSettings,
     fee_rate: float | None = None,
+    spread_already_in_price: bool = False,
 ) -> _DecisionCostEdges:
     price = Decimal(str(decision_price))
     effective_fee_rate = (
@@ -1259,7 +1273,7 @@ def _decision_cost_edges(
     ) * price
     spread_edge = (
         Decimal("0")
-        if spread_bps is None
+        if spread_bps is None or spread_already_in_price
         else (Decimal(spread_bps) / Decimal("10000")) * price
     )
     return _DecisionCostEdges(

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -42,6 +42,7 @@ from pms.actuator.exit_monitor import (
 from pms.actuator.feedback import ActuatorFeedback
 from pms.actuator.risk import RiskManager
 from pms.config import PMSSettings, validate_live_mode_ready
+from pms.controller._price_utils import best_ask
 from pms.controller.baselines import (
     CategoryPriorBaselineEstimator,
     enrich_signal_with_category_prior,
@@ -1372,6 +1373,34 @@ class Runner:
             finally:
                 self.sensor_stream.queue.task_done()
 
+    def _decision_uses_ask_pricing(
+        self,
+        decision: TradeDecision,
+        evidence_signal: MarketSignal,
+    ) -> bool:
+        """True when the decision's limit price is the executable best ask of
+        a price_reference=best_ask strategy — the frame where the spread is
+        already inside expected_edge and must not be charged again in the
+        persisted cost evidence (mirrors the pipeline's net-edge gate)."""
+        runtime = self._controller_runtimes.get(decision.strategy_id)
+        if runtime is None:
+            return False
+        strategy = getattr(runtime.controller, "strategy", None)
+        config = getattr(strategy, "config", None)
+        metadata = getattr(config, "metadata", None)
+        if metadata is None:
+            return False
+        try:
+            price_reference = dict(metadata).get("price_reference")
+        except (TypeError, ValueError):
+            return False
+        if price_reference != "best_ask":
+            return False
+        executable_ask = best_ask(evidence_signal)
+        return executable_ask is not None and (
+            decision.limit_price == executable_ask
+        )
+
     async def _controller_pipeline_loop(self, strategy_id: str) -> None:
         runtime = self._controller_runtimes[strategy_id]
         queue = self._controller_signal_queues[strategy_id]
@@ -1461,6 +1490,12 @@ class Runner:
                             factor_snapshot_hash=factor_snapshot_hash,
                             quote_source=self.config.controller.quote_source,
                             decision_created_at=created_at,
+                            spread_already_in_price=(
+                                self._decision_uses_ask_pricing(
+                                    decision,
+                                    decision_signal,
+                                )
+                            ),
                         )
                         await self.decision_store.insert(
                             decision,
@@ -1628,6 +1663,12 @@ class Runner:
                             factor_snapshot_hash=None,
                             quote_source=self.config.controller.quote_source,
                             decision_created_at=signal.fetched_at,
+                            spread_already_in_price=(
+                                self._decision_uses_ask_pricing(
+                                    decision,
+                                    evidence_signal,
+                                )
+                            ),
                         )
                     self._evaluator_spool.enqueue(
                         fill,
@@ -3943,6 +3984,7 @@ def _decision_evidence_from_signal(
     factor_snapshot_hash: str | None,
     quote_source: str,
     decision_created_at: datetime,
+    spread_already_in_price: bool = False,
 ) -> dict[str, object]:
     book_top_levels = _top_orderbook_levels(signal.orderbook)
     book_token_outcome = _book_token_outcome(signal, decision)
@@ -4004,7 +4046,11 @@ def _decision_evidence_from_signal(
         ),
         "factor_snapshot_hash": factor_snapshot_hash,
         "spread_bps_at_decision": decision.spread_bps_at_decision,
-        **_decision_cost_evidence(signal, decision),
+        **_decision_cost_evidence(
+            signal,
+            decision,
+            spread_already_in_price=spread_already_in_price,
+        ),
         "external_signal_keys": sorted(str(key) for key in signal.external_signal),
     }
 
@@ -4012,6 +4058,8 @@ def _decision_evidence_from_signal(
 def _decision_cost_evidence(
     signal: MarketSignal,
     decision: TradeDecision,
+    *,
+    spread_already_in_price: bool = False,
 ) -> dict[str, float]:
     price = Decimal(str(decision.limit_price))
     if not price.is_finite() or price < 0:
@@ -4033,8 +4081,17 @@ def _decision_cost_evidence(
 
     spread_bps = _optional_float(decision.spread_bps_at_decision)
     if spread_bps is not None and spread_bps >= 0.0:
-        spread_edge = (Decimal(str(spread_bps)) / Decimal("10000")) * price
+        # Ask-frame decisions already paid the spread inside expected_edge;
+        # keep the key present (the h1_flb smoke check requires it) but
+        # charge zero so net_edge_after_costs matches the gate arithmetic.
+        spread_edge = (
+            Decimal("0")
+            if spread_already_in_price
+            else (Decimal(str(spread_bps)) / Decimal("10000")) * price
+        )
         evidence["spread_edge_at_decision"] = float(spread_edge)
+        if spread_already_in_price:
+            evidence["spread_already_in_price"] = True
         total_cost_edge += spread_edge
         has_cost_evidence = True
 

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -4060,12 +4060,12 @@ def _decision_cost_evidence(
     decision: TradeDecision,
     *,
     spread_already_in_price: bool = False,
-) -> dict[str, float]:
+) -> dict[str, float | bool]:
     price = Decimal(str(decision.limit_price))
     if not price.is_finite() or price < 0:
         return {}
 
-    evidence: dict[str, float] = {}
+    evidence: dict[str, float | bool] = {}
     total_cost_edge = Decimal("0")
     has_cost_evidence = False
 
@@ -4080,18 +4080,18 @@ def _decision_cost_evidence(
         has_cost_evidence = True
 
     spread_bps = _optional_float(decision.spread_bps_at_decision)
-    if spread_bps is not None and spread_bps >= 0.0:
+    if spread_already_in_price:
         # Ask-frame decisions already paid the spread inside expected_edge;
         # keep the key present (the h1_flb smoke check requires it) but
         # charge zero so net_edge_after_costs matches the gate arithmetic.
-        spread_edge = (
-            Decimal("0")
-            if spread_already_in_price
-            else (Decimal(str(spread_bps)) / Decimal("10000")) * price
-        )
+        spread_edge = Decimal("0")
         evidence["spread_edge_at_decision"] = float(spread_edge)
-        if spread_already_in_price:
-            evidence["spread_already_in_price"] = True
+        evidence["spread_already_in_price"] = True
+        total_cost_edge += spread_edge
+        has_cost_evidence = True
+    elif spread_bps is not None and spread_bps >= 0.0:
+        spread_edge = (Decimal(str(spread_bps)) / Decimal("10000")) * price
+        evidence["spread_edge_at_decision"] = float(spread_edge)
         total_cost_edge += spread_edge
         has_cost_evidence = True
 

--- a/tests/unit/test_controller_cp02.py
+++ b/tests/unit/test_controller_cp02.py
@@ -1581,6 +1581,19 @@ class _SmallGrossEdgeForecaster:
         return 0.43
 
 
+class _ModestEdgeForecaster:
+    """Against a 0.403 entry price the 0.047 gross edge clears fee+slippage
+    (0.043805) but not a second spread charge (+0.006045 at 150 bps)."""
+
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return (0.45, 0.9, "modest edge")
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        del signal
+        return 0.45
+
+
 @pytest.mark.asyncio
 async def test_on_signal_emits_diagnostic_when_decision_edge_not_positive() -> None:
     pipeline = ControllerPipeline(
@@ -1649,6 +1662,190 @@ def test_decision_cost_edges_convert_bps_to_price_space() -> None:
 
     assert costs.slippage_edge == pytest.approx(0.002)
     assert costs.spread_edge == pytest.approx(0.02)
+
+
+def test_decision_cost_edges_suppress_spread_when_already_in_price() -> None:
+    costs = _decision_cost_edges(
+        decision_price=0.40,
+        spread_bps=500,
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(max_slippage_bps=50),
+        ),
+        spread_already_in_price=True,
+    )
+
+    assert costs.spread_edge == 0.0
+    assert costs.slippage_edge == pytest.approx(0.002)
+    assert costs.total_edge == pytest.approx(costs.fee_edge + 0.002)
+
+
+@pytest.mark.asyncio
+async def test_best_ask_decision_does_not_double_charge_spread() -> None:
+    """best_ask frame: decision_price IS the executable ask, so the gross
+    edge p - ask is already net of crossing the spread. Charging spread_bps
+    again double-counts it and rejects a profitable decision."""
+    pipeline = ControllerPipeline(
+        strategy=_best_ask_strategy(),
+        forecasters=[_ModestEdgeForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0, max_spread_bps=1_000.0)),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(
+                min_volume=100.0,
+                max_spread_bps=1_000.0,
+                max_slippage_bps=50,
+            ),
+        ),
+    )
+    signal = replace(
+        _signal(),
+        orderbook={
+            "bids": [{"price": "0.397", "size": "100"}],
+            "asks": [{"price": "0.403", "size": "100"}],
+        },
+    )
+
+    emission = await pipeline.on_signal(signal, portfolio=_portfolio())
+
+    assert emission is not None
+    opportunity, decision = emission
+    assert decision.limit_price == pytest.approx(0.403)
+    trace = opportunity.composition_trace
+    assert trace["spread_bps_at_decision"] == 150
+    assert trace["spread_edge"] == 0.0
+    assert trace["spread_already_in_price"] is True
+    # net edge = gross - fee - slippage only; the spread is inside the gross.
+    assert trace["net_edge_after_costs"] == pytest.approx(
+        (0.45 - 0.403) - 0.07 * (1.0 - 0.403) - 0.005 * 0.403
+    )
+
+
+@pytest.mark.asyncio
+async def test_yes_price_decision_still_charges_spread_on_identical_book() -> None:
+    """yes_price frame control: with no price_reference metadata the decision
+    price is the mid/last-trade reference, the executable ask is unknown, and
+    the full spread stays a real worst-case entry cost."""
+    pipeline = ControllerPipeline(
+        strategy_id="alpha",
+        strategy_version_id="alpha-v1",
+        forecasters=[_ModestEdgeForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0, max_spread_bps=1_000.0)),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(
+                min_volume=100.0,
+                max_spread_bps=1_000.0,
+                max_slippage_bps=50,
+            ),
+        ),
+    )
+    signal = replace(
+        _signal(),
+        yes_price=0.403,
+        orderbook={
+            "bids": [{"price": "0.397", "size": "100"}],
+            "asks": [{"price": "0.403", "size": "100"}],
+        },
+    )
+
+    emission = await pipeline.on_signal(signal, portfolio=_portfolio())
+
+    assert emission is None
+    diagnostic = pipeline.last_diagnostic
+    assert diagnostic is not None
+    assert diagnostic.code == "decision_net_edge_not_positive"
+    assert diagnostic.metadata["spread_edge"] == pytest.approx(0.015 * 0.403)
+    assert diagnostic.metadata["spread_already_in_price"] is False
+    assert diagnostic.metadata["net_edge_after_costs"] < 0.0
+
+
+@pytest.mark.asyncio
+async def test_no_side_direct_book_decision_does_not_charge_spread() -> None:
+    """NO-side best_ask frame: the direct outcome book provides the
+    executable NO ask, so the spread is already inside p_no - ask_no."""
+    pipeline = ControllerPipeline(
+        strategy=_best_ask_strategy(),
+        forecasters=[BearishForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0, max_spread_bps=1_000.0)),
+        outcome_token_resolver=StaticOutcomeTokenResolver(),
+        direct_book_reader=StaticDirectBookReader(
+            token_id="token-no",
+            bids=[(0.40, 1_000.0)],
+            asks=[(0.41, 1_000.0)],
+        ),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(max_spread_bps=1_000.0),
+        ),
+    )
+    signal = replace(
+        _signal(),
+        token_id="token-yes",
+        yes_price=0.585,
+        external_signal={
+            **_signal().external_signal,
+            "yes_token_id": "token-yes",
+            "no_token_id": "token-no",
+        },
+        orderbook={
+            "bids": [{"price": 0.58, "size": 1_000.0}],
+            "asks": [{"price": 0.59, "size": 1_000.0}],
+        },
+    )
+
+    emission = await pipeline.on_signal(signal, portfolio=_portfolio())
+
+    assert emission is not None
+    opportunity, decision = emission
+    assert decision.outcome == "NO"
+    assert decision.limit_price == pytest.approx(0.41)
+    trace = opportunity.composition_trace
+    assert trace["spread_bps_at_decision"] == 247
+    assert trace["spread_edge"] == 0.0
+    assert trace["spread_already_in_price"] is True
+
+
+@pytest.mark.asyncio
+async def test_best_ask_strategy_without_ask_still_charges_external_spread() -> None:
+    """Fallback hole: a best_ask strategy whose signal has no executable ask
+    anywhere falls back to yes_price pricing, so external spread_bps remains
+    a real entry cost (the price-equality half of the suppression condition)."""
+    pipeline = ControllerPipeline(
+        strategy=_best_ask_strategy(),
+        forecasters=[StaticForecaster()],
+        calibrator=NetcalCalibrator(),
+        sizer=KellySizer(risk=RiskSettings(max_position_per_market=500.0)),
+        router=Router(ControllerSettings(min_volume=100.0, max_spread_bps=1_000.0)),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(
+                min_volume=100.0,
+                max_spread_bps=1_000.0,
+                max_slippage_bps=50,
+            ),
+        ),
+    )
+    signal = replace(
+        _signal(),
+        external_signal={**_signal().external_signal, "spread_bps": 50},
+    )
+
+    emission = await pipeline.on_signal(signal, portfolio=_portfolio())
+
+    assert emission is not None
+    opportunity, decision = emission
+    assert decision.limit_price == pytest.approx(0.4)
+    trace = opportunity.composition_trace
+    assert trace["spread_bps_at_decision"] == 50
+    assert trace["spread_edge"] == pytest.approx(0.005 * 0.4)
+    assert trace["spread_already_in_price"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_controller_runtime_selection_contract_cp01.py
+++ b/tests/unit/test_controller_runtime_selection_contract_cp01.py
@@ -213,7 +213,10 @@ async def test_controller_pipeline_uses_strategy_factor_composition_not_forecast
         "traded_edge": pytest.approx(0.32),
         "gross_edge": pytest.approx(0.32),
         "spread_bps_at_decision": 500,
+        # yes_price frame (no price_reference metadata): the executable ask is
+        # unknown, so the full spread stays a charged entry cost.
         "spread_edge": pytest.approx(0.02),
+        "spread_already_in_price": False,
         "fee_rate": pytest.approx(0.07),
         "fee_edge": pytest.approx(0.042),
         "max_slippage_bps": 50,

--- a/tests/unit/test_paper_report.py
+++ b/tests/unit/test_paper_report.py
@@ -1459,6 +1459,123 @@ def test_report_net_edge_gate_excludes_position_exit_decisions() -> None:
     )
 
 
+def test_report_net_edge_gate_honors_spread_already_in_price_evidence() -> None:
+    """Ask-frame decisions persist spread_already_in_price=True because
+    expected_edge = p - ask already pays the spread; the go/no-go gate input
+    must not subtract a re-derived spread cost a second time."""
+    metrics = metrics_from_api_payloads(
+        report_date=date(2026, 5, 30),
+        status={
+            "mode": "paper",
+            "runner_started_at": "2026-05-30T00:00:00+00:00",
+            "runtime_continuity": _runtime_continuity_status(),
+            "controller": {
+                "decisions_total": 1,
+                "diagnostics_total": 0,
+                "diagnostic_counts": {},
+            },
+            "actuator": {"fills_total": 1},
+            "evaluator": {},
+            "supervision": {"unresolved_feedback_total": 0},
+        },
+        metrics={
+            "slippage_bps": 0.0,
+            "pnl_series": _pnl_series(date(2026, 5, 30)),
+        },
+        decisions=[
+            {
+                "decision_id": "entry-ask-1",
+                "market_id": "m-1",
+                "prob_estimate": 0.55,
+                "limit_price": 0.50,
+                "expected_edge": 0.05,
+                "spread_bps_at_decision": 50,
+                "created_at": "2026-05-30T00:00:00+00:00",
+                "decision_evidence": {
+                    "spread_already_in_price": True,
+                    "spread_edge_at_decision": 0.0,
+                    "fee_edge_at_decision": 0.0035,
+                    "slippage_edge_at_decision": 0.0025,
+                    "net_edge_after_costs": 0.044,
+                },
+            },
+        ],
+        trades={
+            "trades": [
+                {
+                    "decision_id": "entry-ask-1",
+                    "fill_notional_usdc": 10.0,
+                    "fees": 0.10,
+                    "filled_at": "2026-05-30T00:00:00+00:00",
+                },
+            ],
+        },
+        positions={"positions": []},
+    )
+
+    gate = evaluate_paper_soak_gate(
+        metrics,
+        risk=RiskSettings(max_total_exposure=50.0),
+    )
+
+    # 500 bps gross - 0 spread (already inside the ask frame) - 0 slippage
+    # - 50 bps fee; the unfixed re-derivation charged 25 bps spread again.
+    assert metrics.average_edge_bps == pytest.approx(500.0)
+    assert metrics.average_net_edge_bps == pytest.approx(450.0)
+    assert (
+        gate.require_check("average_net_edge_bps").detail == "450.0000 > 0.0000"
+    )
+
+
+def test_trade_cost_breakdown_honors_spread_already_in_price_evidence() -> None:
+    """Breakdown rows for flagged decisions must stay internally consistent:
+    net_edge == gross_edge - spread_cost - fee_cost - slippage_cost."""
+    metrics = metrics_from_api_payloads(
+        report_date=date(2026, 5, 5),
+        status={
+            "mode": "paper",
+            "runner_started_at": "2026-05-03T00:00:00+00:00",
+            "sensors": [],
+            "controller": {"decisions_total": 1, "diagnostic_counts": {}},
+            "actuator": {"fills_total": 1},
+            "evaluator": {},
+            "quality": {},
+        },
+        decisions=[
+            {
+                "decision_id": "d-ask-frame",
+                "market_id": "m-ask-frame",
+                "prob_estimate": 0.55,
+                "limit_price": 0.50,
+                "expected_edge": 0.05,
+                "spread_bps_at_decision": 50,
+                "created_at": "2026-05-05T00:00:00+00:00",
+                "decision_evidence": {
+                    "spread_already_in_price": True,
+                    "spread_edge_at_decision": 0.0,
+                    "fee_edge_at_decision": 0.0035,
+                    "slippage_edge_at_decision": 0.0025,
+                    "net_edge_after_costs": 0.044,
+                },
+            }
+        ],
+        trades={"trades": []},
+        positions={"positions": []},
+    )
+
+    assert metrics.trade_costs == (
+        TradeCostBreakdown(
+            decision_id="d-ask-frame",
+            market_id="m-ask-frame",
+            gross_edge=0.05,
+            spread_cost=0.0,
+            fee_cost=0.0035,
+            slippage_cost=0.0025,
+            net_edge=0.044,
+        ),
+    )
+
+
 def test_metrics_from_api_payloads_flags_active_actuator_halt() -> None:
     metrics = metrics_from_api_payloads(
         report_date=date(2026, 5, 5),

--- a/tests/unit/test_runner_decision_persistence_cp07.py
+++ b/tests/unit/test_runner_decision_persistence_cp07.py
@@ -858,6 +858,40 @@ def test_decision_evidence_excludes_spread_when_already_in_price() -> None:
     assert evidence["net_edge_after_costs"] == pytest.approx(0.19025)
 
 
+def test_decision_evidence_records_ask_frame_without_spread_bps() -> None:
+    signal = replace(
+        _signal(),
+        external_signal={
+            "resolved_outcome": 1.0,
+            "book_age_ms": 75.0,
+            "fee_rate_bps": 300.0,
+        },
+    )
+    decision = replace(
+        _decision(),
+        expected_edge=0.21,
+        limit_price=0.41,
+        max_slippage_bps=50,
+        spread_bps_at_decision=None,
+    )
+
+    evidence = _decision_evidence_from_signal(
+        signal,
+        decision=decision,
+        factor_snapshot_hash="snapshot-cp07",
+        quote_source="postgres_snapshot",
+        decision_created_at=signal.fetched_at,
+        spread_already_in_price=True,
+    )
+
+    assert evidence["spread_edge_at_decision"] == 0.0
+    assert evidence["spread_already_in_price"] is True
+    assert evidence["fee_edge_at_decision"] == pytest.approx(0.0177)
+    assert evidence["slippage_edge_at_decision"] == pytest.approx(0.00205)
+    assert evidence["total_cost_edge_at_decision"] == pytest.approx(0.01975)
+    assert evidence["net_edge_after_costs"] == pytest.approx(0.19025)
+
+
 def test_decision_evidence_projects_direct_no_book_baselines_to_yes_probability() -> None:
     signal = replace(
         _signal(),

--- a/tests/unit/test_runner_decision_persistence_cp07.py
+++ b/tests/unit/test_runner_decision_persistence_cp07.py
@@ -27,6 +27,14 @@ from pms.runner import (
     _decision_evidence_signal_for_decision,
     _decision_expires_at,
 )
+from pms.strategies.projections import (
+    ActiveStrategy,
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
 
 
 FIXTURE_PATH = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
@@ -812,6 +820,44 @@ def test_decision_evidence_records_cost_basis_at_decision_time() -> None:
     assert evidence["net_edge_after_costs"] == pytest.approx(0.18697)
 
 
+def test_decision_evidence_excludes_spread_when_already_in_price() -> None:
+    """Ask-frame sibling of the cost-basis test: when the decision price is
+    the executable ask, the spread is already inside expected_edge and must
+    not be charged again — but the spread_edge_at_decision key stays present
+    (value 0.0) for the h1_flb smoke check."""
+    signal = replace(
+        _signal(),
+        external_signal={
+            "resolved_outcome": 1.0,
+            "book_age_ms": 75.0,
+            "fee_rate_bps": 300.0,
+        },
+    )
+    decision = replace(
+        _decision(),
+        expected_edge=0.21,
+        limit_price=0.41,
+        max_slippage_bps=50,
+        spread_bps_at_decision=80,
+    )
+
+    evidence = _decision_evidence_from_signal(
+        signal,
+        decision=decision,
+        factor_snapshot_hash="snapshot-cp07",
+        quote_source="postgres_snapshot",
+        decision_created_at=signal.fetched_at,
+        spread_already_in_price=True,
+    )
+
+    assert evidence["spread_edge_at_decision"] == 0.0
+    assert evidence["spread_already_in_price"] is True
+    assert evidence["fee_edge_at_decision"] == pytest.approx(0.0177)
+    assert evidence["slippage_edge_at_decision"] == pytest.approx(0.00205)
+    assert evidence["total_cost_edge_at_decision"] == pytest.approx(0.01975)
+    assert evidence["net_edge_after_costs"] == pytest.approx(0.19025)
+
+
 def test_decision_evidence_projects_direct_no_book_baselines_to_yes_probability() -> None:
     signal = replace(
         _signal(),
@@ -853,3 +899,81 @@ def test_decision_evidence_projects_direct_no_book_baselines_to_yes_probability(
     )
     assert evidence["mid_quote_baseline_prob_estimate"] == pytest.approx(0.41)
     assert evidence["last_trade_baseline_prob_estimate"] == pytest.approx(0.43)
+
+
+def _active_strategy_with_metadata(
+    metadata: tuple[tuple[str, str], ...],
+) -> ActiveStrategy:
+    return ActiveStrategy(
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        config=StrategyConfig(
+            strategy_id="default",
+            factor_composition=(),
+            metadata=metadata,
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=500.0,
+            max_daily_drawdown_pct=2.5,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl")),
+        forecaster=ForecasterSpec(forecasters=(("rules", ()),)),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=7,
+            volume_min_usdc=100.0,
+        ),
+    )
+
+
+class _ControllerWithStrategy:
+    def __init__(self, strategy: ActiveStrategy) -> None:
+        self.strategy = strategy
+
+    async def decide(
+        self,
+        signal: MarketSignal,
+        portfolio: Portfolio | None = None,
+    ) -> TradeDecision | None:
+        del signal, portfolio
+        return None
+
+
+def _runner_with_runtime_strategy(
+    metadata: tuple[tuple[str, str], ...],
+) -> Runner:
+    runner = _runner()
+    runner._controller_runtimes["default"] = StrategyControllerRuntime(  # noqa: SLF001
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        controller=cast(Any, _ControllerWithStrategy(
+            _active_strategy_with_metadata(metadata)
+        )),
+        asset_ids=None,
+    )
+    return runner
+
+
+def test_decision_uses_ask_pricing_requires_ask_frame_and_matching_price() -> None:
+    runner = _runner_with_runtime_strategy((("price_reference", "best_ask"),))
+    signal = _signal()  # best executable ask = 0.42
+    ask_priced = replace(_decision(), limit_price=0.42)
+    mid_priced = replace(_decision(), limit_price=0.41)
+
+    assert runner._decision_uses_ask_pricing(ask_priced, signal) is True  # noqa: SLF001
+    assert runner._decision_uses_ask_pricing(mid_priced, signal) is False  # noqa: SLF001
+
+
+def test_decision_uses_ask_pricing_is_false_without_best_ask_metadata() -> None:
+    runner = _runner_with_runtime_strategy((("owner", "test"),))
+    ask_priced = replace(_decision(), limit_price=0.42)
+
+    assert runner._decision_uses_ask_pricing(ask_priced, _signal()) is False  # noqa: SLF001
+
+
+def test_decision_uses_ask_pricing_is_false_for_unknown_strategy() -> None:
+    runner = _runner()
+    ask_priced = replace(_decision(), limit_price=0.42)
+
+    assert runner._decision_uses_ask_pricing(ask_priced, _signal()) is False  # noqa: SLF001


### PR DESCRIPTION
## Summary

Audit finding (high, adversarially verified): `_decision_cost_edges` subtracted the full mid-relative spread as an entry cost even when the decision price is already the executable best ask — every shipped strategy uses `price_reference=best_ask`, so the net-edge gate required `p − ask > spread + fee + slippage`, double-charging the spread and suppressing thin-but-real edges (58/216 net-edge rejections in the 2026-06-10 soak window).

Three atomic commits, TDD:
1. `fix(controller)`: spread edge charged only when the pricing frame does NOT already pay it (keyed on the same `price_reference` evidence the pipeline reads); mid/yes-price frames unchanged.
2. `fix(controller)`: decision cost evidence persists the pricing frame so downstream consumers can tell which frame applied.
3. `fix(report)`: `paper_report`'s GO gate (`average_net_edge_bps`) honors the persisted ask-frame evidence instead of unconditionally re-deriving spread cost — without this the gate metric kept the double-charge (caught by the adversarial review).

## Coordination note

Lands independently of `feat/resolution-ingestion` / `feat/calibration-feedback`; merge order free.

## Verification

TDD per pricing frame; full pytest 0 failed; mypy strict clean; lint-imports clean. Design doc: 2026-06-10 economics design (Design 1) with refutation-tested root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed trade-cost calculations to prevent incorrect double-charging of spread costs when spread is already factored into decision pricing, improving accuracy of cost breakdowns and net edge reporting.

* **Tests**
  * Added test coverage validating proper spread-cost handling across various pricing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->