### PR TITLE
feat(controller): wire evaluator calibration feedback into controller runtimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ markers = [
     "slow: marks tests as slow / integration (deselect with '-m \"not slow\"')",
     "integration: real-network/real-subprocess integration tests (deselect with '-m \"not integration\"')",
     "real_fill_store: opt out of the conftest FillStore.read_positions stub (used by tests that exercise the real implementation directly)",
+    "real_eval_store: opt out of the conftest EvalStore.all_for_strategy stub (used by tests that exercise the real implementation directly)",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/pms/controller/calibrators/netcal.py
+++ b/src/pms/controller/calibrators/netcal.py
@@ -9,9 +9,16 @@ from pms.core.models import EvalRecord
 class NetcalCalibrator:
     min_samples: int = 100
     _samples: dict[str, list[EvalRecord]] = field(default_factory=dict)
+    _ingested_decision_ids: dict[str, set[str]] = field(default_factory=dict)
 
     def add_samples(self, model_id: str, records: list[EvalRecord]) -> None:
-        self._samples.setdefault(model_id, []).extend(records)
+        samples = self._samples.setdefault(model_id, [])
+        ingested = self._ingested_decision_ids.setdefault(model_id, set())
+        for record in records:
+            if record.decision_id in ingested:
+                continue
+            ingested.add(record.decision_id)
+            samples.append(record)
 
     def sample_count(self, model_id: str) -> int:
         return len(self._samples.get(model_id, []))

--- a/src/pms/controller/pipeline.py
+++ b/src/pms/controller/pipeline.py
@@ -1203,7 +1203,10 @@ def _resolved_sample_count(calibrator: ICalibrator, model_ids: Sequence[str]) ->
     sample_count = getattr(calibrator, "sample_count", None)
     if not callable(sample_count) or not model_ids:
         return 0
-    return max(int(sample_count(model_id)) for model_id in model_ids)
+    # EvalRecords are keyed by the decision-level model id ("ensemble" for
+    # multi-forecaster strategies), so the unlock counter must read the same
+    # bucket — not the per-forecaster ids.
+    return int(sample_count(_decision_model_id(model_ids) or "unknown"))
 
 
 def _log_pipeline_funnel(

--- a/src/pms/evaluation/spool.py
+++ b/src/pms/evaluation/spool.py
@@ -10,7 +10,7 @@ from math import isfinite
 from typing import Protocol, cast
 
 from pms.core.models import BookSummary
-from pms.core.models import FillRecord, TradeDecision
+from pms.core.models import EvalRecord, FillRecord, TradeDecision
 from pms.evaluation.adapters.scoring import Scorer
 from pms.evaluation.feedback import EvaluatorFeedback
 from pms.evaluation.metrics import StrategyMetricsSnapshot, StrategyVersionKey
@@ -51,6 +51,7 @@ class EvalSpool:
     quote_reader: QuoteReader | None = None
     quote_scorer: QuoteScorer = field(default_factory=QuoteScorer)
     quote_lag_seconds: int = 0
+    calibration_sink: Callable[[EvalRecord], None] | None = None
     _queue: asyncio.Queue[
         tuple[FillRecord, TradeDecision, Mapping[str, object] | None]
     ] = field(
@@ -93,15 +94,24 @@ class EvalSpool:
                         decision_evidence,
                     )
                     continue
-                await self.store.append(
-                    self.scorer.score(
-                        fill,
-                        decision,
-                        baseline_prob_estimates=_baseline_prob_estimates_from_evidence(
-                            decision_evidence,
-                        ),
-                    )
+                scored_record = self.scorer.score(
+                    fill,
+                    decision,
+                    baseline_prob_estimates=_baseline_prob_estimates_from_evidence(
+                        decision_evidence,
+                    ),
                 )
+                # Persist before pushing: restart re-hydration reads the eval
+                # store, so a record must never feed a calibrator unless it is
+                # also durable.
+                await self.store.append(scored_record)
+                if self.calibration_sink is not None:
+                    try:
+                        self.calibration_sink(scored_record)
+                    except Exception:  # noqa: BLE001
+                        logger.exception(
+                            "calibration sink failed in evaluator spool"
+                        )
                 try:
                     await self._generate_feedback()
                 except Exception:  # noqa: BLE001

--- a/src/pms/evaluation/spool.py
+++ b/src/pms/evaluation/spool.py
@@ -104,6 +104,14 @@ class EvalSpool:
                 # Persist before pushing: restart re-hydration reads the eval
                 # store, so a record must never feed a calibrator unless it is
                 # also durable.
+                #
+                # Coordination contract (feat/resolution-ingestion): the
+                # resolution sweep re-enqueues late-resolved fills through
+                # this same queue, so ANY enqueue whose fill carries
+                # resolved_outcome reaches the sink — regardless of producer.
+                # Duplicate delivery for one decision_id (sweep retry, or
+                # ON CONFLICT-deduped store append) is safe: the sink's
+                # calibrator dedups per (model_id, decision_id).
                 await self.store.append(scored_record)
                 if self.calibration_sink is not None:
                     try:

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -7,7 +7,7 @@ import logging
 from copy import deepcopy
 from math import isfinite
 from hashlib import sha256
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
@@ -62,6 +62,7 @@ from pms.core.interfaces import (
     SubscriptionManagedSensor,
 )
 from pms.core.models import (
+    EvalRecord,
     FillRecord,
     LiveTradingDisabledError,
     MarketSignal,
@@ -252,6 +253,19 @@ class DetachedControllerRuntime:
     task: asyncio.Task[None] | None
 
 
+def _runtime_calibration_add_samples(
+    runtime: StrategyControllerRuntime,
+) -> Callable[[str, list[EvalRecord]], None] | None:
+    # Duck-typed like pipeline._resolved_sample_count: extending the
+    # ICalibrator Protocol would break test fakes that satisfy only
+    # `calibrate`/`sample_count`.
+    calibrator = getattr(runtime.controller, "calibrator", None)
+    add_samples = getattr(calibrator, "add_samples", None)
+    if not callable(add_samples):
+        return None
+    return cast(Callable[[str, list[EvalRecord]], None], add_samples)
+
+
 @dataclass(frozen=True)
 class ActuatorWorkItem:
     decision: TradeDecision
@@ -415,6 +429,7 @@ class Runner:
             feedback_generator=EvaluatorFeedback(self.feedback_store),
             metrics_provider=self._metrics_by_strategy,
             quote_store=self.quote_eval_store,
+            calibration_sink=self._on_eval_record_for_calibration,
         )
         self._decision_queue = asyncio.Queue()
         self._stop_event = asyncio.Event()
@@ -2783,6 +2798,58 @@ class Runner:
         with suppress(asyncio.CancelledError):
             await task
 
+    def _on_eval_record_for_calibration(self, record: EvalRecord) -> None:
+        runtime = self._controller_runtimes.get(record.strategy_id)
+        if (
+            runtime is None
+            or runtime.strategy_version_id != record.strategy_version_id
+        ):
+            # Stale-version records must not feed a new version's calibrator:
+            # those outcomes never tested the new forecaster spec.
+            logger.debug(
+                "dropping eval record for calibration without a matching "
+                "runtime: (%s, %s)",
+                record.strategy_id,
+                record.strategy_version_id,
+            )
+            return
+        add_samples = _runtime_calibration_add_samples(runtime)
+        if add_samples is None:
+            return
+        add_samples(record.model_id or "unknown", [record])
+
+    async def _hydrate_runtime_calibration(
+        self,
+        runtime: StrategyControllerRuntime,
+    ) -> None:
+        add_samples = _runtime_calibration_add_samples(runtime)
+        if add_samples is None:
+            return
+        records = await self.eval_store.all_for_strategy(
+            runtime.strategy_id,
+            runtime.strategy_version_id,
+        )
+        grouped: dict[str, list[EvalRecord]] = {}
+        for record in records:
+            grouped.setdefault(record.model_id or "unknown", []).append(record)
+        for model_id, model_records in grouped.items():
+            add_samples(model_id, model_records)
+        logger.info(
+            "calibration hydration loaded %d resolved eval records for %s@%s",
+            len(records),
+            runtime.strategy_id,
+            runtime.strategy_version_id,
+            extra={
+                "event": "calibration_hydration",
+                "strategy_id": runtime.strategy_id,
+                "strategy_version_id": runtime.strategy_version_id,
+                "resolved_records_by_model": {
+                    model_id: len(model_records)
+                    for model_id, model_records in grouped.items()
+                },
+            },
+        )
+
     def _attach_controller_runtime(self, runtime: StrategyControllerRuntime) -> None:
         signal_queue: asyncio.Queue[MarketSignal] = asyncio.Queue()
         self._controller_runtimes[runtime.strategy_id] = runtime
@@ -2831,10 +2898,13 @@ class Runner:
                     or current_runtime.asset_ids != desired_runtime.asset_ids
                 ):
                     await self._release_controller_runtime_locked(strategy_id)
+                    await self._hydrate_runtime_calibration(desired_runtime)
                     self._attach_controller_runtime(desired_runtime)
 
             for strategy_id in sorted(desired_strategy_ids - current_strategy_ids):
-                self._attach_controller_runtime(desired_by_strategy[strategy_id])
+                desired_runtime = desired_by_strategy[strategy_id]
+                await self._hydrate_runtime_calibration(desired_runtime)
+                self._attach_controller_runtime(desired_runtime)
 
             await self._refresh_subscription_assets_locked()
 
@@ -2970,6 +3040,7 @@ class Runner:
             raise RuntimeError(msg)
         runtimes = await self._build_controller_runtimes()
         for runtime in runtimes:
+            await self._hydrate_runtime_calibration(runtime)
             self._attach_controller_runtime(runtime)
 
     async def _build_controller_runtimes(self) -> list[StrategyControllerRuntime]:

--- a/src/pms/runner.py
+++ b/src/pms/runner.py
@@ -2898,13 +2898,24 @@ class Runner:
                     or current_runtime.asset_ids != desired_runtime.asset_ids
                 ):
                     await self._release_controller_runtime_locked(strategy_id)
-                    await self._hydrate_runtime_calibration(desired_runtime)
+                    # Attach before the hydration DB await: a record pushed
+                    # by the calibration sink during that await would
+                    # otherwise be dropped (no runtime registered) AND can
+                    # miss the in-flight all_for_strategy query — a lost
+                    # sample. Duplicate delivery is safe: the calibrator
+                    # dedups per (model_id, decision_id). Attach-first also
+                    # keeps the strategy attached if hydration fails.
                     self._attach_controller_runtime(desired_runtime)
+                    await self._hydrate_runtime_calibration(desired_runtime)
 
             for strategy_id in sorted(desired_strategy_ids - current_strategy_ids):
                 desired_runtime = desired_by_strategy[strategy_id]
-                await self._hydrate_runtime_calibration(desired_runtime)
+                # Same attach-then-hydrate ordering as the replace branch:
+                # the sink drops records for unattached runtimes, so the
+                # push window exists here too (e.g. a sweep resolving fills
+                # of a re-added strategy).
                 self._attach_controller_runtime(desired_runtime)
+                await self._hydrate_runtime_calibration(desired_runtime)
 
             await self._refresh_subscription_assets_locked()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,53 @@ def _stub_fill_store_read_positions(
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_eval_store_all_for_strategy(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Stub `EvalStore.all_for_strategy` to return [] for non-integration
+    unit tests.
+
+    `Runner` hydrates each controller runtime's calibrator from
+    `EvalStore.all_for_strategy()` at attach time
+    (`_hydrate_runtime_calibration`). The default `EvalStore` queries the
+    bound asyncpg pool — which most unit tests replace with a minimal
+    fake that lacks `.acquire` or whose connection lacks `.fetch`.
+    Without this stub, every unit test that exercises `Runner.start`
+    would fail on a fake-pool AttributeError rather than the test's
+    actual assertion. Mirrors `_stub_fill_store_read_positions`; an
+    empty store is also the documented cold-start posture (hydration is
+    an exact no-op).
+
+    Opt out by tagging tests `@pytest.mark.real_eval_store` (used by
+    tests that exercise `EvalStore.all_for_strategy` directly) or
+    `@pytest.mark.integration` with `PMS_RUN_INTEGRATION=1` set. Tests
+    that replace the runner's `eval_store` field with their own fake
+    bypass this stub naturally.
+    """
+    if (
+        request.node.get_closest_marker("integration") is not None
+        and os.environ.get("PMS_RUN_INTEGRATION") == "1"
+    ):
+        return
+    if request.node.get_closest_marker("real_eval_store") is not None:
+        return
+
+    async def _empty_all_for_strategy(
+        self: object,
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> list[object]:
+        del self, strategy_id, strategy_version_id
+        return []
+
+    monkeypatch.setattr(
+        "pms.storage.eval_store.EvalStore.all_for_strategy",
+        _empty_all_for_strategy,
+    )
+
+
 ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_FILE = ROOT / "compose.yml"
 DEFAULT_COMPOSE_POSTGRES_DSN = "postgresql://postgres:postgres@127.0.0.1:5432/pms_test"

--- a/tests/support/fake_stores.py
+++ b/tests/support/fake_stores.py
@@ -17,6 +17,18 @@ class InMemoryEvalStore:
     async def all(self) -> list[EvalRecord]:
         return list(self._records)
 
+    async def all_for_strategy(
+        self,
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> list[EvalRecord]:
+        return [
+            record
+            for record in self._records
+            if record.strategy_id == strategy_id
+            and record.strategy_version_id == strategy_version_id
+        ]
+
 
 class InMemoryFeedbackStore:
     def __init__(self, items: list[Feedback] | None = None) -> None:

--- a/tests/unit/test_controller_cp04.py
+++ b/tests/unit/test_controller_cp04.py
@@ -144,6 +144,19 @@ def test_netcal_calibrator_dedups_samples_by_decision_id() -> None:
     assert calibrator.sample_count("model-a") == 3
 
 
+def test_netcal_calibrator_dedups_fresh_record_objects_by_decision_id() -> None:
+    """The production duplicate is a DB-rehydrated fresh EvalRecord object vs
+    an in-memory pushed object with an equal decision_id — never the same
+    object identity. An identity-keyed dedup regression would pass the
+    same-list test above but double-count here."""
+    calibrator = NetcalCalibrator()
+
+    calibrator.add_samples("model-a", _records(3))
+    calibrator.add_samples("model-a", _records(3))
+
+    assert calibrator.sample_count("model-a") == 3
+
+
 def test_netcal_calibrator_dedup_is_scoped_per_model_bucket() -> None:
     calibrator = NetcalCalibrator()
     records = _records(2)

--- a/tests/unit/test_controller_cp04.py
+++ b/tests/unit/test_controller_cp04.py
@@ -8,7 +8,7 @@ from pms.config import RiskSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.forecasters.rules import RulesForecaster
 from pms.controller.forecasters.statistical import StatisticalForecaster
-from pms.controller.pipeline import ControllerPipeline
+from pms.controller.pipeline import ControllerPipeline, _resolved_sample_count
 from pms.controller.sizers.kelly import KellySizer
 from pms.core.enums import MarketStatus
 from pms.core.models import EvalRecord, MarketSignal, Portfolio
@@ -153,6 +153,30 @@ def test_netcal_calibrator_dedup_is_scoped_per_model_bucket() -> None:
 
     assert calibrator.sample_count("model-a") == 2
     assert calibrator.sample_count("model-b") == 2
+
+
+def test_resolved_sample_count_counts_decision_level_model_id_for_ensembles() -> None:
+    """EvalRecord.model_id is the decision-level id — "ensemble" for
+    multi-forecaster strategies (pipeline._decision_model_id). The clamp
+    unlock counter must read the same bucket the resolved records land in,
+    or graduation never happens for ensembles."""
+    calibrator = NetcalCalibrator()
+    calibrator.add_samples("ensemble", _records(20))
+
+    assert (
+        _resolved_sample_count(calibrator, ["RulesForecaster", "LLMForecaster"]) == 20
+    )
+
+
+def test_resolved_sample_count_keeps_single_forecaster_keying() -> None:
+    calibrator = NetcalCalibrator()
+    calibrator.add_samples("RulesForecaster", _records(5))
+
+    assert _resolved_sample_count(calibrator, ["RulesForecaster"]) == 5
+
+
+def test_resolved_sample_count_is_zero_without_model_ids() -> None:
+    assert _resolved_sample_count(NetcalCalibrator(), []) == 0
 
 
 def test_kelly_sizer_even_odds_fractional_bet() -> None:

--- a/tests/unit/test_controller_cp04.py
+++ b/tests/unit/test_controller_cp04.py
@@ -130,6 +130,31 @@ def test_netcal_calibrator_applies_isotonic_at_100_samples() -> None:
     assert calibrator.calibrate(0.2, model_id="model-a") == pytest.approx(0.0)
 
 
+def test_netcal_calibrator_dedups_samples_by_decision_id() -> None:
+    """Hydration from the eval store and the live push path can deliver the
+    same resolved record twice (e.g. a record persisted before a mid-session
+    pipeline swap is both hydrated and pushed). Double-counting would let a
+    single resolution unlock graduation thresholds early."""
+    calibrator = NetcalCalibrator()
+    records = _records(3)
+
+    calibrator.add_samples("model-a", records)
+    calibrator.add_samples("model-a", records)
+
+    assert calibrator.sample_count("model-a") == 3
+
+
+def test_netcal_calibrator_dedup_is_scoped_per_model_bucket() -> None:
+    calibrator = NetcalCalibrator()
+    records = _records(2)
+
+    calibrator.add_samples("model-a", records)
+    calibrator.add_samples("model-b", records)
+
+    assert calibrator.sample_count("model-a") == 2
+    assert calibrator.sample_count("model-b") == 2
+
+
 def test_kelly_sizer_even_odds_fractional_bet() -> None:
     sizer = KellySizer(risk=RiskSettings(max_position_per_market=1000.0))
 

--- a/tests/unit/test_evaluation_spool_calibration_sink.py
+++ b/tests/unit/test_evaluation_spool_calibration_sink.py
@@ -1,0 +1,162 @@
+"""Evaluator -> Controller calibration feedback edge (spool side).
+
+The spool pushes every *resolved* EvalRecord to a runner-injected
+``calibration_sink`` after the record is durably persisted. Persist-then-push
+ordering is load-bearing: restart re-hydration reads the eval store, so a
+record must never reach a calibrator without also being on disk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import cast
+
+import pytest
+
+from pms.core.enums import OrderStatus, Side, TimeInForce
+from pms.core.models import EvalRecord, FillRecord, TradeDecision
+from pms.evaluation.adapters.scoring import Scorer
+from pms.evaluation.spool import EvalSpool
+from pms.storage.eval_store import EvalStore
+
+
+def _decision(*, decision_id: str = "d-sink") -> TradeDecision:
+    return TradeDecision(
+        decision_id=decision_id,
+        market_id="m-sink",
+        token_id="t-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        limit_price=0.4,
+        notional_usdc=4.0,
+        order_type="limit",
+        max_slippage_bps=100,
+        stop_conditions=["min_volume:100.00"],
+        prob_estimate=0.7,
+        expected_edge=0.3,
+        time_in_force=TimeInForce.GTC,
+        opportunity_id=f"op-{decision_id}",
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        model_id="model-a",
+    )
+
+
+def _fill(
+    *,
+    decision_id: str = "d-sink",
+    resolved_outcome: float | None = 1.0,
+) -> FillRecord:
+    now = datetime(2026, 6, 10, tzinfo=UTC)
+    return FillRecord(
+        trade_id=f"trade-{decision_id}",
+        order_id=f"order-{decision_id}",
+        decision_id=decision_id,
+        market_id="m-sink",
+        token_id="t-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        fill_price=0.42,
+        fill_notional_usdc=4.2,
+        fill_quantity=10.0,
+        executed_at=now,
+        filled_at=now,
+        status=OrderStatus.MATCHED.value,
+        anomaly_flags=[],
+        strategy_id="default",
+        strategy_version_id="default-v1",
+        resolved_outcome=resolved_outcome,
+    )
+
+
+class _OrderRecordingEvalStore:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self.records: list[EvalRecord] = []
+
+    async def append(self, record: EvalRecord) -> None:
+        self._events.append(f"append:{record.decision_id}")
+        self.records.append(record)
+
+
+@pytest.mark.asyncio
+async def test_calibration_sink_receives_resolved_record_after_persistence() -> None:
+    events: list[str] = []
+    store = _OrderRecordingEvalStore(events)
+    sunk: list[EvalRecord] = []
+
+    def sink(record: EvalRecord) -> None:
+        events.append(f"sink:{record.decision_id}")
+        sunk.append(record)
+
+    spool = EvalSpool(
+        store=cast(EvalStore, store),
+        scorer=Scorer(),
+        calibration_sink=sink,
+    )
+    await spool.start()
+    try:
+        spool.enqueue(_fill(decision_id="d-1"), _decision(decision_id="d-1"))
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+    finally:
+        await spool.stop()
+
+    assert events == ["append:d-1", "sink:d-1"]
+    assert [record.decision_id for record in sunk] == ["d-1"]
+    assert sunk[0].model_id == "model-a"
+    assert sunk[0].resolved_outcome == 1.0
+
+
+@pytest.mark.asyncio
+async def test_calibration_sink_not_called_for_unresolved_fill() -> None:
+    events: list[str] = []
+    store = _OrderRecordingEvalStore(events)
+    spool = EvalSpool(
+        store=cast(EvalStore, store),
+        scorer=Scorer(),
+        calibration_sink=lambda record: events.append(f"sink:{record.decision_id}"),
+    )
+    await spool.start()
+    try:
+        spool.enqueue(
+            _fill(decision_id="d-unresolved", resolved_outcome=None),
+            _decision(decision_id="d-unresolved"),
+        )
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+    finally:
+        await spool.stop()
+
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_spool_survives_raising_calibration_sink() -> None:
+    events: list[str] = []
+    store = _OrderRecordingEvalStore(events)
+
+    def raising_sink(record: EvalRecord) -> None:
+        events.append(f"sink:{record.decision_id}")
+        msg = "calibrator exploded"
+        raise RuntimeError(msg)
+
+    spool = EvalSpool(
+        store=cast(EvalStore, store),
+        scorer=Scorer(),
+        calibration_sink=raising_sink,
+    )
+    await spool.start()
+    try:
+        spool.enqueue(_fill(decision_id="d-boom"), _decision(decision_id="d-boom"))
+        spool.enqueue(_fill(decision_id="d-after"), _decision(decision_id="d-after"))
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+    finally:
+        await spool.stop()
+
+    # Eval persistence happened for both records despite the sink raising.
+    assert events == [
+        "append:d-boom",
+        "sink:d-boom",
+        "append:d-after",
+        "sink:d-after",
+    ]

--- a/tests/unit/test_evaluation_spool_calibration_sink.py
+++ b/tests/unit/test_evaluation_spool_calibration_sink.py
@@ -9,6 +9,7 @@ record must never reach a calibrator without also being on disk.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from datetime import UTC, datetime
 from typing import cast
 
@@ -128,6 +129,46 @@ async def test_calibration_sink_not_called_for_unresolved_fill() -> None:
         await spool.stop()
 
     assert events == []
+
+
+@pytest.mark.asyncio
+async def test_calibration_sink_fires_for_sweep_style_late_resolved_reenqueue() -> None:
+    """Coordination contract with feat/resolution-ingestion: live PAPER/LIVE
+    fills are unresolved at enqueue time, and the resolution sweep later
+    re-enqueues ``replace(fill, resolved_outcome=...)`` through the same
+    ``EvalSpool.enqueue``. The sink must fire for any record passing ``_run``
+    with ``resolved_outcome`` set, regardless of which producer enqueued it."""
+    events: list[str] = []
+    store = _OrderRecordingEvalStore(events)
+    sunk: list[EvalRecord] = []
+
+    def sink(record: EvalRecord) -> None:
+        events.append(f"sink:{record.decision_id}")
+        sunk.append(record)
+
+    spool = EvalSpool(
+        store=cast(EvalStore, store),
+        scorer=Scorer(),
+        calibration_sink=sink,
+    )
+    unresolved_fill = _fill(decision_id="d-sweep", resolved_outcome=None)
+    decision = _decision(decision_id="d-sweep")
+    await spool.start()
+    try:
+        # Fill-time enqueue: market not yet resolved — no eval row, no sink.
+        spool.enqueue(unresolved_fill, decision)
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+        assert events == []
+
+        # Sweep-time re-enqueue: same fill, now carrying the resolution.
+        spool.enqueue(replace(unresolved_fill, resolved_outcome=1.0), decision)
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+    finally:
+        await spool.stop()
+
+    assert events == ["append:d-sweep", "sink:d-sweep"]
+    assert [record.decision_id for record in sunk] == ["d-sweep"]
+    assert sunk[0].resolved_outcome == 1.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_calibration_feedback.py
+++ b/tests/unit/test_runner_calibration_feedback.py
@@ -1,0 +1,522 @@
+"""Evaluator -> Controller calibration feedback edge (runner side).
+
+The runner injects ``_on_eval_record_for_calibration`` as the spool's
+calibration sink (event-driven push per resolved record) and re-hydrates
+each controller runtime's calibrator from the durable eval store when the
+runtime is attached (restart / cold-start / mid-session swap).
+
+Scope is strict ``(strategy_id, strategy_version_id)``: feeding another
+version's resolved samples would unlock extreme-probability trading on a
+model those outcomes never tested.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from pms.config import ControllerSettings, PMSSettings, RiskSettings
+from pms.controller.calibrators.netcal import NetcalCalibrator
+from pms.controller.pipeline import ControllerPipeline
+from pms.core.enums import MarketStatus, RunMode
+from pms.core.models import EvalRecord, MarketSignal, Portfolio, TradeDecision
+from pms.runner import Runner, StrategyControllerRuntime
+from pms.strategies.projections import (
+    ActiveStrategy,
+    CalibrationSpec,
+    EvalSpec,
+    ForecasterSpec,
+    MarketSelectionSpec,
+    RiskParams,
+    StrategyConfig,
+)
+
+
+FIXTURE_PATH = Path("tests/fixtures/polymarket_7day_synthetic.jsonl")
+
+
+def _runner() -> Runner:
+    return Runner(
+        config=PMSSettings(
+            mode=RunMode.BACKTEST,
+            auto_migrate_default_v2=False,
+            risk=RiskSettings(
+                max_position_per_market=1000.0,
+                max_total_exposure=10_000.0,
+            ),
+        ),
+        historical_data_path=FIXTURE_PATH,
+    )
+
+
+def _eval_record(
+    *,
+    decision_id: str,
+    strategy_id: str = "s-cal",
+    strategy_version_id: str = "s-cal-v1",
+    model_id: str | None = "model-a",
+) -> EvalRecord:
+    return EvalRecord(
+        market_id="m-cal",
+        decision_id=decision_id,
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        prob_estimate=0.7,
+        resolved_outcome=1.0,
+        brier_score=0.09,
+        fill_status="matched",
+        recorded_at=datetime(2026, 6, 10, tzinfo=UTC),
+        citations=["unit-test"],
+        model_id=model_id,
+    )
+
+
+class _CalibratedController:
+    """Controller double exposing the duck-typed ``calibrator`` attribute the
+    runner feeds (same access pattern as pipeline._resolved_sample_count)."""
+
+    def __init__(self) -> None:
+        self.calibrator = NetcalCalibrator()
+
+    async def decide(
+        self,
+        signal: MarketSignal,
+        portfolio: Portfolio | None = None,
+    ) -> TradeDecision | None:
+        del signal, portfolio
+        return None
+
+
+class _CalibratorFreeController:
+    async def decide(
+        self,
+        signal: MarketSignal,
+        portfolio: Portfolio | None = None,
+    ) -> TradeDecision | None:
+        del signal, portfolio
+        return None
+
+
+def _runtime(
+    controller: object,
+    *,
+    strategy_id: str = "s-cal",
+    strategy_version_id: str = "s-cal-v1",
+) -> StrategyControllerRuntime:
+    return StrategyControllerRuntime(
+        strategy_id=strategy_id,
+        strategy_version_id=strategy_version_id,
+        controller=cast(Any, controller),
+        asset_ids=None,
+    )
+
+
+class _StrategyScopedEvalStore:
+    def __init__(
+        self,
+        records_by_key: dict[tuple[str, str], list[EvalRecord]] | None = None,
+    ) -> None:
+        self.records_by_key = records_by_key or {}
+        self.queries: list[tuple[str, str]] = []
+
+    async def all_for_strategy(
+        self,
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> list[EvalRecord]:
+        self.queries.append((strategy_id, strategy_version_id))
+        return list(self.records_by_key.get((strategy_id, strategy_version_id), []))
+
+
+def test_runner_wires_calibration_sink_into_eval_spool() -> None:
+    runner = _runner()
+
+    assert (
+        runner._evaluator_spool.calibration_sink  # noqa: SLF001
+        == runner._on_eval_record_for_calibration  # noqa: SLF001
+    )
+
+
+def test_on_eval_record_routes_to_matching_runtime_calibrator() -> None:
+    runner = _runner()
+    controller = _CalibratedController()
+    runner._controller_runtimes["s-cal"] = _runtime(controller)  # noqa: SLF001
+
+    runner._on_eval_record_for_calibration(  # noqa: SLF001
+        _eval_record(decision_id="d-1")
+    )
+
+    assert controller.calibrator.sample_count("model-a") == 1
+
+
+def test_on_eval_record_skips_stale_version_records() -> None:
+    runner = _runner()
+    controller = _CalibratedController()
+    runner._controller_runtimes["s-cal"] = _runtime(  # noqa: SLF001
+        controller,
+        strategy_version_id="s-cal-v2",
+    )
+
+    runner._on_eval_record_for_calibration(  # noqa: SLF001
+        _eval_record(decision_id="d-stale", strategy_version_id="s-cal-v1")
+    )
+
+    assert controller.calibrator.sample_count("model-a") == 0
+
+
+def test_on_eval_record_skips_unknown_strategy() -> None:
+    runner = _runner()
+
+    runner._on_eval_record_for_calibration(  # noqa: SLF001
+        _eval_record(decision_id="d-unmatched", strategy_id="s-unknown")
+    )
+
+
+def test_on_eval_record_falls_back_to_unknown_model_id() -> None:
+    runner = _runner()
+    controller = _CalibratedController()
+    runner._controller_runtimes["s-cal"] = _runtime(controller)  # noqa: SLF001
+
+    runner._on_eval_record_for_calibration(  # noqa: SLF001
+        _eval_record(decision_id="d-no-model", model_id=None)
+    )
+
+    assert controller.calibrator.sample_count("unknown") == 1
+
+
+def test_on_eval_record_ignores_controller_without_calibrator() -> None:
+    runner = _runner()
+    runner._controller_runtimes["s-cal"] = _runtime(  # noqa: SLF001
+        _CalibratorFreeController()
+    )
+
+    runner._on_eval_record_for_calibration(  # noqa: SLF001
+        _eval_record(decision_id="d-duck")
+    )
+
+
+@pytest.mark.asyncio
+async def test_hydrate_runtime_calibration_groups_records_by_model_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    runner = _runner()
+    controller = _CalibratedController()
+    runtime = _runtime(controller)
+    runner.eval_store = cast(
+        Any,
+        _StrategyScopedEvalStore(
+            {
+                ("s-cal", "s-cal-v1"): [
+                    _eval_record(decision_id="d-a1", model_id="model-a"),
+                    _eval_record(decision_id="d-a2", model_id="model-a"),
+                    _eval_record(decision_id="d-ensemble", model_id="ensemble"),
+                    _eval_record(decision_id="d-none", model_id=None),
+                ]
+            }
+        ),
+    )
+
+    with caplog.at_level(logging.INFO, logger="pms.runner"):
+        await runner._hydrate_runtime_calibration(runtime)  # noqa: SLF001
+
+    assert controller.calibrator.sample_count("model-a") == 2
+    assert controller.calibrator.sample_count("ensemble") == 1
+    assert controller.calibrator.sample_count("unknown") == 1
+    hydration_logs = [
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "calibration_hydration"
+    ]
+    assert len(hydration_logs) == 1
+    assert getattr(hydration_logs[0], "strategy_id", None) == "s-cal"
+    assert getattr(hydration_logs[0], "strategy_version_id", None) == "s-cal-v1"
+    assert getattr(hydration_logs[0], "resolved_records_by_model", None) == {
+        "model-a": 2,
+        "ensemble": 1,
+        "unknown": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_hydrate_runtime_calibration_is_noop_on_empty_store() -> None:
+    """The running paper soak has eval_records=0: hydration must be an exact
+    no-op on calibrator state — fail-closed, no crash."""
+    runner = _runner()
+    controller = _CalibratedController()
+    runner.eval_store = cast(Any, _StrategyScopedEvalStore())
+
+    await runner._hydrate_runtime_calibration(_runtime(controller))  # noqa: SLF001
+
+    assert controller.calibrator.sample_count("model-a") == 0
+    assert controller.calibrator.sample_count("unknown") == 0
+
+
+@pytest.mark.asyncio
+async def test_hydrate_runtime_calibration_skips_store_query_without_calibrator(
+) -> None:
+    runner = _runner()
+    store = _StrategyScopedEvalStore()
+    runner.eval_store = cast(Any, store)
+
+    await runner._hydrate_runtime_calibration(  # noqa: SLF001
+        _runtime(_CalibratorFreeController())
+    )
+
+    assert store.queries == []
+
+
+@pytest.mark.asyncio
+async def test_configure_controllers_hydrates_runtime_before_attach(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner()
+    controller = _CalibratedController()
+    runner.controller = cast(Any, controller)
+    store = _StrategyScopedEvalStore(
+        {
+            ("default", "default-v1"): [
+                _eval_record(
+                    decision_id="d-default",
+                    strategy_id="default",
+                    strategy_version_id="default-v1",
+                )
+            ]
+        }
+    )
+    runner.eval_store = cast(Any, store)
+    events: list[str] = []
+
+    original_all_for_strategy = store.all_for_strategy
+
+    async def recording_all_for_strategy(
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> list[EvalRecord]:
+        events.append(f"hydrate:{strategy_id}")
+        return await original_all_for_strategy(strategy_id, strategy_version_id)
+
+    monkeypatch.setattr(store, "all_for_strategy", recording_all_for_strategy)
+    monkeypatch.setattr(
+        runner,
+        "_attach_controller_runtime",
+        lambda runtime: events.append(f"attach:{runtime.strategy_id}"),
+    )
+
+    await runner._configure_controllers()  # noqa: SLF001
+
+    assert events == ["hydrate:default", "attach:default"]
+    assert controller.calibrator.sample_count("model-a") == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_controller_runtimes_hydrates_only_attached_runtimes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery-driven syncs run repeatedly; hydration must hit the DB only
+    for runtimes actually being (re)attached — new strategies and version
+    replacements — never for unchanged ones."""
+    runner = _runner()
+    runner._strategy_registry = cast(Any, object())  # noqa: SLF001
+
+    unchanged_controller = _CalibratedController()
+    unchanged_runtime = _runtime(
+        unchanged_controller,
+        strategy_id="s-unchanged",
+        strategy_version_id="s-unchanged-v1",
+    )
+    runner._controller_runtimes["s-unchanged"] = unchanged_runtime  # noqa: SLF001
+
+    replaced_controller = _CalibratedController()
+    runner._controller_runtimes["s-replaced"] = _runtime(  # noqa: SLF001
+        _CalibratedController(),
+        strategy_id="s-replaced",
+        strategy_version_id="s-replaced-v1",
+    )
+    desired_replacement = _runtime(
+        replaced_controller,
+        strategy_id="s-replaced",
+        strategy_version_id="s-replaced-v2",
+    )
+
+    new_controller = _CalibratedController()
+    new_runtime = _runtime(
+        new_controller,
+        strategy_id="s-new",
+        strategy_version_id="s-new-v1",
+    )
+
+    store = _StrategyScopedEvalStore(
+        {
+            ("s-replaced", "s-replaced-v2"): [
+                _eval_record(
+                    decision_id="d-replaced",
+                    strategy_id="s-replaced",
+                    strategy_version_id="s-replaced-v2",
+                )
+            ],
+            ("s-new", "s-new-v1"): [
+                _eval_record(
+                    decision_id="d-new",
+                    strategy_id="s-new",
+                    strategy_version_id="s-new-v1",
+                )
+            ],
+        }
+    )
+    runner.eval_store = cast(Any, store)
+
+    async def fake_build() -> list[StrategyControllerRuntime]:
+        return [unchanged_runtime, desired_replacement, new_runtime]
+
+    monkeypatch.setattr(runner, "_build_controller_runtimes", fake_build)
+    attached: list[str] = []
+    monkeypatch.setattr(
+        runner,
+        "_attach_controller_runtime",
+        lambda runtime: attached.append(runtime.strategy_id),
+    )
+
+    await runner._sync_controller_runtimes()  # noqa: SLF001
+
+    assert sorted(attached) == ["s-new", "s-replaced"]
+    assert sorted(store.queries) == [
+        ("s-new", "s-new-v1"),
+        ("s-replaced", "s-replaced-v2"),
+    ]
+    assert replaced_controller.calibrator.sample_count("model-a") == 1
+    assert new_controller.calibrator.sample_count("model-a") == 1
+    assert unchanged_controller.calibrator.sample_count("model-a") == 0
+
+
+# --- End-to-end graduation counter-trace -----------------------------------
+# Mirror of tests/unit/test_live_trading_blockers.py clamp-probe setup: an
+# extreme forecast (0.99) is rejected with zero resolved samples, then two
+# resolved EvalRecords arrive through the sink path and the same pipeline
+# emits.
+
+
+class ConstantForecaster:
+    def __init__(self, probability: float, rationale: str = "constant") -> None:
+        self.probability = probability
+        self.rationale = rationale
+
+    def predict(self, signal: MarketSignal) -> tuple[float, float, str]:
+        del signal
+        return self.probability, 0.0, self.rationale
+
+    async def forecast(self, signal: MarketSignal) -> float:
+        del signal
+        return self.probability
+
+
+class FixedSizer:
+    def size(self, *, prob: float, market_price: float, portfolio: Portfolio) -> float:
+        del prob, market_price, portfolio
+        return 10.0
+
+
+def _clamp_probe_strategy(*, min_resolved_for_extreme: int) -> ActiveStrategy:
+    return ActiveStrategy(
+        strategy_id="clamp-probe",
+        strategy_version_id="clamp-probe-v1",
+        config=StrategyConfig(
+            strategy_id="clamp-probe",
+            factor_composition=(),
+            metadata=(("owner", "system"), ("live_allowed", "false")),
+        ),
+        risk=RiskParams(
+            max_position_notional_usdc=1_000.0,
+            max_daily_drawdown_pct=0.0,
+            min_order_size_usdc=1.0,
+        ),
+        eval_spec=EvalSpec(metrics=("brier", "pnl")),
+        forecaster=ForecasterSpec(forecasters=(("rules", ()),)),
+        market_selection=MarketSelectionSpec(
+            venue="polymarket",
+            resolution_time_max_horizon_days=30,
+            volume_min_usdc=0.0,
+        ),
+        calibration=CalibrationSpec(
+            enabled=True,
+            shrinkage_factor=1.0,  # no shrinkage, so 0.99 stays extreme
+            shrinkage_bias=0.0,
+            extreme_clamp_low=0.08,
+            extreme_clamp_high=0.92,
+            min_resolved_for_extreme=min_resolved_for_extreme,
+        ),
+    )
+
+
+def _signal() -> MarketSignal:
+    return MarketSignal(
+        market_id="m-graduation",
+        token_id="t-yes",
+        venue="polymarket",
+        title="Will the clamp graduate?",
+        yes_price=0.4,
+        volume_24h=1000.0,
+        resolves_at=datetime(2026, 7, 1, tzinfo=UTC),
+        orderbook={"bids": [], "asks": []},
+        external_signal={},
+        fetched_at=datetime(2026, 6, 10, tzinfo=UTC),
+        market_status=MarketStatus.OPEN.value,
+    )
+
+
+def _portfolio() -> Portfolio:
+    return Portfolio(
+        total_usdc=1000.0,
+        free_usdc=1000.0,
+        locked_usdc=0.0,
+        open_positions=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_calibration_graduation_unlocks_extreme_clamp_via_sink_path() -> None:
+    pipeline = ControllerPipeline(
+        strategy=_clamp_probe_strategy(min_resolved_for_extreme=2),
+        forecasters=(ConstantForecaster(0.99),),
+        calibrator=NetcalCalibrator(),
+        sizer=FixedSizer(),
+        settings=PMSSettings(
+            mode=RunMode.PAPER,
+            controller=ControllerSettings(min_volume=0.0),
+            risk=RiskSettings(min_order_usdc=1.0),
+        ),
+    )
+    runner = _runner()
+    runner._controller_runtimes["clamp-probe"] = _runtime(  # noqa: SLF001
+        pipeline,
+        strategy_id="clamp-probe",
+        strategy_version_id="clamp-probe-v1",
+    )
+
+    rejected = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+    assert rejected is None
+    diagnostic = pipeline.last_diagnostic
+    assert diagnostic is not None
+    assert diagnostic.code == "calibration_clamp_rejected"
+
+    for index in range(2):
+        runner._on_eval_record_for_calibration(  # noqa: SLF001
+            _eval_record(
+                decision_id=f"d-resolved-{index}",
+                strategy_id="clamp-probe",
+                strategy_version_id="clamp-probe-v1",
+                model_id="ConstantForecaster",
+            )
+        )
+
+    emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+
+    assert emission is not None, (
+        "two resolved eval records (>= min_resolved_for_extreme) fed through "
+        "the calibration sink must unlock the extreme-probability clamp"
+    )
+    _opportunity, decision = emission
+    assert decision.prob_estimate == pytest.approx(0.99)

--- a/tests/unit/test_runner_calibration_feedback.py
+++ b/tests/unit/test_runner_calibration_feedback.py
@@ -495,6 +495,124 @@ async def test_sync_controller_runtimes_hydrates_only_attached_runtimes(
     assert unchanged_controller.calibrator.sample_count("model-a") == 0
 
 
+@pytest.mark.asyncio
+async def test_sync_replace_attaches_before_hydration_so_concurrent_push_survives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A record pushed by the calibration sink while the replace-branch
+    hydration query is in flight must reach the new runtime's calibrator.
+    Hydrate-before-attach drops it (the old runtime is already released, the
+    new one not yet attached) and the in-flight all_for_strategy query can
+    also miss it — a lost sample until the next hydration event. Attach-first
+    is safe because NetcalCalibrator dedups per (model_id, decision_id)."""
+    runner = _runner()
+    runner._strategy_registry = cast(Any, object())  # noqa: SLF001
+
+    replaced_controller = _CalibratedController()
+    runner._controller_runtimes["s-replaced"] = _runtime(  # noqa: SLF001
+        _CalibratedController(),
+        strategy_id="s-replaced",
+        strategy_version_id="s-replaced-v1",
+    )
+    desired_replacement = _runtime(
+        replaced_controller,
+        strategy_id="s-replaced",
+        strategy_version_id="s-replaced-v2",
+    )
+
+    store = _StrategyScopedEvalStore()
+    original_all_for_strategy = store.all_for_strategy
+
+    async def pushing_all_for_strategy(
+        strategy_id: str,
+        strategy_version_id: str,
+    ) -> list[EvalRecord]:
+        # Simulate the evaluator spool pushing a freshly resolved record
+        # while the hydration DB read is awaited.
+        runner._on_eval_record_for_calibration(  # noqa: SLF001
+            _eval_record(
+                decision_id="d-concurrent",
+                strategy_id="s-replaced",
+                strategy_version_id="s-replaced-v2",
+            )
+        )
+        return await original_all_for_strategy(strategy_id, strategy_version_id)
+
+    monkeypatch.setattr(store, "all_for_strategy", pushing_all_for_strategy)
+    runner.eval_store = cast(Any, store)
+
+    async def fake_build() -> list[StrategyControllerRuntime]:
+        return [desired_replacement]
+
+    monkeypatch.setattr(runner, "_build_controller_runtimes", fake_build)
+    # Mirror only the sink-visible effect of attach (runtime registration);
+    # the real attach also spawns the pipeline task, whose teardown this
+    # unit test does not exercise.
+    monkeypatch.setattr(
+        runner,
+        "_attach_controller_runtime",
+        lambda runtime: runner._controller_runtimes.__setitem__(  # noqa: SLF001
+            runtime.strategy_id, runtime
+        ),
+    )
+
+    await runner._sync_controller_runtimes()  # noqa: SLF001
+
+    assert replaced_controller.calibrator.sample_count("model-a") == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_replace_keeps_runtime_attached_when_hydration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An eval-store failure mid-replace must not leave the strategy detached
+    until the next discovery sync: the runtime stays attached (fail-closed
+    calibrator under-count) and hydration still fails loudly."""
+    runner = _runner()
+    runner._strategy_registry = cast(Any, object())  # noqa: SLF001
+
+    desired_replacement = _runtime(
+        _CalibratedController(),
+        strategy_id="s-replaced",
+        strategy_version_id="s-replaced-v2",
+    )
+    runner._controller_runtimes["s-replaced"] = _runtime(  # noqa: SLF001
+        _CalibratedController(),
+        strategy_id="s-replaced",
+        strategy_version_id="s-replaced-v1",
+    )
+
+    class _FailingEvalStore:
+        async def all_for_strategy(
+            self,
+            strategy_id: str,
+            strategy_version_id: str,
+        ) -> list[EvalRecord]:
+            del strategy_id, strategy_version_id
+            msg = "eval store unavailable"
+            raise RuntimeError(msg)
+
+    runner.eval_store = cast(Any, _FailingEvalStore())
+
+    async def fake_build() -> list[StrategyControllerRuntime]:
+        return [desired_replacement]
+
+    monkeypatch.setattr(runner, "_build_controller_runtimes", fake_build)
+    monkeypatch.setattr(
+        runner,
+        "_attach_controller_runtime",
+        lambda runtime: runner._controller_runtimes.__setitem__(  # noqa: SLF001
+            runtime.strategy_id, runtime
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="eval store unavailable"):
+        await runner._sync_controller_runtimes()  # noqa: SLF001
+
+    attached = runner._controller_runtimes.get("s-replaced")  # noqa: SLF001
+    assert attached is desired_replacement
+
+
 # --- End-to-end graduation counter-trace -----------------------------------
 # Mirror of tests/unit/test_live_trading_blockers.py clamp-probe setup: an
 # extreme forecast (0.99) is rejected with zero resolved samples, then two

--- a/tests/unit/test_runner_calibration_feedback.py
+++ b/tests/unit/test_runner_calibration_feedback.py
@@ -12,6 +12,7 @@ model those outcomes never tested.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -22,9 +23,18 @@ import pytest
 from pms.config import ControllerSettings, PMSSettings, RiskSettings
 from pms.controller.calibrators.netcal import NetcalCalibrator
 from pms.controller.pipeline import ControllerPipeline
-from pms.core.enums import MarketStatus, RunMode
-from pms.core.models import EvalRecord, MarketSignal, Portfolio, TradeDecision
+from pms.core.enums import MarketStatus, OrderStatus, RunMode, Side, TimeInForce
+from pms.core.models import (
+    EvalRecord,
+    FillRecord,
+    MarketSignal,
+    Portfolio,
+    TradeDecision,
+)
+from pms.evaluation.adapters.scoring import Scorer
+from pms.evaluation.spool import EvalSpool
 from pms.runner import Runner, StrategyControllerRuntime
+from pms.storage.eval_store import EvalStore
 from pms.strategies.projections import (
     ActiveStrategy,
     CalibrationSpec,
@@ -197,6 +207,99 @@ def test_on_eval_record_ignores_controller_without_calibrator() -> None:
     runner._on_eval_record_for_calibration(  # noqa: SLF001
         _eval_record(decision_id="d-duck")
     )
+
+
+def _scored_decision(*, decision_id: str) -> TradeDecision:
+    return TradeDecision(
+        decision_id=decision_id,
+        market_id="m-cal",
+        token_id="t-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        limit_price=0.4,
+        notional_usdc=4.0,
+        order_type="limit",
+        max_slippage_bps=100,
+        stop_conditions=["min_volume:100.00"],
+        prob_estimate=0.7,
+        expected_edge=0.3,
+        time_in_force=TimeInForce.GTC,
+        opportunity_id=f"op-{decision_id}",
+        strategy_id="s-cal",
+        strategy_version_id="s-cal-v1",
+        model_id="model-a",
+    )
+
+
+def _resolved_fill(*, decision_id: str) -> FillRecord:
+    now = datetime(2026, 6, 10, tzinfo=UTC)
+    return FillRecord(
+        trade_id=f"trade-{decision_id}",
+        order_id=f"order-{decision_id}",
+        decision_id=decision_id,
+        market_id="m-cal",
+        token_id="t-yes",
+        venue="polymarket",
+        side=Side.BUY.value,
+        fill_price=0.42,
+        fill_notional_usdc=4.2,
+        fill_quantity=10.0,
+        executed_at=now,
+        filled_at=now,
+        status=OrderStatus.MATCHED.value,
+        anomaly_flags=[],
+        strategy_id="s-cal",
+        strategy_version_id="s-cal-v1",
+        resolved_outcome=1.0,
+    )
+
+
+class _AppendOnlyEvalStore:
+    """Minimal eval-store fake; production dedups duplicate decision_ids with
+    ON CONFLICT at append, but the sink still fires once per enqueue."""
+
+    def __init__(self) -> None:
+        self.appended: list[EvalRecord] = []
+
+    async def append(self, record: EvalRecord) -> None:
+        self.appended.append(record)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_enqueue_same_decision_id_counts_one_calibration_sample(
+) -> None:
+    """Sweep re-enqueues (feat/resolution-ingestion) can deliver the same
+    decision_id twice — e.g. a fill resolved at enqueue time AND swept, or a
+    sweep retry. The store-level ON CONFLICT dedups the append, but the sink
+    fires per enqueue, so NetcalCalibrator's per-(model_id, decision_id) dedup
+    is what keeps a single resolution from counting twice toward clamp
+    graduation."""
+    runner = _runner()
+    controller = _CalibratedController()
+    runner._controller_runtimes["s-cal"] = _runtime(controller)  # noqa: SLF001
+    spool = EvalSpool(
+        store=cast(EvalStore, cast(object, _AppendOnlyEvalStore())),
+        scorer=Scorer(),
+        calibration_sink=runner._on_eval_record_for_calibration,  # noqa: SLF001
+    )
+    await spool.start()
+    try:
+        # Fresh, equal-by-value objects per enqueue: the production duplicate
+        # is a DB-rehydrated record vs an in-memory pushed one, never the
+        # same object identity.
+        spool.enqueue(
+            _resolved_fill(decision_id="d-dup"),
+            _scored_decision(decision_id="d-dup"),
+        )
+        spool.enqueue(
+            _resolved_fill(decision_id="d-dup"),
+            _scored_decision(decision_id="d-dup"),
+        )
+        await asyncio.wait_for(spool.join(), timeout=1.0)
+    finally:
+        await spool.stop()
+
+    assert controller.calibrator.sample_count("model-a") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_runner_calibration_feedback.py
+++ b/tests/unit/test_runner_calibration_feedback.py
@@ -723,15 +723,35 @@ async def test_calibration_graduation_unlocks_extreme_clamp_via_sink_path() -> N
     assert diagnostic is not None
     assert diagnostic.code == "calibration_clamp_rejected"
 
-    for index in range(2):
-        runner._on_eval_record_for_calibration(  # noqa: SLF001
-            _eval_record(
-                decision_id=f"d-resolved-{index}",
-                strategy_id="clamp-probe",
-                strategy_version_id="clamp-probe-v1",
-                model_id="ConstantForecaster",
-            )
+    runner._on_eval_record_for_calibration(  # noqa: SLF001
+        _eval_record(
+            decision_id="d-resolved-0",
+            strategy_id="clamp-probe",
+            strategy_version_id="clamp-probe-v1",
+            model_id="ConstantForecaster",
         )
+    )
+
+    # Pin the >= boundary: one resolved record is still below
+    # min_resolved_for_extreme=2, so the clamp must keep rejecting — an
+    # off-by-one unlock-early regression would emit here.
+    still_rejected = await pipeline.on_signal(_signal(), portfolio=_portfolio())
+    assert still_rejected is None, (
+        "a single resolved eval record (< min_resolved_for_extreme) must not "
+        "unlock the extreme-probability clamp"
+    )
+    boundary_diagnostic = pipeline.last_diagnostic
+    assert boundary_diagnostic is not None
+    assert boundary_diagnostic.code == "calibration_clamp_rejected"
+
+    runner._on_eval_record_for_calibration(  # noqa: SLF001
+        _eval_record(
+            decision_id="d-resolved-1",
+            strategy_id="clamp-probe",
+            strategy_version_id="clamp-probe-v1",
+            model_id="ConstantForecaster",
+        )
+    )
 
     emission = await pipeline.on_signal(_signal(), portfolio=_portfolio())
 


### PR DESCRIPTION
## Summary

Audit finding (high): `NetcalCalibrator.add_samples` had zero production callers — isotonic calibration never activated and the extreme-probability clamp could never unlock (`min_resolved_for_extreme` unreachable), permanently rejecting tail forecasts for every calibration-enabled strategy.

This wires the Invariant-1 evaluator→controller feedback edge:
- EvalSpool gains a `calibration_sink` post-append hook feeding resolved records to the owning runtime's calibrator, keyed per `(strategy_id, model_id)` with the **decision-level/per-forecaster model-id alignment** the design identified (records land under `"ensemble"` for multi-forecaster strategies; the clamp check now sees them).
- Cold-start re-hydration from the eval store on runtime attach (works with an EMPTY store — the running soak has 0 rows today).
- Duplicate-delivery dedup pinned by test (same `decision_id` enqueued twice must not double-count samples).

## Coordination contract (important for review)

`feat/resolution-ingestion` (separate PR, in final fix round) routes sweep-resolved records **synchronously through the spool's scoring path**, so this sink fires for them — the adversarial review verified the late-resolved re-enqueue path with a dedicated test (`test_calibration_sink_fires_for_sweep_style_late_resolved_reenqueue`). Neither branch depends on the other to merge green, but BOTH must land for calibration graduation to function in live paper (records only exist once resolution ingestion lands).

## Verification

Adversarial re-review verdict: **approve, 0 blockers**. TDD; full pytest 0 failed; mypy strict; lint-imports clean. Design doc: 2026-06-10 economics design (Design 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)